### PR TITLE
Add ability to export ESVs

### DIFF
--- a/src/cli/esv/esv-secret-export.ts
+++ b/src/cli/esv/esv-secret-export.ts
@@ -1,6 +1,12 @@
-import { frodo } from '@rockcarver/frodo-lib';
+import { frodo, state } from '@rockcarver/frodo-lib';
 import { Option } from 'commander';
 
+import {
+  exportSecretsToFile,
+  exportSecretsToFiles,
+  exportSecretToFile,
+} from '../../ops/SecretsOps';
+import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
 const { getTokens } = frodo.login;
@@ -39,9 +45,25 @@ program
         options,
         command
       );
-      if (await getTokens()) {
-        // code goes here
+      if (options.secretId && (await getTokens())) {
+        verboseMessage(
+          `Exporting secret "${
+            options.secretId
+          }" from realm "${state.getRealm()}"...`
+        );
+        await exportSecretToFile(options.secretId, options.file);
+      } else if (options.all && (await getTokens())) {
+        verboseMessage('Exporting all secrets to a single file...');
+        await exportSecretsToFile(options.file);
+      } else if (options.allSeparate && (await getTokens())) {
+        verboseMessage('Exporting all secrets to separate files...');
+        await exportSecretsToFiles();
       } else {
+        printMessage(
+          'Unrecognized combination of options or no options...',
+          'error'
+        );
+        program.help();
         process.exitCode = 1;
       }
     }

--- a/src/cli/esv/esv-secret.ts
+++ b/src/cli/esv/esv-secret.ts
@@ -10,7 +10,7 @@ program.command('delete', 'Delete secrets.');
 
 program.command('describe', 'Describe secret.');
 
-// program.command('export', 'Export secrets.');
+program.command('export', 'Export secrets.');
 
 // program.command('import', 'Import secrets.');
 

--- a/src/cli/esv/esv-variable-export.ts
+++ b/src/cli/esv/esv-variable-export.ts
@@ -57,7 +57,11 @@ program
             options.variableId
           }" from realm "${state.getRealm()}"...`
         );
-        await exportVariableToFile(options.variableId, options.file, options.decode);
+        await exportVariableToFile(
+          options.variableId,
+          options.file,
+          options.decode
+        );
       } else if (options.all && (await getTokens())) {
         verboseMessage('Exporting all variables to a single file...');
         await exportVariablesToFile(options.file, options.decode);

--- a/src/cli/esv/esv-variable-export.ts
+++ b/src/cli/esv/esv-variable-export.ts
@@ -1,6 +1,12 @@
-import { frodo } from '@rockcarver/frodo-lib';
+import { frodo, state } from '@rockcarver/frodo-lib';
 import { Option } from 'commander';
 
+import {
+  exportVariablesToFile,
+  exportVariablesToFiles,
+  exportVariableToFile,
+} from '../../ops/VariablesOps';
+import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
 const { getTokens } = frodo.login;
@@ -28,6 +34,12 @@ program
       'Export all variables to separate files (*.variable.json) in the current directory. Ignored with -i or -a.'
     )
   )
