### PR TITLE
use the correct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.5.0",
-        "@rockcarver/frodo-lib": "github:rockcarver/lib-frodo#main",
+        "@rockcarver/frodo-lib": "github:rockcarver/frodo-lib#main",
         "axios": "^0.27.2",
         "axios-retry": "^3.3.1",
         "cli-progress": "^3.11.2",
@@ -1593,8 +1593,8 @@
       }
     },
     "node_modules/@rockcarver/frodo-lib": {
-      "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/rockcarver/lib-frodo.git#ca3c85f432e69ae8577af3210aa2d54fa23e1c25",
+      "version": "0.11.1-2",
+      "resolved": "git+ssh://git@github.com/rockcarver/frodo-lib.git#6334e9863e888249e0e05a7a1c0b0c74b897291f",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.5.0",
@@ -13949,8 +13949,8 @@
       }
     },
     "@rockcarver/frodo-lib": {
-      "version": "git+ssh://git@github.com/rockcarver/lib-frodo.git#ca3c85f432e69ae8577af3210aa2d54fa23e1c25",
-      "from": "@rockcarver/frodo-lib@github:rockcarver/lib-frodo#main",
+      "version": "git+ssh://git@github.com/rockcarver/frodo-lib.git#6334e9863e888249e0e05a7a1c0b0c74b897291f",
+      "from": "@rockcarver/frodo-lib@github:rockcarver/frodo-lib#main",
       "requires": {
         "@colors/colors": "^1.5.0",
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@colors/colors": "^1.5.0",
-    "@rockcarver/frodo-lib": "github:rockcarver/lib-frodo#main",
+    "@rockcarver/frodo-lib": "github:rockcarver/frodo-lib#main",
     "axios": "^0.27.2",
     "axios-retry": "^3.3.1",
     "cli-progress": "^3.11.2",


### PR DESCRIPTION
switch the git repo url

we can probably cleanup any old repos now apart from `frodo`