### PR TITLE
Fix idm count and add idm count tests

### DIFF
--- a/src/cli/idm/idm-count.ts
+++ b/src/cli/idm/idm-count.ts
@@ -13,7 +13,7 @@ program
   .description('Count managed objects.')
   .addOption(
     new Option(
-      '-m, --managed-object <type>',
+      '-o, --managed-object <type>',
       'Type of managed object to count. E.g. "alpha_user", "alpha_role", "user", "role".'
     )
   )

--- a/test/e2e/__snapshots__/idm-count.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/idm-count.e2e.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo idm count "frodo idm count --managed-object alpha_user": should count all alpha_users 1`] = `
+"alpha_user: 5
+"
+`;
+
+exports[`frodo idm count "frodo idm count -o alpha_user": should count all alpha_users 1`] = `
+"alpha_user: 5
+"
+`;

--- a/test/e2e/idm-count.e2e.test.js
+++ b/test/e2e/idm-count.e2e.test.js
@@ -1,0 +1,80 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo idm count -o alpha_user
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo idm count --managed-object alpha_user
+ */
+import cp from 'child_process';
+import { promisify } from 'util';
+import { removeAnsiEscapeCodes } from './utils/TestUtils';
+import { connection as c } from './utils/TestConfig';
+
+const exec = promisify(cp.exec);
+
+process.env['FRODO_MOCK'] = '1';
+const env = {
+    env: process.env,
+};
+env.env.FRODO_HOST = c.host;
+env.env.FRODO_SA_ID = c.saId;
+env.env.FRODO_SA_JWK = c.saJwk;
+
+describe('frodo idm count', () => {
+    test('"frodo idm count -o alpha_user": should count all alpha_users', async () => {
+        const CMD = `frodo idm count -o alpha_user`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test('"frodo idm count --managed-object alpha_user": should count all alpha_users', async () => {
+        const CMD = `frodo idm count --managed-object alpha_user`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
A fix for idm count to disambiguate the --managed-object short form option since -m is used for --type option. Adds tests for idm count as well. Test mocks are included in the pull request titled "Add mocks for idm count tests" in frodo-lib.