+  .addOption(
+    new Option(
+      '--no-decode',
+      'Do not include decoded variable value in export'
+    ).default(false, 'false')
+  )
   .action(
     // implement command logic inside action handler
     async (host, realm, user, password, options, command) => {
@@ -39,9 +51,25 @@ program
         options,
         command
       );
-      if (await getTokens()) {
-        // code goes here
+      if (options.variableId && (await getTokens())) {
+        verboseMessage(
+          `Exporting variable "${
+            options.variableId
+          }" from realm "${state.getRealm()}"...`
+        );
+        await exportVariableToFile(options.variableId, options.file, options.decode);
+      } else if (options.all && (await getTokens())) {
+        verboseMessage('Exporting all variables to a single file...');
+        await exportVariablesToFile(options.file, options.decode);
+      } else if (options.allSeparate && (await getTokens())) {
+        verboseMessage('Exporting all variables to separate files...');
+        await exportVariablesToFiles(options.decode);
       } else {
+        printMessage(
+          'Unrecognized combination of options or no options...',
+          'error'
+        );
+        program.help();
         process.exitCode = 1;
       }
     }

--- a/src/cli/esv/esv-variable.ts
+++ b/src/cli/esv/esv-variable.ts
@@ -10,7 +10,7 @@ program.command('delete', 'Delete variables.');
 
 program.command('describe', 'Describe variables.');
 
-// program.command('export', 'Export variables.');
+program.command('export', 'Export variables.');
 
 // program.command('import', 'Import variables.');
 

--- a/src/ops/SecretsOps.ts
+++ b/src/ops/SecretsOps.ts
@@ -239,7 +239,10 @@ export async function describeSecret(secretId) {
  * @param {String} secretId Secret id
  * @param {String} file Optional filename
  */
-export async function exportSecretToFile(secretId: string, file: string | null) {
+export async function exportSecretToFile(
+  secretId: string,
+  file: string | null
+) {
   debugMessage(
     `Cli.SecretsOps.exportSecretToFile: start [secretId=${secretId}, file=${file}]`
   );

--- a/src/ops/SecretsOps.ts
+++ b/src/ops/SecretsOps.ts
@@ -4,6 +4,7 @@ import {
   createKeyValueTable,
   createProgressBar,
   createTable,
+  debugMessage,
   failSpinner,
   printMessage,
   showSpinner,
@@ -11,6 +12,12 @@ import {
   succeedSpinner,
   updateProgressBar,
 } from '../utils/Console';
+import {
+  getTypedFilename,
+  saveJsonToFile,
+  saveToFile,
+  titleCase,
+} from '../utils/ExportImportUtils';
 import wordwrap from './utils/Wordwrap';
 
 const { resolveUserName } = frodo.idm.managed;
@@ -19,6 +26,8 @@ const {
   createSecret: _createSecret,
   readVersionsOfSecret,
   readSecret,
+  exportSecret,
+  exportSecrets,
   enableVersionOfSecret,
   disableVersionOfSecret,
   createVersionOfSecret: _createVersionOfSecret,
@@ -26,6 +35,8 @@ const {
   deleteSecret: _deleteSecret,
   deleteVersionOfSecret: _deleteVersionOfSecret,
 } = frodo.cloud.secret;
+
+const { getFilePath } = frodo.utils;
 
 /**
  * List secrets
@@ -221,6 +232,75 @@ export async function describeSecret(secretId) {
   printMessage(table.toString());
   printMessage('\nSecret Versions:');
   await listSecretVersions(secretId);
+}
+
+/**
+ * Export a single secret to file
+ * @param {String} secretId Secret id
+ * @param {String} file Optional filename
+ */
+export async function exportSecretToFile(secretId: string, file: string | null) {
+  debugMessage(
+    `Cli.SecretsOps.exportSecretToFile: start [secretId=${secretId}, file=${file}]`
+  );
+  let fileName = file;
+  if (!fileName) {
+    fileName = getTypedFilename(secretId, 'secret');
+  }
+  const filePath = getFilePath(fileName, true);
+  try {
+    createProgressBar(1, `Exporting secret ${secretId}`);
+    const fileData = await exportSecret(secretId);
+    saveJsonToFile(fileData, filePath);
+    updateProgressBar(`Exported secret ${secretId}`);
+    stopProgressBar(
+      // @ts-expect-error - brightCyan colors the string, even though it is not a property of string
+      `Exported ${secretId.brightCyan} to ${filePath.brightCyan}.`
+    );
+  } catch (err) {
+    stopProgressBar(`${err}`);
+    printMessage(err, 'error');
+  }
+  debugMessage(
+    `Cli.SecretsOps.exportSecretToFile: end [secretId=${secretId}, file=${file}]`
+  );
+}
+
+/**
+ * Export all secrets to single file
+ * @param {string} file Optional filename
+ */
+export async function exportSecretsToFile(file: string) {
+  debugMessage(`Cli.SecretsOps.exportSecretsToFile: start [file=${file}]`);
+  let fileName = file;
+  if (!fileName) {
+    fileName = getTypedFilename(
+      `all${titleCase(state.getRealm())}Secrets`,
+      'secret'
+    );
+  }
+  try {
+    const secretsExport = await exportSecrets();
+    saveJsonToFile(secretsExport, getFilePath(fileName, true));
+  } catch (error) {
+    printMessage(error.message, 'error');
+    printMessage(`exportSecretsToFile: ${error.response?.status}`, 'error');
+  }
+  debugMessage(`Cli.SecretsOps.exportSecretsToFile: end [file=${file}]`);
+}
+
+/**
+ * Export all secrets to individual files
+ */
+export async function exportSecretsToFiles() {
+  const allSecretsData = await readSecrets();
+  createProgressBar(allSecretsData.length, 'Exporting secrets');
+  for (const secret of allSecretsData) {
+    updateProgressBar(`Writing secret ${secret._id}`);
+    const fileName = getTypedFilename(secret._id, 'secret');
+    saveToFile('secret', secret, '_id', getFilePath(fileName, true));
+  }
+  stopProgressBar(`${allSecretsData.length} secrets exported.`);
 }
 
 /**

--- a/src/ops/VariablesOps.ts
+++ b/src/ops/VariablesOps.ts
@@ -216,7 +216,11 @@ export async function describeVariable(variableId) {
  * @param {String} file Optional filename
  * @param {boolean} noDecode Do not include decoded variable value in export
  */
-export async function exportVariableToFile(variableId: string, file: string | null, noDecode: boolean) {
+export async function exportVariableToFile(
+  variableId: string,
+  file: string | null,
+  noDecode: boolean
+) {
   debugMessage(
     `Cli.VariablesOps.exportVariableToFile: start [variableId=${variableId}, file=${file}]`
   );
@@ -248,7 +252,10 @@ export async function exportVariableToFile(variableId: string, file: string | nu
  * @param {string} file Optional filename
  * @param {boolean} noDecode Do not include decoded variable value in export
  */
-export async function exportVariablesToFile(file: string | null, noDecode: boolean) {
+export async function exportVariablesToFile(
+  file: string | null,
+  noDecode: boolean
+) {
   debugMessage(`Cli.VariablesOps.exportVariablesToFile: start [file=${file}]`);
   let fileName = file;
   if (!fileName) {

--- a/test/client_cli/en/__snapshots__/esv-secret-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-export.test.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI help interface for 'esv secret export' should be expected english 1`] = `
+"Usage: frodo esv secret export [options] [host] [realm] [username] [password]
+
+Export secrets.
+
+Arguments:
+  host                         Access Management base URL, e.g.:
+                               https://cdk.iam.example.com/am. To use a
+                               connection profile, just specify a unique
+                               substring.
+  realm                        Realm. Specify realm as '/' for the root realm
+                               or 'realm' or '/parent/child' otherwise.
+                               (default: "alpha" for Identity Cloud tenants,
+                               "/" otherwise.)
+  username                     Username to login with. Must be an admin user
+                               with appropriate rights to manage authentication
+                               journeys/trees.
+  password                     Password.
+
+Options:
+  -a, --all                    Export all secrets to a single file. Ignored
+                               with -i.
+  -A, --all-separate           Export all sub1s to separate files
+                               (*.secret.json) in the current directory.
+                               Ignored with -i or -a.
+  --curlirize                  Output all network calls in curl format.
+  -D, --directory <directory>  Set the working directory.
+  --debug                      Debug output during command execution. If
+                               specified, may or may not produce additional
+                               output helpful for troubleshooting.
+  -f, --file <file>            Name of the export file.
+  -h, --help                   Help
+  -i, --secret-id <secret-id>  Secret id. If specified, -a and -A are ignored.
+  -k, --insecure               Allow insecure connections when using SSL/TLS.
+                               Has no effect when using a network proxy for
+                               https (HTTPS_PROXY=http://<host>:<port>), in
+                               that case the proxy must provide this
+                               capability. (default: Don't allow insecure
+                               connections)
+  -m, --type <type>            Override auto-detected deployment type. Valid
+                               values for type:
+                               classic:  A classic Access Management-only
+                               deployment with custom layout and configuration.
+  
+                               cloud:    A ForgeRock Identity Cloud
+                               environment.
+                               forgeops: A ForgeOps CDK or CDM deployment.
+                               The detected or provided deployment type
+                               controls certain behavior like obtaining an
+                               Identity Management admin token or not and
+                               whether to export/import referenced email
+                               templates or how to walk through the tenant
+                               admin login flow of Identity Cloud and handle
+                               MFA (choices: "classic", "cloud", "forgeops")
+  --sa-id <sa-id>              Service account id.
+  --sa-jwk-file <file>         File containing the JSON Web Key (JWK)
+                               associated with the the service account.
+  --verbose                    Verbose output during command execution. If
+                               specified, may or may not produce additional
+                               output.
+
+Evironment Variables:
+  FRODO_HOST: Access Management base URL. Overrides 'host' argument.
+  FRODO_REALM: Realm. Overrides 'realm' argument.
+  FRODO_USERNAME: Username. Overrides 'username' argument.
+  FRODO_PASSWORD: Password. Overrides 'password' argument.
+  FRODO_SA_ID: Service account uuid. Overrides '--sa-id' option.
+  FRODO_SA_JWK: Service account JWK. Overrides '--sa-jwk-file' option but takes the actual JWK as a value, not a file name.
+  FRODO_CONNECTION_PROFILES_PATH: Use this connection profiles file instead of '~/.frodo/Connections.json'.
+  FRODO_AUTHENTICATION_SERVICE: Name of a login journey to use.
+  FRODO_DEBUG: Set to any value to enable debug output. Same as '--debug'.
+  FRODO_MASTER_KEY_PATH: Use this master key file instead of '~/.frodo/masterkey.key' file.
+  FRODO_MASTER_KEY: Use this master key instead of '~/.frodo/masterkey.key' file. Takes precedence over FRODO_MASTER_KEY_PATH.
+
+"
+`;

--- a/test/client_cli/en/__snapshots__/esv-secret.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret.test.js.snap
@@ -12,6 +12,7 @@ Commands:
   create          Create secrets.
   delete          Delete secrets.
   describe        Describe secret.
+  export          Export secrets.
   help [command]  display help for command
   list            List secrets.
   set             Set secret descriptions.

--- a/test/client_cli/en/__snapshots__/esv-variable-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-export.test.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI help interface for 'esv variable export' should be expected english 1`] = `
+"Usage: frodo esv variable export [options] [host] [realm] [username] [password]
+
+Export variables.
+
+Arguments:
+  host                             Access Management base URL, e.g.:
+                                   https://cdk.iam.example.com/am. To use a
+                                   connection profile, just specify a unique
+                                   substring.
+  realm                            Realm. Specify realm as '/' for the root
+                                   realm or 'realm' or '/parent/child'
+                                   otherwise. (default: "alpha" for Identity
+                                   Cloud tenants, "/" otherwise.)
+  username                         Username to login with. Must be an admin
+                                   user with appropriate rights to manage
+                                   authentication journeys/trees.
+  password                         Password.
+
+Options:
+  -a, --all                        Export all variables to a single file.
+                                   Ignored with -i.
+  -A, --all-separate               Export all variables to separate files
+                                   (*.variable.json) in the current directory.
+                                   Ignored with -i or -a.
+  --curlirize                      Output all network calls in curl format.
+  -D, --directory <directory>      Set the working directory.
+  --debug                          Debug output during command execution. If
+                                   specified, may or may not produce additional
+                                   output helpful for troubleshooting.
+  -f, --file <file>                Name of the export file.
+  -h, --help                       Help
+  -i, --variable-id <variable-id>  Variable id. If specified, -a and -A are
+                                   ignored.
+  -k, --insecure                   Allow insecure connections when using
+                                   SSL/TLS. Has no effect when using a network
+                                   proxy for https
+                                   (HTTPS_PROXY=http://<host>:<port>), in that
+                                   case the proxy must provide this capability.
+                                   (default: Don't allow insecure connections)
+  -m, --type <type>                Override auto-detected deployment type.
+                                   Valid values for type:
+                                   classic:  A classic Access Management-only
+                                   deployment with custom layout and
+                                   configuration.
+                                   cloud:    A ForgeRock Identity Cloud
+                                   environment.
+                                   forgeops: A ForgeOps CDK or CDM deployment.
+                                   The detected or provided deployment type
+                                   controls certain behavior like obtaining an
+                                   Identity Management admin token or not and
+                                   whether to export/import referenced email
+                                   templates or how to walk through the tenant
+                                   admin login flow of Identity Cloud and
+                                   handle MFA (choices: "classic", "cloud",
+                                   "forgeops")
+  --no-decode                      Do not include decoded variable value in
+                                   export
+  --sa-id <sa-id>                  Service account id.
+  --sa-jwk-file <file>             File containing the JSON Web Key (JWK)
+                                   associated with the the service account.
+  --verbose                        Verbose output during command execution. If
+                                   specified, may or may not produce additional
+                                   output.
+
+Evironment Variables:
+  FRODO_HOST: Access Management base URL. Overrides 'host' argument.
+  FRODO_REALM: Realm. Overrides 'realm' argument.
+  FRODO_USERNAME: Username. Overrides 'username' argument.
+  FRODO_PASSWORD: Password. Overrides 'password' argument.
+  FRODO_SA_ID: Service account uuid. Overrides '--sa-id' option.
+  FRODO_SA_JWK: Service account JWK. Overrides '--sa-jwk-file' option but takes the actual JWK as a value, not a file name.
+  FRODO_CONNECTION_PROFILES_PATH: Use this connection profiles file instead of '~/.frodo/Connections.json'.
+  FRODO_AUTHENTICATION_SERVICE: Name of a login journey to use.
+  FRODO_DEBUG: Set to any value to enable debug output. Same as '--debug'.
+  FRODO_MASTER_KEY_PATH: Use this master key file instead of '~/.frodo/masterkey.key' file.
+  FRODO_MASTER_KEY: Use this master key instead of '~/.frodo/masterkey.key' file. Takes precedence over FRODO_MASTER_KEY_PATH.
+
+"
+`;

--- a/test/client_cli/en/__snapshots__/esv-variable.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable.test.js.snap
@@ -12,6 +12,7 @@ Commands:
   create          Create variables.
   delete          Delete variables.
   describe        Describe variables.
+  export          Export variables.
   help [command]  display help for command
   list            List variables.
   set             Set variable descriptions.

--- a/test/client_cli/en/esv-secret-export.test.js
+++ b/test/client_cli/en/esv-secret-export.test.js
@@ -1,0 +1,10 @@
+import cp from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(cp.exec);
+const CMD = 'frodo esv secret export --help';
+const { stdout } = await exec(CMD);
+
+test("CLI help interface for 'esv secret export' should be expected english", async () => {
+  expect(stdout).toMatchSnapshot();
+});

--- a/test/client_cli/en/esv-variable-export.test.js
+++ b/test/client_cli/en/esv-variable-export.test.js
@@ -1,0 +1,10 @@
+import cp from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(cp.exec);
+const CMD = 'frodo esv variable export --help';
+const { stdout } = await exec(CMD);
+
+test("CLI help interface for 'esv variable export' should be expected english", async () => {
+  expect(stdout).toMatchSnapshot();
+});

--- a/test/e2e/__snapshots__/esv-secret-export.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/esv-secret-export.e2e.test.js.snap
@@ -1,0 +1,524 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo esv secret export "frodo esv secret export --all": should export all secrets to a single file 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export --all": should export all secrets to a single file: ./allAlphaSecrets.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secrets": {
+    "esv-admin-token": {
+      "_id": "esv-admin-token",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2022-08-11T22:32:38.056Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-admin-token-1999386457729": {
+      "_id": "esv-admin-token-1999386457729",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2023-05-14T01:07:41.970Z",
+      "lastChangedBy": "8d9723a9-a439-4cbf-beb4-30e52811789d",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-1": {
+      "_id": "esv-test-secret-1",
+      "activeVersion": "1",
+      "description": "test secret one",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-06T03:53:17.716Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-pi-generic": {
+      "_id": "esv-test-secret-pi-generic",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-17T22:37:13.115Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-pi-generic2": {
+      "_id": "esv-test-secret-pi-generic2",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-18T21:45:46.571Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": false,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3: secretExportTestDir3/esv-admin-token.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-admin-token": {
+      "_id": "esv-admin-token",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2022-08-11T22:32:38.056Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3: secretExportTestDir3/esv-admin-token-1999386457729.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-admin-token-1999386457729": {
+      "_id": "esv-admin-token-1999386457729",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2023-05-14T01:07:41.970Z",
+      "lastChangedBy": "8d9723a9-a439-4cbf-beb4-30e52811789d",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3: secretExportTestDir3/esv-test-secret.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3: secretExportTestDir3/esv-test-secret-1.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret-1": {
+      "_id": "esv-test-secret-1",
+      "activeVersion": "1",
+      "description": "test secret one",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-06T03:53:17.716Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3: secretExportTestDir3/esv-test-secret-pi-generic.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret-pi-generic": {
+      "_id": "esv-test-secret-pi-generic",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-17T22:37:13.115Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3: secretExportTestDir3/esv-test-secret-pi-generic2.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret-pi-generic2": {
+      "_id": "esv-test-secret-pi-generic2",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-18T21:45:46.571Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": false,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export --secret-id esv-test-secret": should export the secret with secret id "esv-test-secret" 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export --secret-id esv-test-secret": should export the secret with secret id "esv-test-secret": ./esv-test-secret.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secrets": {
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -A": should export all secrets to separate files 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export -A": should export all secrets to separate files: ./esv-admin-token.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-admin-token": {
+      "_id": "esv-admin-token",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2022-08-11T22:32:38.056Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -A": should export all secrets to separate files: ./esv-admin-token-1999386457729.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-admin-token-1999386457729": {
+      "_id": "esv-admin-token-1999386457729",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2023-05-14T01:07:41.970Z",
+      "lastChangedBy": "8d9723a9-a439-4cbf-beb4-30e52811789d",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -A": should export all secrets to separate files: ./esv-test-secret.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -A": should export all secrets to separate files: ./esv-test-secret-1.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret-1": {
+      "_id": "esv-test-secret-1",
+      "activeVersion": "1",
+      "description": "test secret one",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-06T03:53:17.716Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -A": should export all secrets to separate files: ./esv-test-secret-pi-generic.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret-pi-generic": {
+      "_id": "esv-test-secret-pi-generic",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-17T22:37:13.115Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -A": should export all secrets to separate files: ./esv-test-secret-pi-generic2.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secret": {
+    "esv-test-secret-pi-generic2": {
+      "_id": "esv-test-secret-pi-generic2",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-18T21:45:46.571Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": false,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -a --file my-allAlphaSecrets.secret.json": should export all secrets to a single file named my-allAlphaSecrets.secret.json 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export -a --file my-allAlphaSecrets.secret.json": should export all secrets to a single file named my-allAlphaSecrets.secret.json: ./my-allAlphaSecrets.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secrets": {
+    "esv-admin-token": {
+      "_id": "esv-admin-token",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2022-08-11T22:32:38.056Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-admin-token-1999386457729": {
+      "_id": "esv-admin-token-1999386457729",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2023-05-14T01:07:41.970Z",
+      "lastChangedBy": "8d9723a9-a439-4cbf-beb4-30e52811789d",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-1": {
+      "_id": "esv-test-secret-1",
+      "activeVersion": "1",
+      "description": "test secret one",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-06T03:53:17.716Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-pi-generic": {
+      "_id": "esv-test-secret-pi-generic",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-17T22:37:13.115Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-pi-generic2": {
+      "_id": "esv-test-secret-pi-generic2",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-18T21:45:46.571Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": false,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -aD secretExportTestDir2": should export all secrets to a single file in the directory secretExportTestDir2 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export -aD secretExportTestDir2": should export all secrets to a single file in the directory secretExportTestDir2: secretExportTestDir2/allAlphaSecrets.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secrets": {
+    "esv-admin-token": {
+      "_id": "esv-admin-token",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2022-08-11T22:32:38.056Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-admin-token-1999386457729": {
+      "_id": "esv-admin-token-1999386457729",
+      "activeVersion": "1",
+      "description": "Long-lived admin token",
+      "encoding": "generic",
+      "lastChangeDate": "2023-05-14T01:07:41.970Z",
+      "lastChangedBy": "8d9723a9-a439-4cbf-beb4-30e52811789d",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-1": {
+      "_id": "esv-test-secret-1",
+      "activeVersion": "1",
+      "description": "test secret one",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-06T03:53:17.716Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-pi-generic": {
+      "_id": "esv-test-secret-pi-generic",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-17T22:37:13.115Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": true,
+    },
+    "esv-test-secret-pi-generic2": {
+      "_id": "esv-test-secret-pi-generic2",
+      "activeVersion": "1",
+      "description": "This is a test secret containing the value pi.",
+      "encoding": "generic",
+      "lastChangeDate": "2023-10-18T21:45:46.571Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "1",
+      "useInPlaceholders": false,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -i esv-test-secret -D secretExportTestDir1": should export the secret with secret id "esv-test-secret" into the directory named secretExportTestDir1 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export -i esv-test-secret -D secretExportTestDir1": should export the secret with secret id "esv-test-secret" into the directory named secretExportTestDir1: secretExportTestDir1/esv-test-secret.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secrets": {
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;
+
+exports[`frodo esv secret export "frodo esv secret export -i esv-test-secret -f my-esv-test-secret.secret.json": should export the secret with secret id "esv-test-secret" into file named my-esv-test-secret.secret.json 1`] = `""`;
+
+exports[`frodo esv secret export "frodo esv secret export -i esv-test-secret -f my-esv-test-secret.secret.json": should export the secret with secret id "esv-test-secret" into file named my-esv-test-secret.secret.json: ./my-esv-test-secret.secret.json 1`] = `
+{
+  "meta": Any<Object>,
+  "secrets": {
+    "esv-test-secret": {
+      "_id": "esv-test-secret",
+      "activeVersion": "2",
+      "description": "Secret Value for testing",
+      "encoding": "generic",
+      "lastChangeDate": "2023-08-09T19:00:01.501Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "loadedVersion": "2",
+      "useInPlaceholders": true,
+    },
+  },
+}
+`;

--- a/test/e2e/__snapshots__/esv-variable-export.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/esv-variable-export.e2e.test.js.snap
@@ -1,0 +1,978 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo esv variable export "frodo esv variable export --all": should export all variables to a single file 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export --all": should export all variables to a single file: ./allAlphaVariables.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variables": {
+    "esv-blue-piller": {
+      "_id": "esv-blue-piller",
+      "description": "Zion membership criteria.",
+      "expressionType": "bool",
+      "lastChangeDate": "2023-07-18T22:21:38.640Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "false",
+      "valueBase64": "ZmFsc2U=",
+    },
+    "esv-ipv4-cidr-access-rules": {
+      "_id": "esv-ipv4-cidr-access-rules",
+      "description": "IPv4 CIDR access rules:
+{
+  "allow": [
+    "address/mask"
+  ]
+}",
+      "expressionType": "",
+      "lastChangeDate": "2022-08-25T22:54:28.551Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "{  "allow": [    "150.128.0.0/16",    "139.35.0.0/16",    "101.216.0.0/16",    "99.72.28.182/32"  ]}",
+      "valueBase64": "eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==",
+    },
+    "esv-nebuchadnezzar-crew": {
+      "_id": "esv-nebuchadnezzar-crew",
+      "description": "The crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "array",
+      "lastChangeDate": "2023-07-18T21:59:58.974Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "["Morpheus","Trinity","Link","Tank","Dozer","Apoc","Cypher","Mouse","Neo","Switch"]",
+      "valueBase64": "WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=",
+    },
+    "esv-nebuchadnezzar-crew-structure": {
+      "_id": "esv-nebuchadnezzar-crew-structure",
+      "description": "The structure of the crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "object",
+      "lastChangeDate": "2023-07-18T22:09:54.630Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "{"Captain":"Morpheus","FirstMate":"Trinity","Operator":["Link","Tank"],"Medic":"Dozer","Crewmen":["Apoc","Cypher","Mouse","Neo","Switch"]}",
+      "valueBase64": "eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19",
+    },
+    "esv-neo-age": {
+      "_id": "esv-neo-age",
+      "description": "Neo's age in the matrix.",
+      "expressionType": "int",
+      "lastChangeDate": "2023-07-18T22:21:23.578Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "28",
+      "valueBase64": "Mjg=",
+    },
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+    "esv-test-var-1": {
+      "_id": "esv-test-var-1",
+      "description": "test var one",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-09T17:42:41.684Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "test var 1 value2",
+      "valueBase64": "dGVzdCB2YXIgMSB2YWx1ZTI=",
+    },
+    "esv-test-var-2": {
+      "_id": "esv-test-var-2",
+      "description": "A temporary test variable",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-02T21:09:01.847Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "testval",
+      "valueBase64": "dGVzdHZhbA==",
+    },
+    "esv-test-var-3": {
+      "_id": "esv-test-var-3",
+      "description": "This is a test variable",
+      "expressionType": "int",
+      "lastChangeDate": "2023-10-17T22:22:52.023Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "42",
+      "valueBase64": "NDI=",
+    },
+    "esv-test-var-pi": {
+      "_id": "esv-test-var-pi",
+      "description": "This is another test variable.",
+      "expressionType": "number",
+      "lastChangeDate": "2023-10-17T22:28:44.529Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+    "esv-test-var-pi-string": {
+      "_id": "esv-test-var-pi-string",
+      "description": "This is another test variable.",
+      "expressionType": "string",
+      "lastChangeDate": "2023-10-18T22:05:30.300Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+    "esv-trinity-phone": {
+      "_id": "esv-trinity-phone",
+      "description": "In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690",
+      "expressionType": "string",
+      "lastChangeDate": "2023-07-18T20:33:28.922Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "(312)-555-0690",
+      "valueBase64": "KDMxMiktNTU1LTA2OTA=",
+    },
+    "esv-volkerstestvariable1": {
+      "_id": "esv-volkerstestvariable1",
+      "description": "variable created for api testing",
+      "expressionType": "",
+      "lastChangeDate": "2022-11-30T00:13:52.478Z",
+      "lastChangedBy": "10ecab02-f357-4522-bc17-dfcc64744064",
+      "loaded": true,
+      "value": "for jest",
+      "valueBase64": "Zm9yIGplc3Q=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-blue-piller.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-blue-piller": {
+      "_id": "esv-blue-piller",
+      "description": "Zion membership criteria.",
+      "expressionType": "bool",
+      "lastChangeDate": "2023-07-18T22:21:38.640Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "false",
+      "valueBase64": "ZmFsc2U=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-ipv4-cidr-access-rules.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-ipv4-cidr-access-rules": {
+      "_id": "esv-ipv4-cidr-access-rules",
+      "description": "IPv4 CIDR access rules:
+{
+  "allow": [
+    "address/mask"
+  ]
+}",
+      "expressionType": "",
+      "lastChangeDate": "2022-08-25T22:54:28.551Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "{  "allow": [    "150.128.0.0/16",    "139.35.0.0/16",    "101.216.0.0/16",    "99.72.28.182/32"  ]}",
+      "valueBase64": "eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-nebuchadnezzar-crew.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-nebuchadnezzar-crew": {
+      "_id": "esv-nebuchadnezzar-crew",
+      "description": "The crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "array",
+      "lastChangeDate": "2023-07-18T21:59:58.974Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "["Morpheus","Trinity","Link","Tank","Dozer","Apoc","Cypher","Mouse","Neo","Switch"]",
+      "valueBase64": "WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-nebuchadnezzar-crew-structure.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-nebuchadnezzar-crew-structure": {
+      "_id": "esv-nebuchadnezzar-crew-structure",
+      "description": "The structure of the crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "object",
+      "lastChangeDate": "2023-07-18T22:09:54.630Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "{"Captain":"Morpheus","FirstMate":"Trinity","Operator":["Link","Tank"],"Medic":"Dozer","Crewmen":["Apoc","Cypher","Mouse","Neo","Switch"]}",
+      "valueBase64": "eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-neo-age.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-neo-age": {
+      "_id": "esv-neo-age",
+      "description": "Neo's age in the matrix.",
+      "expressionType": "int",
+      "lastChangeDate": "2023-07-18T22:21:23.578Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "28",
+      "valueBase64": "Mjg=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-test-var.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-test-var-1.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-1": {
+      "_id": "esv-test-var-1",
+      "description": "test var one",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-09T17:42:41.684Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "test var 1 value2",
+      "valueBase64": "dGVzdCB2YXIgMSB2YWx1ZTI=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-test-var-2.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-2": {
+      "_id": "esv-test-var-2",
+      "description": "A temporary test variable",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-02T21:09:01.847Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "testval",
+      "valueBase64": "dGVzdHZhbA==",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-test-var-3.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-3": {
+      "_id": "esv-test-var-3",
+      "description": "This is a test variable",
+      "expressionType": "int",
+      "lastChangeDate": "2023-10-17T22:22:52.023Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "42",
+      "valueBase64": "NDI=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-test-var-pi.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-pi": {
+      "_id": "esv-test-var-pi",
+      "description": "This is another test variable.",
+      "expressionType": "number",
+      "lastChangeDate": "2023-10-17T22:28:44.529Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-test-var-pi-string.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-pi-string": {
+      "_id": "esv-test-var-pi-string",
+      "description": "This is another test variable.",
+      "expressionType": "string",
+      "lastChangeDate": "2023-10-18T22:05:30.300Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-trinity-phone.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-trinity-phone": {
+      "_id": "esv-trinity-phone",
+      "description": "In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690",
+      "expressionType": "string",
+      "lastChangeDate": "2023-07-18T20:33:28.922Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "(312)-555-0690",
+      "valueBase64": "KDMxMiktNTU1LTA2OTA=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3: variableExportTestDir3/esv-volkerstestvariable1.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-volkerstestvariable1": {
+      "_id": "esv-volkerstestvariable1",
+      "description": "variable created for api testing",
+      "expressionType": "",
+      "lastChangeDate": "2022-11-30T00:13:52.478Z",
+      "lastChangedBy": "10ecab02-f357-4522-bc17-dfcc64744064",
+      "loaded": true,
+      "value": "for jest",
+      "valueBase64": "Zm9yIGplc3Q=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export --variable-id esv-test-var": should export the variable with variable id "esv-test-var" 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export --variable-id esv-test-var": should export the variable with variable id "esv-test-var": ./esv-test-var.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variables": {
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-blue-piller.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-blue-piller": {
+      "_id": "esv-blue-piller",
+      "description": "Zion membership criteria.",
+      "expressionType": "bool",
+      "lastChangeDate": "2023-07-18T22:21:38.640Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "false",
+      "valueBase64": "ZmFsc2U=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-ipv4-cidr-access-rules.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-ipv4-cidr-access-rules": {
+      "_id": "esv-ipv4-cidr-access-rules",
+      "description": "IPv4 CIDR access rules:
+{
+  "allow": [
+    "address/mask"
+  ]
+}",
+      "expressionType": "",
+      "lastChangeDate": "2022-08-25T22:54:28.551Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "{  "allow": [    "150.128.0.0/16",    "139.35.0.0/16",    "101.216.0.0/16",    "99.72.28.182/32"  ]}",
+      "valueBase64": "eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-nebuchadnezzar-crew.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-nebuchadnezzar-crew": {
+      "_id": "esv-nebuchadnezzar-crew",
+      "description": "The crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "array",
+      "lastChangeDate": "2023-07-18T21:59:58.974Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "["Morpheus","Trinity","Link","Tank","Dozer","Apoc","Cypher","Mouse","Neo","Switch"]",
+      "valueBase64": "WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-nebuchadnezzar-crew-structure.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-nebuchadnezzar-crew-structure": {
+      "_id": "esv-nebuchadnezzar-crew-structure",
+      "description": "The structure of the crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "object",
+      "lastChangeDate": "2023-07-18T22:09:54.630Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "{"Captain":"Morpheus","FirstMate":"Trinity","Operator":["Link","Tank"],"Medic":"Dozer","Crewmen":["Apoc","Cypher","Mouse","Neo","Switch"]}",
+      "valueBase64": "eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-neo-age.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-neo-age": {
+      "_id": "esv-neo-age",
+      "description": "Neo's age in the matrix.",
+      "expressionType": "int",
+      "lastChangeDate": "2023-07-18T22:21:23.578Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "28",
+      "valueBase64": "Mjg=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-test-var.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-test-var-1.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-1": {
+      "_id": "esv-test-var-1",
+      "description": "test var one",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-09T17:42:41.684Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "test var 1 value2",
+      "valueBase64": "dGVzdCB2YXIgMSB2YWx1ZTI=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-test-var-2.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-2": {
+      "_id": "esv-test-var-2",
+      "description": "A temporary test variable",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-02T21:09:01.847Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "testval",
+      "valueBase64": "dGVzdHZhbA==",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-test-var-3.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-3": {
+      "_id": "esv-test-var-3",
+      "description": "This is a test variable",
+      "expressionType": "int",
+      "lastChangeDate": "2023-10-17T22:22:52.023Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "42",
+      "valueBase64": "NDI=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-test-var-pi.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-pi": {
+      "_id": "esv-test-var-pi",
+      "description": "This is another test variable.",
+      "expressionType": "number",
+      "lastChangeDate": "2023-10-17T22:28:44.529Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-test-var-pi-string.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-test-var-pi-string": {
+      "_id": "esv-test-var-pi-string",
+      "description": "This is another test variable.",
+      "expressionType": "string",
+      "lastChangeDate": "2023-10-18T22:05:30.300Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-trinity-phone.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-trinity-phone": {
+      "_id": "esv-trinity-phone",
+      "description": "In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690",
+      "expressionType": "string",
+      "lastChangeDate": "2023-07-18T20:33:28.922Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "(312)-555-0690",
+      "valueBase64": "KDMxMiktNTU1LTA2OTA=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -A": should export all variables to separate files: ./esv-volkerstestvariable1.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variable": {
+    "esv-volkerstestvariable1": {
+      "_id": "esv-volkerstestvariable1",
+      "description": "variable created for api testing",
+      "expressionType": "",
+      "lastChangeDate": "2022-11-30T00:13:52.478Z",
+      "lastChangedBy": "10ecab02-f357-4522-bc17-dfcc64744064",
+      "loaded": true,
+      "value": "for jest",
+      "valueBase64": "Zm9yIGplc3Q=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -a --file my-allAlphaVariables.variable.json --no-decode": should export all variables to a single file named my-allAlphaVariables.variable.json 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export -a --file my-allAlphaVariables.variable.json --no-decode": should export all variables to a single file named my-allAlphaVariables.variable.json: ./my-allAlphaVariables.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variables": {
+    "esv-blue-piller": {
+      "_id": "esv-blue-piller",
+      "description": "Zion membership criteria.",
+      "expressionType": "bool",
+      "lastChangeDate": "2023-07-18T22:21:38.640Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "false",
+      "valueBase64": "ZmFsc2U=",
+    },
+    "esv-ipv4-cidr-access-rules": {
+      "_id": "esv-ipv4-cidr-access-rules",
+      "description": "IPv4 CIDR access rules:
+{
+  "allow": [
+    "address/mask"
+  ]
+}",
+      "expressionType": "",
+      "lastChangeDate": "2022-08-25T22:54:28.551Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "{  "allow": [    "150.128.0.0/16",    "139.35.0.0/16",    "101.216.0.0/16",    "99.72.28.182/32"  ]}",
+      "valueBase64": "eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==",
+    },
+    "esv-nebuchadnezzar-crew": {
+      "_id": "esv-nebuchadnezzar-crew",
+      "description": "The crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "array",
+      "lastChangeDate": "2023-07-18T21:59:58.974Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "["Morpheus","Trinity","Link","Tank","Dozer","Apoc","Cypher","Mouse","Neo","Switch"]",
+      "valueBase64": "WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=",
+    },
+    "esv-nebuchadnezzar-crew-structure": {
+      "_id": "esv-nebuchadnezzar-crew-structure",
+      "description": "The structure of the crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "object",
+      "lastChangeDate": "2023-07-18T22:09:54.630Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "{"Captain":"Morpheus","FirstMate":"Trinity","Operator":["Link","Tank"],"Medic":"Dozer","Crewmen":["Apoc","Cypher","Mouse","Neo","Switch"]}",
+      "valueBase64": "eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19",
+    },
+    "esv-neo-age": {
+      "_id": "esv-neo-age",
+      "description": "Neo's age in the matrix.",
+      "expressionType": "int",
+      "lastChangeDate": "2023-07-18T22:21:23.578Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "28",
+      "valueBase64": "Mjg=",
+    },
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+    "esv-test-var-1": {
+      "_id": "esv-test-var-1",
+      "description": "test var one",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-09T17:42:41.684Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "test var 1 value2",
+      "valueBase64": "dGVzdCB2YXIgMSB2YWx1ZTI=",
+    },
+    "esv-test-var-2": {
+      "_id": "esv-test-var-2",
+      "description": "A temporary test variable",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-02T21:09:01.847Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "testval",
+      "valueBase64": "dGVzdHZhbA==",
+    },
+    "esv-test-var-3": {
+      "_id": "esv-test-var-3",
+      "description": "This is a test variable",
+      "expressionType": "int",
+      "lastChangeDate": "2023-10-17T22:22:52.023Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "42",
+      "valueBase64": "NDI=",
+    },
+    "esv-test-var-pi": {
+      "_id": "esv-test-var-pi",
+      "description": "This is another test variable.",
+      "expressionType": "number",
+      "lastChangeDate": "2023-10-17T22:28:44.529Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+    "esv-test-var-pi-string": {
+      "_id": "esv-test-var-pi-string",
+      "description": "This is another test variable.",
+      "expressionType": "string",
+      "lastChangeDate": "2023-10-18T22:05:30.300Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+    "esv-trinity-phone": {
+      "_id": "esv-trinity-phone",
+      "description": "In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690",
+      "expressionType": "string",
+      "lastChangeDate": "2023-07-18T20:33:28.922Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "(312)-555-0690",
+      "valueBase64": "KDMxMiktNTU1LTA2OTA=",
+    },
+    "esv-volkerstestvariable1": {
+      "_id": "esv-volkerstestvariable1",
+      "description": "variable created for api testing",
+      "expressionType": "",
+      "lastChangeDate": "2022-11-30T00:13:52.478Z",
+      "lastChangedBy": "10ecab02-f357-4522-bc17-dfcc64744064",
+      "loaded": true,
+      "value": "for jest",
+      "valueBase64": "Zm9yIGplc3Q=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -aD variableExportTestDir2": should export all variables to a single file in the directory variableExportTestDir2 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export -aD variableExportTestDir2": should export all variables to a single file in the directory variableExportTestDir2: variableExportTestDir2/allAlphaVariables.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variables": {
+    "esv-blue-piller": {
+      "_id": "esv-blue-piller",
+      "description": "Zion membership criteria.",
+      "expressionType": "bool",
+      "lastChangeDate": "2023-07-18T22:21:38.640Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "false",
+      "valueBase64": "ZmFsc2U=",
+    },
+    "esv-ipv4-cidr-access-rules": {
+      "_id": "esv-ipv4-cidr-access-rules",
+      "description": "IPv4 CIDR access rules:
+{
+  "allow": [
+    "address/mask"
+  ]
+}",
+      "expressionType": "",
+      "lastChangeDate": "2022-08-25T22:54:28.551Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "{  "allow": [    "150.128.0.0/16",    "139.35.0.0/16",    "101.216.0.0/16",    "99.72.28.182/32"  ]}",
+      "valueBase64": "eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==",
+    },
+    "esv-nebuchadnezzar-crew": {
+      "_id": "esv-nebuchadnezzar-crew",
+      "description": "The crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "array",
+      "lastChangeDate": "2023-07-18T21:59:58.974Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "["Morpheus","Trinity","Link","Tank","Dozer","Apoc","Cypher","Mouse","Neo","Switch"]",
+      "valueBase64": "WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=",
+    },
+    "esv-nebuchadnezzar-crew-structure": {
+      "_id": "esv-nebuchadnezzar-crew-structure",
+      "description": "The structure of the crew of the Nebuchadnezzar hovercraft.",
+      "expressionType": "object",
+      "lastChangeDate": "2023-07-18T22:09:54.630Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "{"Captain":"Morpheus","FirstMate":"Trinity","Operator":["Link","Tank"],"Medic":"Dozer","Crewmen":["Apoc","Cypher","Mouse","Neo","Switch"]}",
+      "valueBase64": "eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19",
+    },
+    "esv-neo-age": {
+      "_id": "esv-neo-age",
+      "description": "Neo's age in the matrix.",
+      "expressionType": "int",
+      "lastChangeDate": "2023-07-18T22:21:23.578Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "28",
+      "valueBase64": "Mjg=",
+    },
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+    "esv-test-var-1": {
+      "_id": "esv-test-var-1",
+      "description": "test var one",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-09T17:42:41.684Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "test var 1 value2",
+      "valueBase64": "dGVzdCB2YXIgMSB2YWx1ZTI=",
+    },
+    "esv-test-var-2": {
+      "_id": "esv-test-var-2",
+      "description": "A temporary test variable",
+      "expressionType": "string",
+      "lastChangeDate": "2023-08-02T21:09:01.847Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "testval",
+      "valueBase64": "dGVzdHZhbA==",
+    },
+    "esv-test-var-3": {
+      "_id": "esv-test-var-3",
+      "description": "This is a test variable",
+      "expressionType": "int",
+      "lastChangeDate": "2023-10-17T22:22:52.023Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "42",
+      "valueBase64": "NDI=",
+    },
+    "esv-test-var-pi": {
+      "_id": "esv-test-var-pi",
+      "description": "This is another test variable.",
+      "expressionType": "number",
+      "lastChangeDate": "2023-10-17T22:28:44.529Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+    "esv-test-var-pi-string": {
+      "_id": "esv-test-var-pi-string",
+      "description": "This is another test variable.",
+      "expressionType": "string",
+      "lastChangeDate": "2023-10-18T22:05:30.300Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "3.1415926",
+      "valueBase64": "My4xNDE1OTI2",
+    },
+    "esv-trinity-phone": {
+      "_id": "esv-trinity-phone",
+      "description": "In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690",
+      "expressionType": "string",
+      "lastChangeDate": "2023-07-18T20:33:28.922Z",
+      "lastChangedBy": "b672336b-41ef-428d-ae4a-e0c082875377",
+      "loaded": true,
+      "value": "(312)-555-0690",
+      "valueBase64": "KDMxMiktNTU1LTA2OTA=",
+    },
+    "esv-volkerstestvariable1": {
+      "_id": "esv-volkerstestvariable1",
+      "description": "variable created for api testing",
+      "expressionType": "",
+      "lastChangeDate": "2022-11-30T00:13:52.478Z",
+      "lastChangedBy": "10ecab02-f357-4522-bc17-dfcc64744064",
+      "loaded": true,
+      "value": "for jest",
+      "valueBase64": "Zm9yIGplc3Q=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -i esv-test-var -D variableExportTestDir1": should export the variable with variable id "esv-test-var" into the directory named variableExportTestDir1 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export -i esv-test-var -D variableExportTestDir1": should export the variable with variable id "esv-test-var" into the directory named variableExportTestDir1: variableExportTestDir1/esv-test-var.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variables": {
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+  },
+}
+`;
+
+exports[`frodo esv variable export "frodo esv variable export -i esv-test-var -f my-esv-test-var.variable.json --no-decode": should export the variable with variable id "esv-test-var" into file named my-esv-test-var.variable.json 1`] = `""`;
+
+exports[`frodo esv variable export "frodo esv variable export -i esv-test-var -f my-esv-test-var.variable.json --no-decode": should export the variable with variable id "esv-test-var" into file named my-esv-test-var.variable.json: ./my-esv-test-var.variable.json 1`] = `
+{
+  "meta": Any<Object>,
+  "variables": {
+    "esv-test-var": {
+      "_id": "esv-test-var",
+      "description": "this is a test description",
+      "expressionType": "",
+      "lastChangeDate": "2022-09-02T04:23:56.075Z",
+      "lastChangedBy": "8efaa5b6-8c98-4489-9b21-ee41f5589ab7",
+      "loaded": true,
+      "value": "this is a test variable",
+      "valueBase64": "dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=",
+    },
+  },
+}
+`;

--- a/test/e2e/esv-secret-export.e2e.test.js
+++ b/test/e2e/esv-secret-export.e2e.test.js
@@ -1,0 +1,119 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export --secret-id esv-test-secret
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export -i esv-test-secret -f my-esv-test-secret.secret.json
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export -i esv-test-secret -D secretExportTestDir1
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export --all
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export -a --file my-allAlphaSecrets.secret.json
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export -aD secretExportTestDir2
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export -A
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv secret export --all-separate --directory secretExportTestDir3
+*/
+import { testExport } from './utils/TestUtils';
+import { connection as c } from './utils/TestConfig';
+
+process.env['FRODO_MOCK'] = '1';
+const env = {
+    env: process.env,
+};
+env.env.FRODO_HOST = c.host;
+env.env.FRODO_SA_ID = c.saId;
+env.env.FRODO_SA_JWK = c.saJwk;
+
+const type = 'secret';
+
+describe('frodo esv secret export', () => {
+    test('"frodo esv secret export --secret-id esv-test-secret": should export the secret with secret id "esv-test-secret"', async () => {
+        const exportFile = "esv-test-secret.secret.json";
+        const CMD = `frodo esv secret export --secret-id esv-test-secret`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv secret export -i esv-test-secret -f my-esv-test-secret.secret.json": should export the secret with secret id "esv-test-secret" into file named my-esv-test-secret.secret.json', async () => {
+        const exportFile = "my-esv-test-secret.secret.json";
+        const CMD = `frodo esv secret export -i esv-test-secret -f ${exportFile}`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv secret export -i esv-test-secret -D secretExportTestDir1": should export the secret with secret id "esv-test-secret" into the directory named secretExportTestDir1', async () => {
+        const exportDirectory = "secretExportTestDir1";
+        const CMD = `frodo esv secret export -i esv-test-secret -D ${exportDirectory}`;
+        await testExport(CMD, env, type, undefined, exportDirectory);
+    });
+
+    test('"frodo esv secret export --all": should export all secrets to a single file', async () => {
+        const exportFile = "allAlphaSecrets.secret.json";
+        const CMD = `frodo esv secret export --all`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv secret export -a --file my-allAlphaSecrets.secret.json": should export all secrets to a single file named my-allAlphaSecrets.secret.json', async () => {
+        const exportFile = "my-allAlphaSecrets.secret.json";
+        const CMD = `frodo esv secret export -a --file ${exportFile}`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv secret export -aD secretExportTestDir2": should export all secrets to a single file in the directory secretExportTestDir2', async () => {
+        const exportDirectory = "secretExportTestDir2";
+        const CMD = `frodo esv secret export -aD ${exportDirectory}`;
+        await testExport(CMD, env, type, undefined, exportDirectory);
+    });
+
+    test('"frodo esv secret export -A": should export all secrets to separate files', async () => {
+        const CMD = `frodo esv secret export -A`;
+        await testExport(CMD, env, type);
+    });
+
+    test('"frodo esv secret export --all-separate --directory secretExportTestDir3": should export all secrets to separate files in the directory secretExportTestDir3', async () => {
+        const exportDirectory = "secretExportTestDir3";
+        const CMD = `frodo esv secret export --all-separate --directory ${exportDirectory}`;
+        await testExport(CMD, env, type, undefined, exportDirectory);
+    });
+});

--- a/test/e2e/esv-variable-export.e2e.test.js
+++ b/test/e2e/esv-variable-export.e2e.test.js
@@ -1,0 +1,119 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export --variable-id esv-test-var
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export -i esv-test-var -f my-esv-test-var.variable.json --no-decode
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export -i esv-test-var -D variableExportTestDir1
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export --all
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export -a --file my-allAlphaVariables.variable.json --no-decode
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export -aD variableExportTestDir2
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export -A
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode
+*/
+import { testExport } from './utils/TestUtils';
+import { connection as c } from './utils/TestConfig';
+
+process.env['FRODO_MOCK'] = '1';
+const env = {
+    env: process.env,
+};
+env.env.FRODO_HOST = c.host;
+env.env.FRODO_SA_ID = c.saId;
+env.env.FRODO_SA_JWK = c.saJwk;
+
+const type = 'variable';
+
+describe('frodo esv variable export', () => {
+    test('"frodo esv variable export --variable-id esv-test-var": should export the variable with variable id "esv-test-var"', async () => {
+        const exportFile = "esv-test-var.variable.json";
+        const CMD = `frodo esv variable export --variable-id esv-test-var`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv variable export -i esv-test-var -f my-esv-test-var.variable.json --no-decode": should export the variable with variable id "esv-test-var" into file named my-esv-test-var.variable.json', async () => {
+        const exportFile = "my-esv-test-var.variable.json";
+        const CMD = `frodo esv variable export -i esv-test-var -f ${exportFile} --no-decode`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv variable export -i esv-test-var -D variableExportTestDir1": should export the variable with variable id "esv-test-var" into the directory named variableExportTestDir1', async () => {
+        const exportDirectory = "variableExportTestDir1";
+        const CMD = `frodo esv variable export -i esv-test-var -D ${exportDirectory}`;
+        await testExport(CMD, env, type, undefined, exportDirectory);
+    });
+
+    test('"frodo esv variable export --all": should export all variables to a single file', async () => {
+        const exportFile = "allAlphaVariables.variable.json";
+        const CMD = `frodo esv variable export --all`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv variable export -a --file my-allAlphaVariables.variable.json --no-decode": should export all variables to a single file named my-allAlphaVariables.variable.json', async () => {
+        const exportFile = "my-allAlphaVariables.variable.json";
+        const CMD = `frodo esv variable export -a --file ${exportFile} --no-decode`;
+        await testExport(CMD, env, type, exportFile);
+    });
+
+    test('"frodo esv variable export -aD variableExportTestDir2": should export all variables to a single file in the directory variableExportTestDir2', async () => {
+        const exportDirectory = "variableExportTestDir2";
+        const CMD = `frodo esv variable export -aD ${exportDirectory}`;
+        await testExport(CMD, env, type, undefined, exportDirectory);
+    });
+
+    test('"frodo esv variable export -A": should export all variables to separate files', async () => {
+        const CMD = `frodo esv variable export -A`;
+        await testExport(CMD, env, type);
+    });
+
+    test('"frodo esv variable export --all-separate --directory variableExportTestDir3 --no-decode": should export all variables to separate files in the directory variableExportTestDir3', async () => {
+        const exportDirectory = "variableExportTestDir3";
+        const CMD = `frodo esv variable export --all-separate --directory ${exportDirectory} --no-decode`;
+        await testExport(CMD, env, type, undefined, exportDirectory);
+    });
+});

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_A/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:56 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:57.108Z",
+        "time": 158,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 158
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:56 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:57.405Z",
+        "time": 73,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 73
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_A/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a24d647eb74a9e69a6b0bd9ed23dc6ce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1485,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets"
+        },
+        "response": {
+          "bodySize": 1805,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1805,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-admin-token\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2022-08-11T22:32:38.056Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-admin-token-1999386457729\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-05-14T01:07:41.970Z\",\"lastChangedBy\":\"8d9723a9-a439-4cbf-beb4-30e52811789d\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-1\",\"activeVersion\":\"1\",\"description\":\"test secret one\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-06T03:53:17.716Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-17T22:37:13.115Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic2\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-18T21:45:46.571Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":false}],\"resultCount\":6,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:58 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1805"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 241,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:57.570Z",
+        "time": 604,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 604
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_A/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:56 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:57.299Z",
+        "time": 95,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 95
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_A_2106804035/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_A/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:57 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e0c19204-b066-4e0e-8b62-6415cbfa78aa"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:57.488Z",
+        "time": 69,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 69
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_aD/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:34 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:35.087Z",
+        "time": 371,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 371
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:34 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:35.634Z",
+        "time": 72,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 72
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_aD/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a24d647eb74a9e69a6b0bd9ed23dc6ce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1485,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets"
+        },
+        "response": {
+          "bodySize": 1805,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1805,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-admin-token\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2022-08-11T22:32:38.056Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-admin-token-1999386457729\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-05-14T01:07:41.970Z\",\"lastChangedBy\":\"8d9723a9-a439-4cbf-beb4-30e52811789d\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-1\",\"activeVersion\":\"1\",\"description\":\"test secret one\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-06T03:53:17.716Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-17T22:37:13.115Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic2\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-18T21:45:46.571Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":false}],\"resultCount\":6,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:36 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1805"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 241,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:35.813Z",
+        "time": 594,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 594
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_aD/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:34 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:35.517Z",
+        "time": 104,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 104
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_aD_4129875621/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_aD/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:35 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2202a883-1de5-4e46-b331-57513609a98e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:35.718Z",
+        "time": 82,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 82
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_a_file/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:04 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:05.550Z",
+        "time": 115,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 115
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:05 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:05.815Z",
+        "time": 79,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 79
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_a_file/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a24d647eb74a9e69a6b0bd9ed23dc6ce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1485,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets"
+        },
+        "response": {
+          "bodySize": 1805,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1805,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-admin-token\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2022-08-11T22:32:38.056Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-admin-token-1999386457729\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-05-14T01:07:41.970Z\",\"lastChangedBy\":\"8d9723a9-a439-4cbf-beb4-30e52811789d\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-1\",\"activeVersion\":\"1\",\"description\":\"test secret one\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-06T03:53:17.716Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-17T22:37:13.115Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic2\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-18T21:45:46.571Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":false}],\"resultCount\":6,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:10 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1805"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 241,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:05.993Z",
+        "time": 4992,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4992
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_a_file/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:05 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:05.691Z",
+        "time": 109,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 109
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_a_file_4115838018/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_a_file/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:15:05 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-261cdbef-487f-4297-b74f-744884b6ba45"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:15:05.907Z",
+        "time": 79,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 79
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all-separate_directory/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:16:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:16:19.678Z",
+        "time": 129,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 129
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:16:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:16:19.985Z",
+        "time": 77,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 77
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all-separate_directory/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a24d647eb74a9e69a6b0bd9ed23dc6ce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1485,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets"
+        },
+        "response": {
+          "bodySize": 1805,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1805,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-admin-token\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2022-08-11T22:32:38.056Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-admin-token-1999386457729\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-05-14T01:07:41.970Z\",\"lastChangedBy\":\"8d9723a9-a439-4cbf-beb4-30e52811789d\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-1\",\"activeVersion\":\"1\",\"description\":\"test secret one\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-06T03:53:17.716Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-17T22:37:13.115Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic2\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-18T21:45:46.571Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":false}],\"resultCount\":6,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:16:20 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1805"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 241,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:16:20.155Z",
+        "time": 720,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 720
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all-separate_directory/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:16:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:16:19.870Z",
+        "time": 107,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 107
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all-separate_directory_3135850579/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all-separate_directory/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:16:20 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-e3906d8b-f040-41b4-b836-63d51d84f67e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:16:20.072Z",
+        "time": 72,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 72
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:39 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:39.665Z",
+        "time": 114,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 114
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:39 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:39.929Z",
+        "time": 77,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 77
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a24d647eb74a9e69a6b0bd9ed23dc6ce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1485,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets"
+        },
+        "response": {
+          "bodySize": 1805,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1805,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-admin-token\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2022-08-11T22:32:38.056Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-admin-token-1999386457729\",\"activeVersion\":\"1\",\"description\":\"Long-lived admin token\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-05-14T01:07:41.970Z\",\"lastChangedBy\":\"8d9723a9-a439-4cbf-beb4-30e52811789d\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-1\",\"activeVersion\":\"1\",\"description\":\"test secret one\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-06T03:53:17.716Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-17T22:37:13.115Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":true},{\"_id\":\"esv-test-secret-pi-generic2\",\"activeVersion\":\"1\",\"description\":\"This is a test secret containing the value pi.\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-10-18T21:45:46.571Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"1\",\"useInPlaceholders\":false}],\"resultCount\":6,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:40 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "1805"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 241,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:40.122Z",
+        "time": 603,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 603
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:39 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:39.806Z",
+        "time": 110,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 110
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_all_1797740195/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_all/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:40 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d0dc7dcf-e458-43f1-b941-8b788294af5e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:40.028Z",
+        "time": 80,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 80
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_D/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:19.204Z",
+        "time": 117,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 117
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:19.461Z",
+        "time": 75,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 75
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_D/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "0b347f3163c26e50f02a2c38a0f934f8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1501,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-test-secret"
+        },
+        "response": {
+          "bodySize": 266,
+          "content": {
+            "mimeType": "application/json",
+            "size": 266,
+            "text": "{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:19 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "266"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:19.636Z",
+        "time": 253,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 253
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_D/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:18 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:19.346Z",
+        "time": 96,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 96
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_D_3629472760/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_D/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:14:19 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-68de5343-df0e-46f2-998b-49619cacc94c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:14:19.547Z",
+        "time": 81,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 81
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_f/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:57 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:57.634Z",
+        "time": 117,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 117
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:57 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:57.878Z",
+        "time": 73,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 73
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_f/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "0b347f3163c26e50f02a2c38a0f934f8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1501,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-test-secret"
+        },
+        "response": {
+          "bodySize": 266,
+          "content": {
+            "mimeType": "application/json",
+            "size": 266,
+            "text": "{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:58 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "266"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:58.056Z",
+        "time": 369,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 369
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_f/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:57 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:57.780Z",
+        "time": 93,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 93
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_i_f_3126144190/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_i_f/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:57 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16d82b25-43a2-4633-9a4e-dcff62abd50a"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:57.964Z",
+        "time": 84,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 84
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_secret-id/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:29 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:29.208Z",
+        "time": 117,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 117
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:29 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:29.461Z",
+        "time": 77,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 77
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_secret-id/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "0b347f3163c26e50f02a2c38a0f934f8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1501,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/secrets/esv-test-secret"
+        },
+        "response": {
+          "bodySize": 266,
+          "content": {
+            "mimeType": "application/json",
+            "size": 266,
+            "text": "{\"_id\":\"esv-test-secret\",\"activeVersion\":\"2\",\"description\":\"Secret Value for testing\",\"encoding\":\"generic\",\"lastChangeDate\":\"2023-08-09T19:00:01.501Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"loadedVersion\":\"2\",\"useInPlaceholders\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:29 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "266"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:29.660Z",
+        "time": 240,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 240
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_secret-id/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:29 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:29.347Z",
+        "time": 105,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 105
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/secret-export_865062466/0_secret-id_3636945294/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/secret-export/0_secret-id/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:13:29 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2b2090fa-d521-42b0-aa4e-e00104be8f6f"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:13:29.559Z",
+        "time": 84,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 84
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_A/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:53 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:53.772Z",
+        "time": 157,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 157
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:53 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:54.082Z",
+        "time": 83,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 83
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_A/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "3e8d5f28d2136edf1b00c2f955eaa5fa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1487,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables"
+        },
+        "response": {
+          "bodySize": 3821,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3821,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-blue-piller\",\"description\":\"Zion membership criteria.\",\"expressionType\":\"bool\",\"lastChangeDate\":\"2023-07-18T22:21:38.640Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"ZmFsc2U=\"},{\"_id\":\"esv-ipv4-cidr-access-rules\",\"description\":\"IPv4 CIDR access rules:\\n{\\n  \\\"allow\\\": [\\n    \\\"address/mask\\\"\\n  ]\\n}\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-08-25T22:54:28.551Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==\"},{\"_id\":\"esv-nebuchadnezzar-crew\",\"description\":\"The crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"array\",\"lastChangeDate\":\"2023-07-18T21:59:58.974Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=\"},{\"_id\":\"esv-nebuchadnezzar-crew-structure\",\"description\":\"The structure of the crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"object\",\"lastChangeDate\":\"2023-07-18T22:09:54.630Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19\"},{\"_id\":\"esv-neo-age\",\"description\":\"Neo's age in the matrix.\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-07-18T22:21:23.578Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"Mjg=\"},{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"},{\"_id\":\"esv-test-var-1\",\"description\":\"test var one\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-09T17:42:41.684Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdCB2YXIgMSB2YWx1ZTI=\"},{\"_id\":\"esv-test-var-2\",\"description\":\"A temporary test variable\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-02T21:09:01.847Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdHZhbA==\"},{\"_id\":\"esv-test-var-3\",\"description\":\"This is a test variable\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-10-17T22:22:52.023Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"NDI=\"},{\"_id\":\"esv-test-var-pi\",\"description\":\"This is another test variable.\",\"expressionType\":\"number\",\"lastChangeDate\":\"2023-10-17T22:28:44.529Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-test-var-pi-string\",\"description\":\"This is another test variable.\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-10-18T22:05:30.300Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-trinity-phone\",\"description\":\"In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-07-18T20:33:28.922Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"KDMxMiktNTU1LTA2OTA=\"},{\"_id\":\"esv-volkerstestvariable1\",\"description\":\"variable created for api testing\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-11-30T00:13:52.478Z\",\"lastChangedBy\":\"10ecab02-f357-4522-bc17-dfcc64744064\",\"loaded\":true,\"valueBase64\":\"Zm9yIGplc3Q=\"}],\"resultCount\":13,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:56 GMT"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 247,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:54.269Z",
+        "time": 2509,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2509
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_A/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:53 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:53.978Z",
+        "time": 96,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 96
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_A_2106804035/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_A/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:54 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a61506a-2ddf-4d25-bc92-2d7c25be24c4"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:54.176Z",
+        "time": 86,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 86
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_aD/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:31 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:31.840Z",
+        "time": 152,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 152
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:31 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:32.161Z",
+        "time": 91,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 91
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_aD/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "3e8d5f28d2136edf1b00c2f955eaa5fa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1487,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables"
+        },
+        "response": {
+          "bodySize": 3821,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3821,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-blue-piller\",\"description\":\"Zion membership criteria.\",\"expressionType\":\"bool\",\"lastChangeDate\":\"2023-07-18T22:21:38.640Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"ZmFsc2U=\"},{\"_id\":\"esv-ipv4-cidr-access-rules\",\"description\":\"IPv4 CIDR access rules:\\n{\\n  \\\"allow\\\": [\\n    \\\"address/mask\\\"\\n  ]\\n}\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-08-25T22:54:28.551Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==\"},{\"_id\":\"esv-nebuchadnezzar-crew\",\"description\":\"The crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"array\",\"lastChangeDate\":\"2023-07-18T21:59:58.974Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=\"},{\"_id\":\"esv-nebuchadnezzar-crew-structure\",\"description\":\"The structure of the crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"object\",\"lastChangeDate\":\"2023-07-18T22:09:54.630Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19\"},{\"_id\":\"esv-neo-age\",\"description\":\"Neo's age in the matrix.\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-07-18T22:21:23.578Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"Mjg=\"},{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"},{\"_id\":\"esv-test-var-1\",\"description\":\"test var one\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-09T17:42:41.684Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdCB2YXIgMSB2YWx1ZTI=\"},{\"_id\":\"esv-test-var-2\",\"description\":\"A temporary test variable\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-02T21:09:01.847Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdHZhbA==\"},{\"_id\":\"esv-test-var-3\",\"description\":\"This is a test variable\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-10-17T22:22:52.023Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"NDI=\"},{\"_id\":\"esv-test-var-pi\",\"description\":\"This is another test variable.\",\"expressionType\":\"number\",\"lastChangeDate\":\"2023-10-17T22:28:44.529Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-test-var-pi-string\",\"description\":\"This is another test variable.\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-10-18T22:05:30.300Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-trinity-phone\",\"description\":\"In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-07-18T20:33:28.922Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"KDMxMiktNTU1LTA2OTA=\"},{\"_id\":\"esv-volkerstestvariable1\",\"description\":\"variable created for api testing\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-11-30T00:13:52.478Z\",\"lastChangedBy\":\"10ecab02-f357-4522-bc17-dfcc64744064\",\"loaded\":true,\"valueBase64\":\"Zm9yIGplc3Q=\"}],\"resultCount\":13,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:34 GMT"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 247,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:32.372Z",
+        "time": 2397,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2397
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_aD/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:31 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:32.022Z",
+        "time": 119,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 119
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_aD_4129875621/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_aD/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:22:32 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-16049af9-c7ee-49b0-b351-ee52f41e1130"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:22:32.274Z",
+        "time": 85,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 85
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_a_file_no-decode/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:31 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:31.440Z",
+        "time": 114,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 114
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:31 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:31.744Z",
+        "time": 112,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 112
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_a_file_no-decode/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "3e8d5f28d2136edf1b00c2f955eaa5fa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1487,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables"
+        },
+        "response": {
+          "bodySize": 3821,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3821,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-blue-piller\",\"description\":\"Zion membership criteria.\",\"expressionType\":\"bool\",\"lastChangeDate\":\"2023-07-18T22:21:38.640Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"ZmFsc2U=\"},{\"_id\":\"esv-ipv4-cidr-access-rules\",\"description\":\"IPv4 CIDR access rules:\\n{\\n  \\\"allow\\\": [\\n    \\\"address/mask\\\"\\n  ]\\n}\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-08-25T22:54:28.551Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==\"},{\"_id\":\"esv-nebuchadnezzar-crew\",\"description\":\"The crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"array\",\"lastChangeDate\":\"2023-07-18T21:59:58.974Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=\"},{\"_id\":\"esv-nebuchadnezzar-crew-structure\",\"description\":\"The structure of the crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"object\",\"lastChangeDate\":\"2023-07-18T22:09:54.630Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19\"},{\"_id\":\"esv-neo-age\",\"description\":\"Neo's age in the matrix.\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-07-18T22:21:23.578Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"Mjg=\"},{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"},{\"_id\":\"esv-test-var-1\",\"description\":\"test var one\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-09T17:42:41.684Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdCB2YXIgMSB2YWx1ZTI=\"},{\"_id\":\"esv-test-var-2\",\"description\":\"A temporary test variable\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-02T21:09:01.847Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdHZhbA==\"},{\"_id\":\"esv-test-var-3\",\"description\":\"This is a test variable\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-10-17T22:22:52.023Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"NDI=\"},{\"_id\":\"esv-test-var-pi\",\"description\":\"This is another test variable.\",\"expressionType\":\"number\",\"lastChangeDate\":\"2023-10-17T22:28:44.529Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-test-var-pi-string\",\"description\":\"This is another test variable.\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-10-18T22:05:30.300Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-trinity-phone\",\"description\":\"In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-07-18T20:33:28.922Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"KDMxMiktNTU1LTA2OTA=\"},{\"_id\":\"esv-volkerstestvariable1\",\"description\":\"variable created for api testing\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-11-30T00:13:52.478Z\",\"lastChangedBy\":\"10ecab02-f357-4522-bc17-dfcc64744064\",\"loaded\":true,\"valueBase64\":\"Zm9yIGplc3Q=\"}],\"resultCount\":13,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:34 GMT"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 247,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:31.978Z",
+        "time": 2286,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2286
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_a_file_no-decode/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:31 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:31.576Z",
+        "time": 156,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 156
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_a_file_no-decode_1918306693/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_a_file_no-decode/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:31 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c4c4d3b7-1f44-46b8-b340-92db1fe4e008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:31.865Z",
+        "time": 104,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 104
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all-separate_directory_no-decode/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:51.723Z",
+        "time": 111,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 111
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:52.015Z",
+        "time": 90,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 90
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all-separate_directory_no-decode/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "3e8d5f28d2136edf1b00c2f955eaa5fa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1487,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables"
+        },
+        "response": {
+          "bodySize": 3821,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3821,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-blue-piller\",\"description\":\"Zion membership criteria.\",\"expressionType\":\"bool\",\"lastChangeDate\":\"2023-07-18T22:21:38.640Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"ZmFsc2U=\"},{\"_id\":\"esv-ipv4-cidr-access-rules\",\"description\":\"IPv4 CIDR access rules:\\n{\\n  \\\"allow\\\": [\\n    \\\"address/mask\\\"\\n  ]\\n}\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-08-25T22:54:28.551Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==\"},{\"_id\":\"esv-nebuchadnezzar-crew\",\"description\":\"The crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"array\",\"lastChangeDate\":\"2023-07-18T21:59:58.974Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=\"},{\"_id\":\"esv-nebuchadnezzar-crew-structure\",\"description\":\"The structure of the crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"object\",\"lastChangeDate\":\"2023-07-18T22:09:54.630Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19\"},{\"_id\":\"esv-neo-age\",\"description\":\"Neo's age in the matrix.\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-07-18T22:21:23.578Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"Mjg=\"},{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"},{\"_id\":\"esv-test-var-1\",\"description\":\"test var one\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-09T17:42:41.684Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdCB2YXIgMSB2YWx1ZTI=\"},{\"_id\":\"esv-test-var-2\",\"description\":\"A temporary test variable\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-02T21:09:01.847Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdHZhbA==\"},{\"_id\":\"esv-test-var-3\",\"description\":\"This is a test variable\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-10-17T22:22:52.023Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"NDI=\"},{\"_id\":\"esv-test-var-pi\",\"description\":\"This is another test variable.\",\"expressionType\":\"number\",\"lastChangeDate\":\"2023-10-17T22:28:44.529Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-test-var-pi-string\",\"description\":\"This is another test variable.\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-10-18T22:05:30.300Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-trinity-phone\",\"description\":\"In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-07-18T20:33:28.922Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"KDMxMiktNTU1LTA2OTA=\"},{\"_id\":\"esv-volkerstestvariable1\",\"description\":\"variable created for api testing\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-11-30T00:13:52.478Z\",\"lastChangedBy\":\"10ecab02-f357-4522-bc17-dfcc64744064\",\"loaded\":true,\"valueBase64\":\"Zm9yIGplc3Q=\"}],\"resultCount\":13,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:54 GMT"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 247,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:52.215Z",
+        "time": 2382,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2382
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all-separate_directory_no-decode/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:51 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:51.864Z",
+        "time": 145,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 145
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all-separate_directory_no-decode_1330532604/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all-separate_directory_no-decode/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:52 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-dbe0cd82-06e1-4790-8e87-660cb13f3738"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:52.112Z",
+        "time": 90,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 90
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:46 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:46.926Z",
+        "time": 144,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 144
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:46 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:47.229Z",
+        "time": 79,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 79
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "3e8d5f28d2136edf1b00c2f955eaa5fa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1487,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables"
+        },
+        "response": {
+          "bodySize": 3821,
+          "content": {
+            "mimeType": "application/json",
+            "size": 3821,
+            "text": "{\"pagedResultsCookie\":null,\"remainingPagedResults\":-1,\"result\":[{\"_id\":\"esv-blue-piller\",\"description\":\"Zion membership criteria.\",\"expressionType\":\"bool\",\"lastChangeDate\":\"2023-07-18T22:21:38.640Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"ZmFsc2U=\"},{\"_id\":\"esv-ipv4-cidr-access-rules\",\"description\":\"IPv4 CIDR access rules:\\n{\\n  \\\"allow\\\": [\\n    \\\"address/mask\\\"\\n  ]\\n}\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-08-25T22:54:28.551Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"eyAgImFsbG93IjogWyAgICAiMTUwLjEyOC4wLjAvMTYiLCAgICAiMTM5LjM1LjAuMC8xNiIsICAgICIxMDEuMjE2LjAuMC8xNiIsICAgICI5OS43Mi4yOC4xODIvMzIiICBdfQ==\"},{\"_id\":\"esv-nebuchadnezzar-crew\",\"description\":\"The crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"array\",\"lastChangeDate\":\"2023-07-18T21:59:58.974Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"WyJNb3JwaGV1cyIsIlRyaW5pdHkiLCJMaW5rIiwiVGFuayIsIkRvemVyIiwiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl0=\"},{\"_id\":\"esv-nebuchadnezzar-crew-structure\",\"description\":\"The structure of the crew of the Nebuchadnezzar hovercraft.\",\"expressionType\":\"object\",\"lastChangeDate\":\"2023-07-18T22:09:54.630Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"eyJDYXB0YWluIjoiTW9ycGhldXMiLCJGaXJzdE1hdGUiOiJUcmluaXR5IiwiT3BlcmF0b3IiOlsiTGluayIsIlRhbmsiXSwiTWVkaWMiOiJEb3plciIsIkNyZXdtZW4iOlsiQXBvYyIsIkN5cGhlciIsIk1vdXNlIiwiTmVvIiwiU3dpdGNoIl19\"},{\"_id\":\"esv-neo-age\",\"description\":\"Neo's age in the matrix.\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-07-18T22:21:23.578Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"Mjg=\"},{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"},{\"_id\":\"esv-test-var-1\",\"description\":\"test var one\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-09T17:42:41.684Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdCB2YXIgMSB2YWx1ZTI=\"},{\"_id\":\"esv-test-var-2\",\"description\":\"A temporary test variable\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-08-02T21:09:01.847Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"dGVzdHZhbA==\"},{\"_id\":\"esv-test-var-3\",\"description\":\"This is a test variable\",\"expressionType\":\"int\",\"lastChangeDate\":\"2023-10-17T22:22:52.023Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"NDI=\"},{\"_id\":\"esv-test-var-pi\",\"description\":\"This is another test variable.\",\"expressionType\":\"number\",\"lastChangeDate\":\"2023-10-17T22:28:44.529Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-test-var-pi-string\",\"description\":\"This is another test variable.\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-10-18T22:05:30.300Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"My4xNDE1OTI2\"},{\"_id\":\"esv-trinity-phone\",\"description\":\"In the opening of The Matrix (1999), the phone number Trinity is calling from is traced to (312)-555-0690\",\"expressionType\":\"string\",\"lastChangeDate\":\"2023-07-18T20:33:28.922Z\",\"lastChangedBy\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"loaded\":true,\"valueBase64\":\"KDMxMiktNTU1LTA2OTA=\"},{\"_id\":\"esv-volkerstestvariable1\",\"description\":\"variable created for api testing\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-11-30T00:13:52.478Z\",\"lastChangedBy\":\"10ecab02-f357-4522-bc17-dfcc64744064\",\"loaded\":true,\"valueBase64\":\"Zm9yIGplc3Q=\"}],\"resultCount\":13,\"totalPagedResults\":-1,\"totalPagedResultsPolicy\":\"NONE\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:49 GMT"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 247,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:47.421Z",
+        "time": 2323,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2323
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:46 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:47.104Z",
+        "time": 119,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 119
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_all_1797740195/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_all/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:47 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-10735b24-c304-42c1-b71e-060fbd5136ab"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:47.320Z",
+        "time": 94,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 94
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_D/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:25 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:25.941Z",
+        "time": 164,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 164
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:25 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:26.269Z",
+        "time": 76,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 76
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_D/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "f217054662b72f68e607d9ad77221b90",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1500,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables/esv-test-var"
+        },
+        "response": {
+          "bodySize": 248,
+          "content": {
+            "mimeType": "application/json",
+            "size": 248,
+            "text": "{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:26 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "248"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:26.444Z",
+        "time": 467,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 467
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_D/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:25 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:26.152Z",
+        "time": 110,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 110
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_D_3629472760/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_D/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:21:26 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-0757b18c-7590-4b0b-9638-54b8a63c4577"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:21:26.353Z",
+        "time": 83,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 83
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_f_no-decode/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:07 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:08.053Z",
+        "time": 229,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 229
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:08 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:08.468Z",
+        "time": 98,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 98
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_f_no-decode/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "f217054662b72f68e607d9ad77221b90",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1500,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables/esv-test-var"
+        },
+        "response": {
+          "bodySize": 248,
+          "content": {
+            "mimeType": "application/json",
+            "size": 248,
+            "text": "{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:09 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "248"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:08.702Z",
+        "time": 646,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 646
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_f_no-decode/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:07 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:08.306Z",
+        "time": 145,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 145
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_i_f_no-decode_1936577529/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_i_f_no-decode/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 17:45:08 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-45408a4e-3669-4205-a07e-c5e087ff1f3b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T17:45:08.585Z",
+        "time": 107,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 107
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/am_1076162899/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/am_1076162899/recording.har
@@ -1,0 +1,296 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_variable-id/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:20:46 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:20:45.787Z",
+        "time": 267,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 267
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:20:46 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:20:46.243Z",
+        "time": 98,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 98
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/environment_1072573434/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/environment_1072573434/recording.har
@@ -1,0 +1,105 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_variable-id/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "f217054662b72f68e607d9ad77221b90",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1500,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/variables/esv-test-var"
+        },
+        "response": {
+          "bodySize": 248,
+          "content": {
+            "mimeType": "application/json",
+            "size": 248,
+            "text": "{\"_id\":\"esv-test-var\",\"description\":\"this is a test description\",\"expressionType\":\"\",\"lastChangeDate\":\"2022-09-02T04:23:56.075Z\",\"lastChangedBy\":\"8efaa5b6-8c98-4489-9b21-ee41f5589ab7\",\"loaded\":true,\"valueBase64\":\"dGhpcyBpcyBhIHRlc3QgdmFyaWFibGU=\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:20:46 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "248"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:20:46.471Z",
+        "time": 487,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 487
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_variable-id/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:20:46 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:20:46.083Z",
+        "time": 152,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 152
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/esv_2056898509/variable-export_2731004030/0_variable-id_3527122442/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "esv/variable-export/0_variable-id/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-45"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 24 Oct 2023 16:20:46 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5f4273de-0e7a-4eda-a658-8e73b30920a3"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-24T16:20:46.349Z",
+        "time": 114,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 114
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
Adds the ability to export ESVs, both variables and secrets. Tests included. Relies on updates to frodo-lib, contained in the "Add ability to export ESVs" pull request on frodo-lib.