### PR TITLE
Add ability to delete scripts

### DIFF
--- a/src/cli/script/script-delete.ts
+++ b/src/cli/script/script-delete.ts
@@ -1,27 +1,36 @@
-import { frodo } from '@rockcarver/frodo-lib';
+import { frodo, state } from '@rockcarver/frodo-lib';
 import { Option } from 'commander';
 
+import {
+  deleteAllScripts,
+  deleteScriptId,
+  deleteScriptName,
+} from '../../ops/ScriptOps';
+import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
 const { getTokens } = frodo.login;
 
-const program = new FrodoCommand('frodo cmd delete');
+const program = new FrodoCommand('frodo script delete');
 
 program
-  .description('Cmd delete.')
+  .description('Delete scripts.')
   .addOption(
     new Option(
-      '-i, --cmd-id <cmd-id>',
-      'Cmd id. If specified, -a and -A are ignored.'
+      '-i, --script-id <script>',
+      'id of a script. If specified, -a and -A are ignored.'
     )
   )
   .addOption(
-    new Option('-a, --all', 'Delete all cmds in a realm. Ignored with -i.')
+    new Option(
+      '-n, --script-name <script>',
+      'name of a script. If specified, -a and -A are ignored.'
+    )
   )
   .addOption(
     new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+      '-a, --all',
+      'Delete all non-default scripts in a realm. Ignored with -i.'
     )
   )
   .action(
@@ -35,9 +44,29 @@ program
         options,
         command
       );
-      if (await getTokens()) {
-        // code goes here
+      if (options.scriptId && (await getTokens())) {
+        verboseMessage(
+          `Deleting script ${
+            options.scriptId
+          } in realm "${state.getRealm()}"...`
+        );
+        deleteScriptId(options.scriptId);
+      } else if (options.scriptName && (await getTokens())) {
+        verboseMessage(
+          `Deleting script ${
+            options.scriptName
+          } in realm "${state.getRealm()}"...`
+        );
+        deleteScriptName(options.scriptName);
+      } else if (options.all && (await getTokens())) {
+        verboseMessage('Deleting all non-default scripts...');
+        deleteAllScripts();
       } else {
+        printMessage(
+          'Unrecognized combination of options or no options...',
+          'error'
+        );
+        program.help();
         process.exitCode = 1;
       }
     }

--- a/src/cli/script/script.ts
+++ b/src/cli/script/script.ts
@@ -18,7 +18,7 @@ export default function setup() {
 
   program.command('import', 'Import scripts.');
 
-  // program.command('delete', 'Delete scripts.');
+  program.command('delete', 'Delete scripts.');
 
   return program;
 }

--- a/src/ops/ScriptOps.ts
+++ b/src/ops/ScriptOps.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 
 import {
   createProgressBar,
+  createProgressIndicator,
   createTable,
   debugMessage,
   failSpinner,
@@ -13,6 +14,7 @@ import {
   showSpinner,
   spinSpinner,
   stopProgressBar,
+  stopProgressIndicator,
   succeedSpinner,
   updateProgressBar,
 } from '../utils/Console';
@@ -30,6 +32,9 @@ const {
   exportScriptByName,
   exportScripts,
   importScripts,
+  deleteScript,
+  deleteScriptByName,
+  deleteScripts,
 } = frodo.script;
 
 const { isBase64Encoded, getFilePath, getWorkingDirectory } = frodo.utils;
@@ -530,4 +535,49 @@ function getScriptId(script: ScriptExportInterface): string {
     throw new Error(`Expected 1 script, found ${scriptIds.length}`);
   }
   return scriptIds[0];
+}
+
+/**
+ * Delete script by id
+ * @param {String} id script id
+ */
+export async function deleteScriptId(id) {
+  createProgressIndicator('indeterminate', undefined, `Deleting ${id}...`);
+  try {
+    await deleteScript(id);
+    stopProgressIndicator(`Deleted ${id}.`, 'success');
+  } catch (error) {
+    stopProgressIndicator(`Error: ${error.message}`, 'fail');
+  }
+}
+
+/**
+ * Delete script by name
+ * @param {String} name script name
+ */
+export async function deleteScriptName(name) {
+  createProgressIndicator('indeterminate', undefined, `Deleting ${name}...`);
+  try {
+    await deleteScriptByName(name);
+    stopProgressIndicator(`Deleted ${name}.`, 'success');
+  } catch (error) {
+    stopProgressIndicator(`Error: ${error.message}`, 'fail');
+  }
+}
+
+/**
+ * Delete all non-default scripts
+ */
+export async function deleteAllScripts() {
+  createProgressIndicator(
+    'indeterminate',
+    undefined,
+    `Deleting all non-default scripts...`
+  );
+  try {
+    await deleteScripts();
+    stopProgressIndicator(`Deleted all non-default scripts.`, 'success');
+  } catch (error) {
+    stopProgressIndicator(`Error: ${error.message}`, 'fail');
+  }
 }

