### PR TITLE
Fix and add tests for authz policy list

### DIFF
--- a/src/ops/PolicyOps.ts
+++ b/src/ops/PolicyOps.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import {
   createObjectTable,
   createProgressBar,
+  createTable,
   debugMessage,
   failSpinner,
   printMessage,
@@ -52,6 +53,21 @@ export async function listPolicies(long = false): Promise<boolean> {
         printMessage(`${policy._id}`, 'data');
       }
     }
+    if (long) {
+      const table = createTable(['Id', 'Description', 'Status']);
+      for (const policy of policies) {
+        table.push([
+          `${policy._id}`,
+          `${policy.description}`,
+          policy.active ? 'active'['brightGreen'] : 'inactive'['brightRed'],
+        ]);
+      }
+      printMessage(table.toString(), 'data');
+    } else {
+      for (const policy of policies) {
+        printMessage(`${policy._id}`, 'data');
+      }
+    }
     outcome = true;
   } catch (err) {
     printMessage(`listPolicies ERROR: ${err.message}`, 'error');
@@ -74,8 +90,18 @@ export async function listPoliciesByPolicySet(
   try {
     const policies = await readPoliciesByPolicySet(policySetId);
     policies.sort((a, b) => a._id.localeCompare(b._id));
-    for (const policy of policies) {
-      if (!long) {
+    if (long) {
+      const table = createTable(['Id', 'Description', 'Status']);
+      for (const policy of policies) {
+        table.push([
+          `${policy._id}`,
+          `${policy.description}`,
+          policy.active ? 'active'['brightGreen'] : 'inactive'['brightRed'],
+        ]);
+      }
+      printMessage(table.toString(), 'data');
+    } else {
+      for (const policy of policies) {
         printMessage(`${policy._id}`, 'data');
       }
     }

--- a/test/e2e/__snapshots__/authz-policy-list.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/authz-policy-list.e2e.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo authz policy list "frodo authz policy list --long --set-id test-policy-set": should list the ids, descriptions, and statuses of the authz policies in the test-policy-set set 1`] = `
+"Id         │Description            │Status  
+Test Policy│Test Policy Description│inactive
+"
+`;
+
+exports[`frodo authz policy list "frodo authz policy list --long": should list the ids, descriptions, and statuses of the authz policies 1`] = `
+"Id         │Description            │Status  
+Test Policy│Test Policy Description│inactive
+"
+`;
+
+exports[`frodo authz policy list "frodo authz policy list --set-id test-policy-set": should list the ids of the authz policies in the test-policy-set set 1`] = `
+"Test Policy
+"
+`;
+
+exports[`frodo authz policy list "frodo authz policy list -l --set-id test-policy-set": should list the ids, descriptions, and statuses of the authz policies in the test-policy-set set 1`] = `
+"Id         │Description            │Status  
+Test Policy│Test Policy Description│inactive
+"
+`;
+
+exports[`frodo authz policy list "frodo authz policy list -l": should list the ids, descriptions, and statuses of the authz policies 1`] = `
+"Id         │Description            │Status  
+Test Policy│Test Policy Description│inactive
+"
+`;
+
+exports[`frodo authz policy list "frodo authz policy list": should list the ids of the authz policies 1`] = `
+"Test Policy
+Test Policy
+"
+`;

--- a/test/e2e/authz-policy-list.e2e.test.js
+++ b/test/e2e/authz-policy-list.e2e.test.js
@@ -1,0 +1,109 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo authz policy list
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo authz policy list -l
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo authz policy list --long
+
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo authz policy list --set-id test-policy-set
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo authz policy list -l --set-id test-policy-set
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo authz policy list --long --set-id test-policy-set
+ */
+import cp from 'child_process';
+import { promisify } from 'util';
+import { removeAnsiEscapeCodes } from './utils/TestUtils';
+import { connection as c } from './utils/TestConfig';
+
+const exec = promisify(cp.exec);
+
+process.env['FRODO_MOCK'] = '1';
+const env = {
+    env: process.env,
+};
+env.env.FRODO_HOST = c.host;
+env.env.FRODO_SA_ID = c.saId;
+env.env.FRODO_SA_JWK = c.saJwk;
+
+describe('frodo authz policy list', () => {
+    test('"frodo authz policy list": should list the ids of the authz policies', async () => {
+        const CMD = `frodo authz policy list`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test('"frodo authz policy list -l": should list the ids, descriptions, and statuses of the authz policies', async () => {
+        const CMD = `frodo authz policy list -l`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test('"frodo authz policy list --long": should list the ids, descriptions, and statuses of the authz policies', async () => {
+        const CMD = `frodo authz policy list --long`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test('"frodo authz policy list --set-id test-policy-set": should list the ids of the authz policies in the test-policy-set set', async () => {
+        const CMD = `frodo authz policy list --set-id test-policy-set`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test('"frodo authz policy list -l --set-id test-policy-set": should list the ids, descriptions, and statuses of the authz policies in the test-policy-set set', async () => {
+        const CMD = `frodo authz policy list -l --set-id test-policy-set`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test('"frodo authz policy list --long --set-id test-policy-set": should list the ids, descriptions, and statuses of the authz policies in the test-policy-set set', async () => {
+        const CMD = `frodo authz policy list --long --set-id test-policy-set`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
A fix to enable authz policy list to be able to utilize the --long option, along with tests. Test mocks are included in the pull request titled "Add mocks for authz policy list" in frodo-lib.