### PR TITLE
DRAFT: Demo of using command differently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rockcarver/frodo-cli",
-  "version": "2.0.0-52",
+  "version": "2.0.0-54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rockcarver/frodo-cli",
-      "version": "2.0.0-52",
+      "version": "2.0.0-54",
       "license": "MIT",
       "dependencies": {
         "@rockcarver/frodo-lib": "2.0.0-75",

--- a/src/app.ts
+++ b/src/app.ts
@@ -54,7 +54,7 @@ const { initTokenCache } = frodo.cache;
     await initConnectionProfiles();
     await initTokenCache();
 
-    program.addCommand(admin());
+    admin(program);
     program.addCommand(agent());
     program.addCommand(authn());
     program.addCommand(authz());

--- a/src/cli/admin/admin-federation-export.ts
+++ b/src/cli/admin/admin-federation-export.ts
@@ -1,4 +1,4 @@
-import { Option } from 'commander';
+import { Command, Option } from 'commander';
 
 import { getTokens } from '../../ops/AuthenticateOps';
 import {
@@ -7,86 +7,90 @@ import {
   exportAdminFederationProviderToFile,
 } from '../../ops/cloud/AdminFederationOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
-import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin federation export', ['realm']);
-
-program
-  .description('Export admin federation providers.')
-  .addOption(
-    new Option(
-      '-i, --idp-id <idp-id>',
-      'Id/name of a provider. If specified, -a and -A are ignored.'
+export const addFederationExport = (command: Command) => {
+  command
+    .command('export')
+    .description('Export admin federation providers.')
+    .addOption(
+      new Option(
+        '-i, --idp-id <idp-id>',
+        'Id/name of a provider. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the file to write the exported provider(s) to. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the file to write the exported provider(s) to. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all the providers to a single file. Ignored with -t and -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all the providers to a single file. Ignored with -t and -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all the providers as separate files <provider name>.admin.federation.json. Ignored with -t, -i, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all the providers as separate files <provider name>.admin.federation.json. Ignored with -t, -i, and -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(host, user, password, options, command);
-      if (await getTokens(true)) {
-        // export by id/name
-        if (options.idpId) {
-          verboseMessage(`Exporting provider "${options.idpId}...`);
-          const outcome = await exportAdminFederationProviderToFile(
-            options.idpId,
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Exporting all providers to a single file...');
-          const outcome = await exportAdminFederationProvidersToFile(
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate) {
-          verboseMessage('Exporting all providers to separate files...');
-          const outcome = await exportAdminFederationProvidersToFiles(
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          printMessage(
-            'Unrecognized combination of options or no options...',
-            'error'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens(true)) {
+          // export by id/name
+          if (options.idpId) {
+            verboseMessage(`Exporting provider "${options.idpId}...`);
+            const outcome = await exportAdminFederationProviderToFile(
+              options.idpId,
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Exporting all providers to a single file...');
+            const outcome = await exportAdminFederationProvidersToFile(
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate) {
+            verboseMessage('Exporting all providers to separate files...');
+            const outcome = await exportAdminFederationProvidersToFiles(
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            printMessage(
+              'Unrecognized combination of options or no options...',
+              'error'
+            );
+            command.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
-
-program.parse();
+      // end command logic inside action handler
+    );
+};

--- a/src/cli/admin/admin-federation-import.ts
+++ b/src/cli/admin/admin-federation-import.ts
@@ -1,4 +1,4 @@
-import { Option } from 'commander';
+import { Command, Option } from 'commander';
 
 import { getTokens } from '../../ops/AuthenticateOps';
 import {
@@ -8,89 +8,93 @@ import {
   importFirstAdminFederationProviderFromFile,
 } from '../../ops/cloud/AdminFederationOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
-import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin federation import', ['realm']);
-
-program
-  .description('Import admin federation providers.')
-  .addOption(
-    new Option(
-      '-i, --idp-id <id>',
-      'Provider id. If specified, -a and -A are ignored.'
+export const addFederationImport = (command: Command) => {
+  command
+    .command('import')
+    .description('Import admin federation providers.')
+    .addOption(
+      new Option(
+        '-i, --idp-id <id>',
+        'Provider id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import the provider(s) from.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import the provider(s) from.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all the providers from single file. Ignored with -t or -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all the providers from single file. Ignored with -t or -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all the providers from separate files (*.admin.federation.json) in the current directory. Ignored with -t or -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all the providers from separate files (*.admin.federation.json) in the current directory. Ignored with -t or -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(host, user, password, options, command);
-      // import by id
-      if (options.file && options.idpId && (await getTokens(true))) {
-        verboseMessage(`Importing provider "${options.idpId}"...`);
-        const outcome = await importAdminFederationProviderFromFile(
-          options.idpId,
-          options.file
+    .action(
+      // implement command logic inside action handler
+      async (host, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // import by id
+        if (options.file && options.idpId && (await getTokens(true))) {
+          verboseMessage(`Importing provider "${options.idpId}"...`);
+          const outcome = await importAdminFederationProviderFromFile(
+            options.idpId,
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens(true))) {
+          verboseMessage(
+            `Importing all providers from a single file (${options.file})...`
+          );
+          const outcome = await importAdminFederationProvidersFromFile(
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (
+          options.allSeparate &&
+          !options.file &&
+          (await getTokens(true))
+        ) {
+          verboseMessage(
+            'Importing all providers from separate files in current directory...'
+          );
+          const outcome = await importAdminFederationProvidersFromFiles();
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first provider from file
+        else if (options.file && (await getTokens(true))) {
+          verboseMessage(
+            `Importing first provider from file "${options.file}"...`
+          );
+          const outcome = await importFirstAdminFederationProviderFromFile(
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          command.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens(true))) {
-        verboseMessage(
-          `Importing all providers from a single file (${options.file})...`
-        );
-        const outcome = await importAdminFederationProvidersFromFile(
-          options.file
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (
-        options.allSeparate &&
-        !options.file &&
-        (await getTokens(true))
-      ) {
-        verboseMessage(
-          'Importing all providers from separate files in current directory...'
-        );
-        const outcome = await importAdminFederationProvidersFromFiles();
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first provider from file
-      else if (options.file && (await getTokens(true))) {
-        verboseMessage(
-          `Importing first provider from file "${options.file}"...`
-        );
-        const outcome = await importFirstAdminFederationProviderFromFile(
-          options.file
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
-
-program.parse();
+      // end command logic inside action handler
+    );
+};

--- a/src/cli/admin/admin-federation-list.ts
+++ b/src/cli/admin/admin-federation-list.ts
@@ -1,28 +1,34 @@
+import { Command } from 'commander';
+
 import { getTokens } from '../../ops/AuthenticateOps';
 import { listAdminFederationProviders } from '../../ops/cloud/AdminFederationOps';
 import { verboseMessage } from '../../utils/Console';
-import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin federation list', ['realm']);
-
-program
-  .description('List admin federation providers.')
-  // .addOption(
-  //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(host, user, password, options, command);
-      if (await getTokens(true)) {
-        verboseMessage(`Listing admin federation providers...`);
-        const outcome = await listAdminFederationProviders();
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+export const addFederationList = (command: Command) => {
+  command
+    .command('list')
+    .description('List admin federation providers.')
+    // .addOption(
+    //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens(true)) {
+          verboseMessage(`Listing admin federation providers...`);
+          const outcome = await listAdminFederationProviders();
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
-
-program.parse();
+      // end command logic inside action handler
+    );
+};

--- a/src/cli/admin/admin-federation.ts
+++ b/src/cli/admin/admin-federation.ts
@@ -1,17 +1,15 @@
-import { FrodoStubCommand } from '../FrodoCommand';
+import { Command } from 'commander';
 
-const program = new FrodoStubCommand('frodo admin federation');
+import { addFederationExport } from './admin-federation-export';
+import { addFederationImport } from './admin-federation-import';
+import { addFederationList } from './admin-federation-list';
 
-program.description('Manages admin federation configuration.');
+export const addFederation = (command: Command) => {
+  const federationCommand = command
+    .command('federation')
+    .description('Manage admin federation configuration.');
 
-// program.command('delete', 'Delete admin federation provider.');
-
-// program.command('describe', 'Describe admin federation provider.');
-
-program.command('export', 'Export admin federation providers.');
-
-program.command('import', 'Import admin federation providers.');
-
-program.command('list', 'List admin federation providers.');
-
-program.parse();
+  addFederationExport(federationCommand);
+  addFederationImport(federationCommand);
+  addFederationList(federationCommand);
+};

--- a/src/cli/admin/admin.ts
+++ b/src/cli/admin/admin.ts
@@ -1,16 +1,18 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { Command } from 'commander';
 
 import { FrodoStubCommand } from '../FrodoCommand';
+import { addFederation } from './admin-federation';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export default function setup(command: Command) {
+  // this stays for the moment in order to set up some process wide stuff - though that
+  // could be set in the cli start up instead
+  const program = new FrodoStubCommand('admin');
 
-export default function setup() {
-  const program = new FrodoStubCommand('admin')
-    .description('Platform admin tasks.')
-    .executableDir(__dirname);
+  const adminCommand = command
+    .command('admin')
+    .description('Platform admin tasks.');
 
-  program.command('federation', 'Manage admin federation configuration.');
+  addFederation(adminCommand);
 
   program.command(
     'create-oauth2-client-with-admin-privileges',


### PR DESCRIPTION
@vscheuber  - this is not for merging. This is a POC to illustrate an alternative approach to building out the network of cli commands. You want it to be modularised, but by modularising it by using a spread of files with naming conventions and a lot of separate sub-programs, there are some disadvantages.

It's a long refactor to move to an alternative, especially given the core behaviour of `FrodoCommand`, but this is an example of how things could be done differently, which I think would survive webpacks and pkgs better. Though it would need some serious legwork to complete it.

View it with the `hide whitespace changes` mode set in GitHub.

Let me know if you think it has legs.

I think I prefer the coupling by function name to by file naming convention that this introduces, along with how it splits the responsibilities slightly better between the files - i.e. the command name is chosen by the command itself in its own file.