--- a/test/client_cli/en/__snapshots__/script-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-delete.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI help interface for 'script delete' should be expected english 1`] = `
+"Usage: frodo script delete [options] [host] [realm] [username] [password]
+
+Delete scripts.
+
+Arguments:
+  host                         Access Management base URL, e.g.:
+                               https://cdk.iam.example.com/am. To use a
+                               connection profile, just specify a unique
+                               substring.
+  realm                        Realm. Specify realm as '/' for the root realm
+                               or 'realm' or '/parent/child' otherwise.
+                               (default: "alpha" for Identity Cloud tenants,
+                               "/" otherwise.)
+  username                     Username to login with. Must be an admin user
+                               with appropriate rights to manage authentication
+                               journeys/trees.
+  password                     Password.
+
+Options:
+  -a, --all                    Delete all non-default scripts in a realm.
+                               Ignored with -i.
+  --curlirize                  Output all network calls in curl format.
+  -D, --directory <directory>  Set the working directory.
+  --debug                      Debug output during command execution. If
+                               specified, may or may not produce additional
+                               output helpful for troubleshooting.
+  --flush-cache                Flush token cache.
+  -h, --help                   Help
+  -i, --script-id <script>     id of a script. If specified, -a and -A are
+                               ignored.
+  -k, --insecure               Allow insecure connections when using SSL/TLS.
+                               Has no effect when using a network proxy for
+                               https (HTTPS_PROXY=http://<host>:<port>), in
+                               that case the proxy must provide this
+                               capability. (default: Don't allow insecure
+                               connections)
+  -m, --type <type>            Override auto-detected deployment type. Valid
+                               values for type:
+                               classic:  A classic Access Management-only
+                               deployment with custom layout and configuration.
+  
+                               cloud:    A ForgeRock Identity Cloud
+                               environment.
+                               forgeops: A ForgeOps CDK or CDM deployment.
+                               The detected or provided deployment type
+                               controls certain behavior like obtaining an
+                               Identity Management admin token or not and
+                               whether to export/import referenced email
+                               templates or how to walk through the tenant
+                               admin login flow of Identity Cloud and handle
+                               MFA (choices: "classic", "cloud", "forgeops")
+  -n, --script-name <script>   name of a script. If specified, -a and -A are
+                               ignored.
+  --no-cache                   Disable token cache for this operation.
+  --sa-id <sa-id>              Service account id.
+  --sa-jwk-file <file>         File containing the JSON Web Key (JWK)
+                               associated with the the service account.
+  --verbose                    Verbose output during command execution. If
+                               specified, may or may not produce additional
+                               output.
+
+Evironment Variables:
+  FRODO_HOST: Access Management base URL. Overrides 'host' argument.
+  FRODO_REALM: Realm. Overrides 'realm' argument.
+  FRODO_USERNAME: Username. Overrides 'username' argument.
+  FRODO_PASSWORD: Password. Overrides 'password' argument.
+  FRODO_SA_ID: Service account uuid. Overrides '--sa-id' option.
+  FRODO_SA_JWK: Service account JWK. Overrides '--sa-jwk-file' option but takes the actual JWK as a value, not a file name.
+  FRODO_NO_CACHE: Disable token cache. Same as '--no-cache' option.
+  FRODO_TOKEN_CACHE_PATH: Use this token cache file instead of '~/.frodo/TokenCache.json'.
+  FRODO_CONNECTION_PROFILES_PATH: Use this connection profiles file instead of '~/.frodo/Connections.json'.
+  FRODO_AUTHENTICATION_SERVICE: Name of a login journey to use.
+  FRODO_DEBUG: Set to any value to enable debug output. Same as '--debug'.
+  FRODO_MASTER_KEY_PATH: Use this master key file instead of '~/.frodo/masterkey.key' file.
+  FRODO_MASTER_KEY: Use this master key instead of what's in '~/.frodo/masterkey.key'. Takes precedence over FRODO_MASTER_KEY_PATH.
+
+"
+`;

--- a/test/client_cli/en/__snapshots__/script.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script.test.js.snap
@@ -9,6 +9,7 @@ Options:
   -h, --help      Help
 
 Commands:
+  delete          Delete scripts.
   export          Export scripts.
   help [command]  display help for command
   import          Import scripts.

--- a/test/client_cli/en/script-delete.test.js
+++ b/test/client_cli/en/script-delete.test.js
@@ -1,0 +1,10 @@
+import cp from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(cp.exec);
+const CMD = 'frodo script delete --help';
+const { stdout } = await exec(CMD);
+
+test("CLI help interface for 'script delete' should be expected english", async () => {
+    expect(stdout).toMatchSnapshot();
+});

--- a/test/e2e/__snapshots__/script-delete.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/script-delete.e2e.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo script delete "frodo script delete --script-id e15a13ee-9168-40cf-934f-656a5f568a6a": should display error when the script with id 'e15a13ee-9168-40cf-934f-656a5f568a6a' cannot be deleted since it hashdeviceProfile 1`] = `
+"Connected to https://openam-frodo-dev.forgeblocks.com/am [alpha] as service account frodo-test [b672336b-41ef-428d-ae4a-e0c082875377]
+- Deleting e15a13ee-9168-40cf-934f-656a5f568a6a...
+✖ Error: Request failed with status code 404
+"
+`;
+
+exports[`frodo script delete "frodo script delete --script-name 'hashdeviceProfile'": should display error when the script named 'hashdeviceProfile' cannot be deleted since it hashdeviceProfile 1`] = `
+"Connected to https://openam-frodo-dev.forgeblocks.com/am [alpha] as service account frodo-test [b672336b-41ef-428d-ae4a-e0c082875377]
+- Deleting hashdeviceProfile...
+✖ Error: Script with name hashdeviceProfile does not exist.
+"
+`;
+
+exports[`frodo script delete "frodo script delete -i e15a13ee-9168-40cf-934f-656a5f568a6a": should delete the script with id 'e15a13ee-9168-40cf-934f-656a5f568a6a' 1`] = `""`;
+
+exports[`frodo script delete "frodo script delete -n 'hashdeviceProfile'": should delete the script named 'hashdeviceProfile' 1`] = `""`;

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_i_2777908795/am_1076162899/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_i_2777908795/am_1076162899/recording.har
@@ -1,0 +1,435 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_i/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:19.080Z",
+        "time": 115,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 115
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:19.345Z",
+        "time": 81,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 81
+        }
+      },
+      {
+        "_id": "6f37c8af2e0269f7bdc48734c4b3467a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1617,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/e15a13ee-9168-40cf-934f-656a5f568a6a"
+        },
+        "response": {
+          "bodySize": 46,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 46,
+            "text": "{\"_id\":\"e15a13ee-9168-40cf-934f-656a5f568a6a\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "46"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 745,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:19.532Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_i_2777908795/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_i_2777908795/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_i/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:19 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:19.216Z",
+        "time": 118,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 118
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_i_2777908795/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_i_2777908795/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_i/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:19 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-2a9a82e4-2b3b-4da3-a993-a07540cf1399"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:19.434Z",
+        "time": 86,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 86
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_n_2861796890/am_1076162899/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_n_2861796890/am_1076162899/recording.har
@@ -1,0 +1,579 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_n/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:12 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:12.509Z",
+        "time": 111,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 111
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:12 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:12.749Z",
+        "time": 74,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 74
+        }
+      },
+      {
+        "_id": "34d3c418b7e14e727732041a7002c358",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1626,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "name eq \"hashdeviceProfile\""
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts?_queryFilter=name%20eq%20%22hashdeviceProfile%22"
+        },
+        "response": {
+          "bodySize": 1463,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1463,
+            "text": "{\"result\":[{\"_id\":\"e15a13ee-9168-40cf-934f-656a5f568a6a\",\"name\":\"hashdeviceProfile\",\"description\":\"null\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKLy88c2NyaXB0IHR5cGU9InRleHQvamF2YXNjcmlwdCIgc3JjPSJodHRwOi8vd3d3Lm15ZXJzZGFpbHkub3JnL2pvc2VwaC9qYXZhc2NyaXB0L21kNS5qcyIgLz4KCmZ1bmN0aW9uIGhhc2hDb2RlKHIpe3ZhciBlLGg9MDtmb3IoZT0wO2U8ci5sZW5ndGg7ZSsrKWg9KGg8PDUpLWgrci5jaGFyQ29kZUF0KGUpLGh8PTA7cmV0dXJuIGg+Pj4wfQoKCnZhciBoYXNoTWUgPSBzaGFyZWRTdGF0ZS5nZXQoImZvcmdlUm9jay5kZXZpY2UucHJvZmlsZSIpOwp2YXIgaGFzaE1lID0gc2hhcmVkU3RhdGUucHV0KCJmb3JnZVJvY2suZGV2aWNlLnByb2ZpbGUiLCJkZWxldGVkIGluIHNjcmlwdCAtIGhhc2hkZXZpY2VQcm9maWxlIik7Ci8vdmFyIGhhc2hNZVN0ciA9IEpTT04uc3RyaW5naWZ5KGhhc2hNZSk7Ci8vbG9nZ2VyLmVycm9yKCJIYXNoTWVTdHI6ICIgKyBoYXNoTWVTdHIpOwoKc2hhcmVkU3RhdGUucHV0KCJkZXZpY2VIYXNoIixoYXNoQ29kZShlc2NhcGUoaGFzaE1lKSkudG9TdHJpbmcoKSk7CnNoYXJlZFN0YXRlLnB1dCgiZnJJbmRleGVkU3RyaW5nMSIsaGFzaENvZGUoZXNjYXBlKGhhc2hNZSkpLnRvU3RyaW5nKCkpOwoKb3V0Y29tZSA9ICJ0cnVlIjs=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"evaluatorVersion\":\"1.0\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.1, resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1463"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:12 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 774,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:12.923Z",
+        "time": 276,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 276
+        }
+      },
+      {
+        "_id": "6f37c8af2e0269f7bdc48734c4b3467a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1617,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/e15a13ee-9168-40cf-934f-656a5f568a6a"
+        },
+        "response": {
+          "bodySize": 46,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 46,
+            "text": "{\"_id\":\"e15a13ee-9168-40cf-934f-656a5f568a6a\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "46"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:13 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 745,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:13.205Z",
+        "time": 89,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 89
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_n_2861796890/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_n_2861796890/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_n/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:12 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:12.647Z",
+        "time": 96,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 96
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_n_2861796890/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_n_2861796890/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_n/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:12 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-b0f3deab-7c29-473a-8f99-c85ad341b430"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:12.832Z",
+        "time": 82,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 82
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_script-id_645015383/am_1076162899/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_script-id_645015383/am_1076162899/recording.har
@@ -1,0 +1,435 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_script-id/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:47 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:46.992Z",
+        "time": 112,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 112
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:47 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:47.260Z",
+        "time": 79,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 79
+        }
+      },
+      {
+        "_id": "6f37c8af2e0269f7bdc48734c4b3467a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1617,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/e15a13ee-9168-40cf-934f-656a5f568a6a"
+        },
+        "response": {
+          "bodySize": 134,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 134,
+            "text": "{\"code\":404,\"reason\":\"Not Found\",\"message\":\"Script with UUID e15a13ee-9168-40cf-934f-656a5f568a6a could not be found in realm /alpha\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "134"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:47 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 746,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2023-10-31T21:49:47.431Z",
+        "time": 71,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 71
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_script-id_645015383/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_script-id_645015383/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_script-id/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:47 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:47.127Z",
+        "time": 126,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 126
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_script-id_645015383/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_script-id_645015383/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_script-id/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:49:47 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-03b760e5-1820-4500-ad14-4d25e954b33b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:49:47.348Z",
+        "time": 75,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 75
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_script-name_2276253025/am_1076162899/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_script-name_2276253025/am_1076162899/recording.har
@@ -1,0 +1,440 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_script-name/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:34 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:34.207Z",
+        "time": 122,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 122
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1550,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 283,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1217229914\",\"version\":\"7.4.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.4.0-SNAPSHOT Build 7e44c1624c3a11db5b5b0b576bb162618f1ac605 (2023-September-18 09:04)\",\"revision\":\"7e44c1624c3a11db5b5b0b576bb162618f1ac605\",\"date\":\"2023-September-18 09:04\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1217229914\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "283"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:34 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:34.479Z",
+        "time": 76,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 76
+        }
+      },
+      {
+        "_id": "34d3c418b7e14e727732041a7002c358",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1626,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "name eq \"hashdeviceProfile\""
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts?_queryFilter=name%20eq%20%22hashdeviceProfile%22"
+        },
+        "response": {
+          "bodySize": 137,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 137,
+            "text": "{\"result\":[],\"resultCount\":0,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "137"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:34 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 746,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:34.652Z",
+        "time": 149,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 149
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_script-name_2276253025/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_script-name_2276253025/oauth2_393036114/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_script-name/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1138,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": 1138
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 397,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idm:* fr:idc:esv:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1276,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1276,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idm:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1276"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:34 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 541,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:34.359Z",
+        "time": 103,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 103
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/delete_1740784714/0_script-name_2276253025/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/script_540962730/delete_1740784714/0_script-name_2276253025/openidm_3290118515/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "script/delete/0_script-name/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac31ccceb288fe104fb927288dc7c001",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.0-46"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1562,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/b672336b-41ef-428d-ae4a-e0c082875377?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1045,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1045,
+            "text": "{\"_id\":\"b672336b-41ef-428d-ae4a-e0c082875377\",\"_rev\":\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\",\"accountStatus\":\"active\",\"name\":\"frodo-test\",\"description\":\"Frodo Test\",\"scopes\":[\"fr:am:*\",\"fr:idm:*\",\"fr:idc:esv:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"e\\\":\\\"AQAB\\\",\\\"kty\\\":\\\"RSA\\\",\\\"n\\\":\\\"8lN2UVDDHchL_gIYS5lAiEVAVocyqWHmqBPwPkd22NRMLetczaVSH2UQHoQu7SSKeAtojVJUYuxRtGPfGNExZurTy3CRlzpaNa67B6jyunycPHnyNked0ceFGfjD9c6e0b97L5wqwk2YNVVMGa9c1m8R9HWk2kg9lRwlZE_piwTM9bw8tuWfL1A2-fTDQB2PZSgGGz86jG1RGMY7dnafVKIX3HbW98xOxOwqIRz607IQr-NFia5zjTltpJjR1qOlEFmdHqGTGCnFcHxeJWmKOWcDM4WmfWcgK3zR9Br-aZoDTl8RMAths30Pc1pe_dl5OepxCYQ7b0BXg0zQaYcx5G5ZcNR3ldjDNfpiXg1viWjEBiwiCg7gkYksBu0aFHX2pc4KKHKcyIeD0sbhaLSK3JXhI1TJvm7rwyX1wsRKmMTGTZMxYJlADZufKKd-Jg7k2_iwP3WUJxdgkJsgvLj7ZbTf5Paz7_FLeSajjtGPu6hGSWV8uOGgRgcnJgz3DP2S9qfHI7nKswtgwFdjbOMK39iNjU8PI-cOaaVKQcH88xBCu1bpCX1MIVvZ5arQF783qasj9bBB4t27gKXOauIr-sXMUI6_L7CQ7IqWld8VvNWKReMMqiRQV9huEEV1chCFzZI_aEW82fDC9dRbFXG-w92PhPPVbNznWsrhO1aPxA8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Oct 2023 21:50:34 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"dac6d6c0-9ef5-4725-b8df-772785c9040e-4798\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1045"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-7980688a-e128-4abe-bc23-09158a210ec0"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 648,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-10-31T21:50:34.565Z",
+        "time": 79,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 79
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/script-delete.e2e.test.js
+++ b/test/e2e/script-delete.e2e.test.js
@@ -1,0 +1,110 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script delete -n 'hashdeviceProfile'
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script delete --script-name 'hashdeviceProfile'
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script delete -i e15a13ee-9168-40cf-934f-656a5f568a6a
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script delete --script-id e15a13ee-9168-40cf-934f-656a5f568a6a
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script delete -a
+FRODO_MOCK=record FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script delete --all
+*/
+import cp from 'child_process';
+import { promisify } from 'util';
+import { removeAnsiEscapeCodes } from './utils/TestUtils';
+import { connection as c } from './utils/TestConfig';
+
+const exec = promisify(cp.exec);
+
+process.env['FRODO_MOCK'] = '1';
+const env = {
+    env: process.env,
+};
+env.env.FRODO_HOST = c.host;
+env.env.FRODO_SA_ID = c.saId;
+env.env.FRODO_SA_JWK = c.saJwk;
+
+describe('frodo script delete', () => {
+    test("\"frodo script delete -n 'hashdeviceProfile'\": should delete the script named 'hashdeviceProfile'", async () => {
+        const CMD = `frodo script delete -n 'hashdeviceProfile'`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test("\"frodo script delete --script-name 'hashdeviceProfile'\": should display error when the script named 'hashdeviceProfile' cannot be deleted since it hashdeviceProfile", async () => {
+        const CMD = `frodo script delete --script-name 'hashdeviceProfile'`;
+        const { stderr } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stderr)).toMatchSnapshot();
+    });
+
+    test('"frodo script delete -i e15a13ee-9168-40cf-934f-656a5f568a6a": should delete the script with id \'e15a13ee-9168-40cf-934f-656a5f568a6a\'', async () => {
+        const CMD = `frodo script delete -i e15a13ee-9168-40cf-934f-656a5f568a6a`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    test('"frodo script delete --script-id e15a13ee-9168-40cf-934f-656a5f568a6a": should display error when the script with id \'e15a13ee-9168-40cf-934f-656a5f568a6a\' cannot be deleted since it hashdeviceProfile', async () => {
+        const CMD = `frodo script delete --script-id e15a13ee-9168-40cf-934f-656a5f568a6a`;
+        const { stderr } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stderr)).toMatchSnapshot();
+    });
+
+    //TODO: Generate mock for this test (skip for meantime)
+    test.skip('"frodo script delete -a": should delete all scripts', async () => {
+        const CMD = `frodo script delete -a`;
+        const { stdout } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+
+    //TODO: Generate mock for this test (skip for meantime)
+    test.skip('"frodo script delete --all": should do nothing when no scripts can be deleted', async () => {
+        const CMD = `frodo script delete --all`;
+        const { stderr } = await exec(CMD, env);
+        expect(removeAnsiEscapeCodes(stderr)).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
Adds the ability to delete scripts. Since default scripts cannot be deleted, they get skipped when deleting all scripts. Also, tests for deleting all scripts currently have no mocks for them since creating mocks for them may end up deleting important scripts, so they are being skipped for now. This PR relies on the PR "Add ability to delete scripts" in the frodo-lib repo.