### PR TITLE
Command Refactor

### DIFF
--- a/src/cli/FrodoCommand.ts
+++ b/src/cli/FrodoCommand.ts
@@ -1,5 +1,5 @@
 import { frodo, state } from '@rockcarver/frodo-lib';
-import { Argument, Command, Option } from 'commander';
+import { Argument, Command, Help, Option } from 'commander';
 import fs from 'fs';
 
 import * as globalConfig from '../storage/StaticStorage';
@@ -201,6 +201,17 @@ export class FrodoStubCommand extends Command {
       );
       cleanupProgressIndicators();
     });
+  }
+
+  createHelp() {
+    return Object.assign(new FrodoStubHelp(), this.configureHelp());
+  }
+}
+
+class FrodoStubHelp extends Help {
+  subcommandTerm(cmd) {
+    return cmd._name +
+        (cmd._aliases[0] ? '|' + cmd._aliases[0] : '');
   }
 }
 

--- a/src/cli/_template/something-delete.ts
+++ b/src/cli/_template/something-delete.ts
@@ -3,43 +3,45 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo something delete');
 
-program
-  .description('Delete something.')
-  .addOption(
-    new Option(
-      '-i, --something-id <something-id>',
-      '[Something] id. If specified, -a and -A are ignored.'
+  program
+    .description('Delete something.')
+    .addOption(
+      new Option(
+        '-i, --something-id <something-id>',
+        '[Something] id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all [somethings]. Ignored with -i.')
-  )
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(
+      new Option('-a, --all', 'Delete all [somethings]. Ignored with -i.')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-describe.ts
+++ b/src/cli/_template/something-describe.ts
@@ -3,29 +3,33 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo something describe');
 
-program
-  .description('Describe something.')
-  .addOption(new Option('-i, --something-id <something-id>', '[Something] id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe something.')
+    .addOption(
+      new Option('-i, --something-id <something-id>', '[Something] id.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-else-delete.ts
+++ b/src/cli/_template/something-else-delete.ts
@@ -3,41 +3,43 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something else delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo something else delete');
 
-program
-  .description('Delete something else.')
-  .addOption(
-    new Option(
-      '-i, --else-id <else-id>',
-      '[Else] id. If specified, -a and -A are ignored.'
+  program
+    .description('Delete something else.')
+    .addOption(
+      new Option(
+        '-i, --else-id <else-id>',
+        '[Else] id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-a, --all', 'Delete all [elses]. Ignored with -i.'))
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(new Option('-a, --all', 'Delete all [elses]. Ignored with -i.'))
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-else-describe.ts
+++ b/src/cli/_template/something-else-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something else describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo something else describe');
 
-program
-  .description('Describe something else.')
-  .addOption(new Option('-i, --else-id <else-id>', '[Else] id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe something else.')
+    .addOption(new Option('-i, --else-id <else-id>', '[Else] id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-else-export.ts
+++ b/src/cli/_template/something-else-export.ts
@@ -3,53 +3,55 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something else export');
+export default function setup() {
+  const program = new FrodoCommand('frodo something else export');
 
-program
-  .description('Export something else.')
-  .addOption(
-    new Option(
-      '-i, --else-id <else-id>',
-      '[Else] id. If specified, -a and -A are ignored.'
+  program
+    .description('Export something else.')
+    .addOption(
+      new Option(
+        '-i, --else-id <else-id>',
+        '[Else] id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all [else] to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all [else] to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all [else] to separate files (*.[else].json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all [else] to separate files (*.[else].json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-else-import.ts
+++ b/src/cli/_template/something-else-import.ts
@@ -3,47 +3,49 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something else import');
+export default function setup() {
+  const program = new FrodoCommand('frodo something else import');
 
-program
-  .description('Import something else.')
-  .addOption(
-    new Option(
-      '-i, --else-id <else-id>',
-      '[Else] id. If specified, only one [else] is imported and the options -a and -A are ignored.'
+  program
+    .description('Import something else.')
+    .addOption(
+      new Option(
+        '-i, --else-id <else-id>',
+        '[Else] id. If specified, only one [else] is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all [else] from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all [else] from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all [else] from separate files (*.[else].json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all [else] from separate files (*.[else].json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-else-list.ts
+++ b/src/cli/_template/something-else-list.ts
@@ -3,31 +3,33 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something else list');
+export default function setup() {
+  const program = new FrodoCommand('frodo something else list');
 
-program
-  .description('List something else.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List something else.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-else.ts
+++ b/src/cli/_template/something-else.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './something-else-delete.js';
+import DescribeCmd from './something-else-describe.js';
+import ExportCmd from './something-else-export.js';
+import ImportCmd from './something-else-import.js';
+import ListCmd from './something-else-list.js';
 
-const program = new FrodoStubCommand('frodo something else');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo something else');
 
-program.description('Manage something else.');
+  program.description('Manage something else.');
 
-program.command('list', 'List something else.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('describe', 'Describe something else.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export something else.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import something else.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('delete', 'Delete something else.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-export.ts
+++ b/src/cli/_template/something-export.ts
@@ -3,53 +3,55 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something export');
+export default function setup() {
+  const program = new FrodoCommand('frodo something export');
 
-program
-  .description('Export something.')
-  .addOption(
-    new Option(
-      '-i, --something-id <something-id>',
-      '[Something] id. If specified, -a and -A are ignored.'
+  program
+    .description('Export something.')
+    .addOption(
+      new Option(
+        '-i, --something-id <something-id>',
+        '[Something] id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all [somethings] to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all [somethings] to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all [somethings] to separate files (*.[something].json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all [somethings] to separate files (*.[something].json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-import.ts
+++ b/src/cli/_template/something-import.ts
@@ -3,47 +3,49 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something import');
+export default function setup() {
+  const program = new FrodoCommand('frodo something import');
 
-program
-  .description('Import something.')
-  .addOption(
-    new Option(
-      '-i, --something-id <something-id>',
-      '[Something] id. If specified, only one [something] is imported and the options -a and -A are ignored.'
+  program
+    .description('Import something.')
+    .addOption(
+      new Option(
+        '-i, --something-id <something-id>',
+        '[Something] id. If specified, only one [something] is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all [somethings] from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all [somethings] from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all [something] from separate files (*.[something].json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all [something] from separate files (*.[something].json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-list.ts
+++ b/src/cli/_template/something-list.ts
@@ -3,31 +3,33 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something list');
+export default function setup() {
+  const program = new FrodoCommand('frodo something list');
 
-program
-  .description('List something.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List something.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-other-delete.ts
+++ b/src/cli/_template/something-other-delete.ts
@@ -3,41 +3,43 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something other delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo something other delete');
 
-program
-  .description('Delete other.')
-  .addOption(
-    new Option(
-      '-i, --other-id <other-id>',
-      '[Other] id. If specified, -a and -A are ignored.'
+  program
+    .description('Delete other.')
+    .addOption(
+      new Option(
+        '-i, --other-id <other-id>',
+        '[Other] id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-a, --all', 'Delete all [others]. Ignored with -i.'))
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(new Option('-a, --all', 'Delete all [others]. Ignored with -i.'))
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-other-describe.ts
+++ b/src/cli/_template/something-other-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something other describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo something other describe');
 
-program
-  .description('Describe other.')
-  .addOption(new Option('-i, --other-id <other-id>', '[Other] id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe other.')
+    .addOption(new Option('-i, --other-id <other-id>', '[Other] id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-other-export.ts
+++ b/src/cli/_template/something-other-export.ts
@@ -3,53 +3,55 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something other export');
+export default function setup() {
+  const program = new FrodoCommand('frodo something other export');
 
-program
-  .description('Export other.')
-  .addOption(
-    new Option(
-      '-i, --other-id <other-id>',
-      '[Other] id. If specified, -a and -A are ignored.'
+  program
+    .description('Export other.')
+    .addOption(
+      new Option(
+        '-i, --other-id <other-id>',
+        '[Other] id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all [others] to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all [others] to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all [others] to separate files (*.[other].json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all [others] to separate files (*.[other].json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-other-import.ts
+++ b/src/cli/_template/something-other-import.ts
@@ -3,47 +3,49 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something other import');
+export default function setup() {
+  const program = new FrodoCommand('frodo something other import');
 
-program
-  .description('Import other.')
-  .addOption(
-    new Option(
-      '-i, --other-id <other-id>',
-      '[Other] id. If specified, only one [other] is imported and the options -a and -A are ignored.'
+  program
+    .description('Import other.')
+    .addOption(
+      new Option(
+        '-i, --other-id <other-id>',
+        '[Other] id. If specified, only one [other] is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all [others] from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all [others] from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all [others] from separate files (*.[other].json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all [others] from separate files (*.[other].json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-other-list.ts
+++ b/src/cli/_template/something-other-list.ts
@@ -3,31 +3,33 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo something other list');
+export default function setup() {
+  const program = new FrodoCommand('frodo something other list');
 
-program
-  .description('List other.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List other.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something-other.ts
+++ b/src/cli/_template/something-other.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './something-other-delete.js';
+import DescribeCmd from './something-other-describe.js';
+import ExportCmd from './something-other-export.js';
+import ImportCmd from './something-other-import.js';
+import ListCmd from './something-other-list.js';
 
-const program = new FrodoStubCommand('frodo something other');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo something other');
 
-program.description('Manage other.');
+  program.description('Manage other.');
 
-program.command('list', 'List other.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('describe', 'Describe other.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export other.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import other.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('delete', 'Delete other.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/_template/something.ts
+++ b/src/cli/_template/something.ts
@@ -1,28 +1,30 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './something-delete.js';
+import DescribeCmd from './something-describe.js';
+import ElseCmd from './something-else.js';
+import ExportCmd from './something-export.js';
+import ImportCmd from './something-import.js';
+import ListCmd from './something-list.js';
+import OtherCmd from './something-other.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('something')
-    .description('Manage something.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('something').description(
+    'Manage something.'
+  );
 
-  program.command('else', 'Manage something else.');
+  program.addCommand(ElseCmd().name('else'));
 
-  program.command('other', 'Manage something other.');
+  program.addCommand(OtherCmd().name('other'));
 
-  program.command('list', 'List something.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('describe', 'Describe something.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('export', 'Export something.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import something.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('delete', 'Delete something.');
+  program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/admin/admin-add-autoid-static-user-mapping.ts
+++ b/src/cli/admin/admin-add-autoid-static-user-mapping.ts
@@ -3,32 +3,36 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin add-autoid-static-user-mapping');
-
-program
-  .description(
-    'Add AutoId static user mapping to enable dashboards and other AutoId-based functionality.'
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(`Adding AutoId static user mapping...`);
-        const outcome = await addAutoIdStaticUserMapping();
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin add-autoid-static-user-mapping'
   );
 
-program.parse();
+  program
+    .description(
+      'Add AutoId static user mapping to enable dashboards and other AutoId-based functionality.'
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage(`Adding AutoId static user mapping...`);
+          const outcome = await addAutoIdStaticUserMapping();
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
+      }
+      // end command logic inside action handler
+    );
+
+  return program;
+}

--- a/src/cli/admin/admin-create-oauth2-client-with-admin-privileges.ts
+++ b/src/cli/admin/admin-create-oauth2-client-with-admin-privileges.ts
@@ -11,125 +11,127 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printError, printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand(
-  'frodo admin create-oauth2-client-with-admin-privileges'
-);
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin create-oauth2-client-with-admin-privileges'
+  );
 
-program
-  .description('Create an oauth2 client with admin privileges.')
-  .addOption(new Option('--client-id [id]', 'Client id.'))
-  .addOption(new Option('--client-secret [secret]', 'Client secret.'))
-  .addOption(
-    new Option(
-      '--llt',
-      'Create a long-lived token and store it in a secret. The default secret name is esv-admin-token and the default token lifetime is 315,360,000 seconds (10 years). Both can be overwritten with the --llt-esv and --llt-ttl options.'
+  program
+    .description('Create an oauth2 client with admin privileges.')
+    .addOption(new Option('--client-id [id]', 'Client id.'))
+    .addOption(new Option('--client-secret [secret]', 'Client secret.'))
+    .addOption(
+      new Option(
+        '--llt',
+        'Create a long-lived token and store it in a secret. The default secret name is esv-admin-token and the default token lifetime is 315,360,000 seconds (10 years). Both can be overwritten with the --llt-esv and --llt-ttl options.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--llt-scope [scope]',
-      'Request the following scope(s). This option only applies if used with the --llt option.'
-    ).default('fr:idm:*', 'fr:idm:*')
-  )
-  .addOption(
-    new Option(
-      '--llt-esv [esv]',
-      'Name of the secret to store the token in. This option only applies if used with the --llt option.'
-    ).default('esv-admin-token', 'esv-admin-token')
-  )
-  .addOption(
-    new Option(
-      '--no-llt-esv',
-      "Don't store the token in a secret and output to console instead. This option only applies if used with the --llt option."
+    .addOption(
+      new Option(
+        '--llt-scope [scope]',
+        'Request the following scope(s). This option only applies if used with the --llt option.'
+      ).default('fr:idm:*', 'fr:idm:*')
     )
-  )
-  .addOption(
-    new Option(
-      '--llt-ttl [ttl]',
-      'Token lifetime (seconds). This option only applies if used with the --llt option.'
-    ).default(315360000, '315,360,000 seconds (10 years)')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Creating oauth2 client with admin privileges in realm "${state.getRealm()}"...`
+    .addOption(
+      new Option(
+        '--llt-esv [esv]',
+        'Name of the secret to store the token in. This option only applies if used with the --llt option.'
+      ).default('esv-admin-token', 'esv-admin-token')
+    )
+    .addOption(
+      new Option(
+        '--no-llt-esv',
+        "Don't store the token in a secret and output to console instead. This option only applies if used with the --llt option."
+      )
+    )
+    .addOption(
+      new Option(
+        '--llt-ttl [ttl]',
+        'Token lifetime (seconds). This option only applies if used with the --llt option.'
+      ).default(315360000, '315,360,000 seconds (10 years)')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        let clientId = uuidv4();
-        let clientSecret = uuidv4();
-        if (options.clientId) {
-          clientId = options.clientId;
-        }
-        if (options.clientSecret) {
-          clientSecret = options.clientSecret;
-        }
-        if (
-          await createOAuth2ClientWithAdminPrivileges(clientId, clientSecret)
-        ) {
-          const table = new Table({
-            chars: {
-              top: '',
-              'top-mid': '',
-              'top-left': '',
-              'top-right': '',
-              bottom: '',
-              'bottom-mid': '',
-              'bottom-left': '',
-              'bottom-right': '',
-              left: '',
-              'left-mid': '',
-              mid: '',
-              'mid-mid': '',
-              right: '',
-              'right-mid': '',
-            },
-            style: { 'padding-left': 0, 'padding-right': 0 },
-            wordWrap: true,
-          });
-          table.push(['Client ID'['brightCyan'], clientId]);
-          table.push(['Client Secret'['brightCyan'], clientSecret]);
-          if (options.llt) {
-            try {
-              const response = await createLongLivedToken(
-                clientId,
-                clientSecret,
-                options.lltScope,
-                options.lltEsv,
-                options.lltTtl
-              );
-              if (options.lltEsv)
-                table.push(['Secret Name'['brightCyan'], response.secret]);
-              table.push(['Scope'['brightCyan'], response.scope]);
-              table.push(['Expires'['brightCyan'], response.expires_on]);
-              printMessage(table.toString());
-              if (options.lltEsv === false) {
-                printMessage(`\nBearer token:`, 'info');
-                printMessage(`${response.access_token}`, 'data');
+        if (await getTokens()) {
+          printMessage(
+            `Creating oauth2 client with admin privileges in realm "${state.getRealm()}"...`
+          );
+          let clientId = uuidv4();
+          let clientSecret = uuidv4();
+          if (options.clientId) {
+            clientId = options.clientId;
+          }
+          if (options.clientSecret) {
+            clientSecret = options.clientSecret;
+          }
+          if (
+            await createOAuth2ClientWithAdminPrivileges(clientId, clientSecret)
+          ) {
+            const table = new Table({
+              chars: {
+                top: '',
+                'top-mid': '',
+                'top-left': '',
+                'top-right': '',
+                bottom: '',
+                'bottom-mid': '',
+                'bottom-left': '',
+                'bottom-right': '',
+                left: '',
+                'left-mid': '',
+                mid: '',
+                'mid-mid': '',
+                right: '',
+                'right-mid': '',
+              },
+              style: { 'padding-left': 0, 'padding-right': 0 },
+              wordWrap: true,
+            });
+            table.push(['Client ID'['brightCyan'], clientId]);
+            table.push(['Client Secret'['brightCyan'], clientSecret]);
+            if (options.llt) {
+              try {
+                const response = await createLongLivedToken(
+                  clientId,
+                  clientSecret,
+                  options.lltScope,
+                  options.lltEsv,
+                  options.lltTtl
+                );
+                if (options.lltEsv)
+                  table.push(['Secret Name'['brightCyan'], response.secret]);
+                table.push(['Scope'['brightCyan'], response.scope]);
+                table.push(['Expires'['brightCyan'], response.expires_on]);
+                printMessage(table.toString());
+                if (options.lltEsv === false) {
+                  printMessage(`\nBearer token:`, 'info');
+                  printMessage(`${response.access_token}`, 'data');
+                }
+              } catch (error) {
+                printError(error);
+                process.exitCode = 1;
               }
-            } catch (error) {
-              printError(error);
-              process.exitCode = 1;
+            } else {
+              printMessage(table.toString());
             }
           } else {
-            printMessage(table.toString());
+            process.exitCode = 1;
           }
         } else {
           process.exitCode = 1;
         }
-      } else {
-        process.exitCode = 1;
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-execute-rfc7523-authz-grant-flow.ts
+++ b/src/cli/admin/admin-execute-rfc7523-authz-grant-flow.ts
@@ -9,93 +9,95 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand.js';
 
-const program = new FrodoCommand(
-  'frodo admin execute-rfc7523-authz-grant-flow'
-);
-
-program
-  .description('Execute RFC7523 authorization grant flow.')
-  .addOption(new Option('--client-id [id]', 'Client id.'))
-  .addOption(
-    new Option(
-      '--jwk-file [file]',
-      'Path to JSON Web Key (JWK) file containing private key.'
-    )
-  )
-  .addOption(
-    new Option(
-      '--sub [subject]',
-      'Subject identifier, typically a UUID. Must resolve to a valid user in the realm.'
-    )
-  )
-  .addOption(new Option('--iss [issuer]', 'Trusted issuer, typically a URL.'))
-  .addOption(
-    new Option('--scope [scope]', 'Space-delimited list of scopes.').default(
-      'openid fr:am:* fr:idm:*'
-    )
-  )
-  .addOption(new Option('--json', 'Output in JSON format.'))
-  .addHelpText(
-    'after',
-    `Usage Examples:\n` +
-      `  If you used frodo to create the RFC7523 configuration (see 'Related Commands' below), then you can test your configuration with minimal input and frodo will locate the missing parameters. The command below returns access token and identity token:\n` +
-      `  $ frodo admin execute-rfc7523-authz-grant-flow --client-id rfc7523-client1 ${s.amBaseUrl}\n`[
-        'brightCyan'
-      ] +
-      `  Same as above but output raw json:\n` +
-      `  $ frodo admin execute-rfc7523-authz-grant-flow --client-id rfc7523-client1 --json ${s.amBaseUrl}'\n`[
-        'brightCyan'
-      ] +
-      `  Same as first command above but explicitly provide all parameters:\n` +
-      `  $ frodo admin execute-rfc7523-authz-grant-flow --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --jwk-file rfc7523-client1_private.jwk.json ${s.amBaseUrl}'\n`[
-        'brightCyan'
-      ] +
-      `\nRelated Commands:\n` +
-      `  Run ${'frodo admin generate-rfc7523-authz-grant-artefacts --help'['brightCyan']} to see how to create the required configuration artefacts for ${'frodo admin execute-rfc7523-authz-grant-flow'['brightCyan']}:\n`
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(`Executing RFC7523 authorization grant flow...`);
-        let clientId = uuidv4();
-        if (options.clientId) {
-          clientId = options.clientId;
-        }
-        let jwk: JwkRsa = undefined;
-        if (options.jwkFile) {
-          try {
-            const data = fs.readFileSync(options.jwkFile);
-            jwk = JSON.parse(data.toString());
-          } catch (error) {
-            printMessage(
-              `Error parsing JWK from file ${options.jwkFile}: ${error.message}`,
-              'error'
-            );
-          }
-        }
-        const outcome = await executeRfc7523AuthZGrantFlow(
-          clientId,
-          options.iss,
-          jwk,
-          options.sub,
-          options.scope.split(' '),
-          options.json
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin execute-rfc7523-authz-grant-flow'
   );
 
-program.parse();
+  program
+    .description('Execute RFC7523 authorization grant flow.')
+    .addOption(new Option('--client-id [id]', 'Client id.'))
+    .addOption(
+      new Option(
+        '--jwk-file [file]',
+        'Path to JSON Web Key (JWK) file containing private key.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--sub [subject]',
+        'Subject identifier, typically a UUID. Must resolve to a valid user in the realm.'
+      )
+    )
+    .addOption(new Option('--iss [issuer]', 'Trusted issuer, typically a URL.'))
+    .addOption(
+      new Option('--scope [scope]', 'Space-delimited list of scopes.').default(
+        'openid fr:am:* fr:idm:*'
+      )
+    )
+    .addOption(new Option('--json', 'Output in JSON format.'))
+    .addHelpText(
+      'after',
+      `Usage Examples:\n` +
+        `  If you used frodo to create the RFC7523 configuration (see 'Related Commands' below), then you can test your configuration with minimal input and frodo will locate the missing parameters. The command below returns access token and identity token:\n` +
+        `  $ frodo admin execute-rfc7523-authz-grant-flow --client-id rfc7523-client1 ${s.amBaseUrl}\n`[
+          'brightCyan'
+        ] +
+        `  Same as above but output raw json:\n` +
+        `  $ frodo admin execute-rfc7523-authz-grant-flow --client-id rfc7523-client1 --json ${s.amBaseUrl}'\n`[
+          'brightCyan'
+        ] +
+        `  Same as first command above but explicitly provide all parameters:\n` +
+        `  $ frodo admin execute-rfc7523-authz-grant-flow --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --jwk-file rfc7523-client1_private.jwk.json ${s.amBaseUrl}'\n`[
+          'brightCyan'
+        ] +
+        `\nRelated Commands:\n` +
+        `  Run ${'frodo admin generate-rfc7523-authz-grant-artefacts --help'['brightCyan']} to see how to create the required configuration artefacts for ${'frodo admin execute-rfc7523-authz-grant-flow'['brightCyan']}:\n`
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage(`Executing RFC7523 authorization grant flow...`);
+          let clientId = uuidv4();
+          if (options.clientId) {
+            clientId = options.clientId;
+          }
+          let jwk: JwkRsa = undefined;
+          if (options.jwkFile) {
+            try {
+              const data = fs.readFileSync(options.jwkFile);
+              jwk = JSON.parse(data.toString());
+            } catch (error) {
+              printMessage(
+                `Error parsing JWK from file ${options.jwkFile}: ${error.message}`,
+                'error'
+              );
+            }
+          }
+          const outcome = await executeRfc7523AuthZGrantFlow(
+            clientId,
+            options.iss,
+            jwk,
+            options.sub,
+            options.scope.split(' '),
+            options.json
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
+      }
+      // end command logic inside action handler
+    );
+
+  return program;
+}

--- a/src/cli/admin/admin-federation-export.ts
+++ b/src/cli/admin/admin-federation-export.ts
@@ -9,84 +9,92 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin federation export', ['realm']);
+export default function setup() {
+  const program = new FrodoCommand('frodo admin federation export', ['realm']);
 
-program
-  .description('Export admin federation providers.')
-  .addOption(
-    new Option(
-      '-i, --idp-id <idp-id>',
-      'Id/name of a provider. If specified, -a and -A are ignored.'
+  program
+    .description('Export admin federation providers.')
+    .addOption(
+      new Option(
+        '-i, --idp-id <idp-id>',
+        'Id/name of a provider. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the file to write the exported provider(s) to. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the file to write the exported provider(s) to. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all the providers to a single file. Ignored with -t and -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all the providers to a single file. Ignored with -t and -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all the providers as separate files <provider name>.admin.federation.json. Ignored with -t, -i, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all the providers as separate files <provider name>.admin.federation.json. Ignored with -t, -i, and -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(host, user, password, options, command);
-      if (await getTokens(true)) {
-        // export by id/name
-        if (options.idpId) {
-          verboseMessage(`Exporting provider "${options.idpId}...`);
-          const outcome = await exportAdminFederationProviderToFile(
-            options.idpId,
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Exporting all providers to a single file...');
-          const outcome = await exportAdminFederationProvidersToFile(
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate) {
-          verboseMessage('Exporting all providers to separate files...');
-          const outcome = await exportAdminFederationProvidersToFiles(
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          printMessage(
-            'Unrecognized combination of options or no options...',
-            'error'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens(true)) {
+          // export by id/name
+          if (options.idpId) {
+            verboseMessage(`Exporting provider "${options.idpId}...`);
+            const outcome = await exportAdminFederationProviderToFile(
+              options.idpId,
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Exporting all providers to a single file...');
+            const outcome = await exportAdminFederationProvidersToFile(
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate) {
+            verboseMessage('Exporting all providers to separate files...');
+            const outcome = await exportAdminFederationProvidersToFiles(
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            printMessage(
+              'Unrecognized combination of options or no options...',
+              'error'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-federation-import.ts
+++ b/src/cli/admin/admin-federation-import.ts
@@ -10,87 +10,95 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin federation import', ['realm']);
+export default function setup() {
+  const program = new FrodoCommand('frodo admin federation import', ['realm']);
 
-program
-  .description('Import admin federation providers.')
-  .addOption(
-    new Option(
-      '-i, --idp-id <id>',
-      'Provider id. If specified, -a and -A are ignored.'
+  program
+    .description('Import admin federation providers.')
+    .addOption(
+      new Option(
+        '-i, --idp-id <id>',
+        'Provider id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import the provider(s) from.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import the provider(s) from.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all the providers from single file. Ignored with -t or -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all the providers from single file. Ignored with -t or -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all the providers from separate files (*.admin.federation.json) in the current directory. Ignored with -t or -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all the providers from separate files (*.admin.federation.json) in the current directory. Ignored with -t or -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(host, user, password, options, command);
-      // import by id
-      if (options.file && options.idpId && (await getTokens(true))) {
-        verboseMessage(`Importing provider "${options.idpId}"...`);
-        const outcome = await importAdminFederationProviderFromFile(
-          options.idpId,
-          options.file
+    .action(
+      // implement command logic inside action handler
+      async (host, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // import by id
+        if (options.file && options.idpId && (await getTokens(true))) {
+          verboseMessage(`Importing provider "${options.idpId}"...`);
+          const outcome = await importAdminFederationProviderFromFile(
+            options.idpId,
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens(true))) {
+          verboseMessage(
+            `Importing all providers from a single file (${options.file})...`
+          );
+          const outcome = await importAdminFederationProvidersFromFile(
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (
+          options.allSeparate &&
+          !options.file &&
+          (await getTokens(true))
+        ) {
+          verboseMessage(
+            'Importing all providers from separate files in current directory...'
+          );
+          const outcome = await importAdminFederationProvidersFromFiles();
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first provider from file
+        else if (options.file && (await getTokens(true))) {
+          verboseMessage(
+            `Importing first provider from file "${options.file}"...`
+          );
+          const outcome = await importFirstAdminFederationProviderFromFile(
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens(true))) {
-        verboseMessage(
-          `Importing all providers from a single file (${options.file})...`
-        );
-        const outcome = await importAdminFederationProvidersFromFile(
-          options.file
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (
-        options.allSeparate &&
-        !options.file &&
-        (await getTokens(true))
-      ) {
-        verboseMessage(
-          'Importing all providers from separate files in current directory...'
-        );
-        const outcome = await importAdminFederationProvidersFromFiles();
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first provider from file
-      else if (options.file && (await getTokens(true))) {
-        verboseMessage(
-          `Importing first provider from file "${options.file}"...`
-        );
-        const outcome = await importFirstAdminFederationProviderFromFile(
-          options.file
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-federation-list.ts
+++ b/src/cli/admin/admin-federation-list.ts
@@ -3,26 +3,34 @@ import { listAdminFederationProviders } from '../../ops/cloud/AdminFederationOps
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin federation list', ['realm']);
+export default function setup() {
+  const program = new FrodoCommand('frodo admin federation list', ['realm']);
 
-program
-  .description('List admin federation providers.')
-  // .addOption(
-  //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(host, user, password, options, command);
-      if (await getTokens(true)) {
-        verboseMessage(`Listing admin federation providers...`);
-        const outcome = await listAdminFederationProviders();
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List admin federation providers.')
+    // .addOption(
+    //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens(true)) {
+          verboseMessage(`Listing admin federation providers...`);
+          const outcome = await listAdminFederationProviders();
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-federation.ts
+++ b/src/cli/admin/admin-federation.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import ExportCmd from './admin-federation-export.js';
+import ImportCmd from './admin-federation-import.js';
+import ListCmd from './admin-federation-list.js';
+// import DeleteCmd from './admin-federation-delete.js';
+// import DescribeCmd from './admin-federation-describe.js';
 
-const program = new FrodoStubCommand('frodo admin federation');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo admin federation');
 
-program.description('Manages admin federation configuration.');
+  program.description('Manages admin federation configuration.');
 
-// program.command('delete', 'Delete admin federation provider.');
+  // program.addCommand(DeleteCmd().name('delete'));
 
-// program.command('describe', 'Describe admin federation provider.');
+  // program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export admin federation providers.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import admin federation providers.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('list', 'List admin federation providers.');
+  program.addCommand(ListCmd().name('list'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-generate-rfc7523-authz-grant-artefacts.ts
+++ b/src/cli/admin/admin-generate-rfc7523-authz-grant-artefacts.ts
@@ -10,110 +10,112 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand.js';
 
-const program = new FrodoCommand(
-  'frodo admin generate-rfc7523-authz-grant-artefacts'
-);
-
-program
-  .description('Generate RFC7523 authorization grant artefacts.')
-  .addOption(new Option('--client-id [id]', 'Client id.'))
-  .addOption(
-    new Option(
-      '--jwk-file [file]',
-      'Path to JSON Web Key (JWK) file containing private key.'
-    )
-  )
-  .addOption(
-    new Option(
-      '--sub [subject]',
-      'Subject identifier, typically a UUID. Must resolve to a valid user in the realm. Restricts the trusted issuer to only this subject by adding the identifier to the list of allowed subjects. Omitting this option allows the trusted issuer to request tokens for any realm user without restrictions.'
-    )
-  )
-  .addOption(new Option('--iss [issuer]', 'Trusted issuer, typically a URL.'))
-  .addOption(
-    new Option('--scope [scope]', 'Space-delimited list of scopes.').default(
-      'openid fr:am:* fr:idm:*'
-    )
-  )
-  .addOption(
-    new Option(
-      '--no-save',
-      'Do not save artefacts in AM and to file By default this command creates a fully configured oauth2 client and trusted issuer in AM and saves the generated JWK (private key) and JWKS (public key set) to files.'
-    )
-  )
-  .addOption(new Option('--json', 'Output in JSON format.'))
-  .addHelpText(
-    'after',
-    `Usage Examples:\n` +
-      `  Generate, output to console, and save all the artefacts for an RFC7523 authorization grant flow configuration limited to one particular subject:\n` +
-      `  - Fully configured OAuth2 client - named '<clientId>'\n` +
-      `  - Fully configured OAuth2 trusted issuer - named '<clientId>-issuer'\n` +
-      `  - Private Key as Json Web Key (JWK) - named '<clientId>_private.jwk.json'\n` +
-      `  - Public Key as Json Web Key Set (JWKS) - named '<clientId>_public.jwks.json'\n` +
-      `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d ${s.amBaseUrl}\n`[
-        'brightCyan'
-      ] +
-      `  Same as above but use an existing JWK file instead of creating one.\n` +
-      `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --jwk-file rfc7523-client1_private.jwk.json ${s.amBaseUrl}\n`[
-        'brightCyan'
-      ] +
-      `  Generate and output to console all the artefacts for an RFC7523 authorization grant flow configuration but do not create any configuration or files.\n` +
-      `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --no-save ${s.amBaseUrl}\n`[
-        'brightCyan'
-      ] +
-      `  Generate and output in json format all the artefacts for an RFC7523 authorization grant flow configuration.\n` +
-      `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --json ${s.amBaseUrl}\n`[
-        'brightCyan'
-      ] +
-      `\nRelated Commands:\n` +
-      `  Run ${'frodo admin execute-rfc7523-authz-grant-flow --help'['brightCyan']} to see how to test your configuration created with ${'frodo admin generate-rfc7523-authz-grant-artefacts'['brightCyan']}:\n`
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Generating RFC7523 authorization grant artefacts in realm "${state.getRealm()}"...`
-        );
-        let clientId = uuidv4();
-        if (options.clientId) {
-          clientId = options.clientId;
-        }
-        let jwk: JwkRsa = undefined;
-        if (options.jwkFile) {
-          try {
-            const data = fs.readFileSync(options.jwkFile);
-            jwk = JSON.parse(data.toString());
-          } catch (error) {
-            printMessage(
-              `Error parsing JWK from file ${options.jwkFile}: ${error.message}`,
-              'error'
-            );
-          }
-        }
-        const outcome = await generateRfc7523AuthZGrantArtefacts(
-          clientId,
-          options.iss,
-          jwk,
-          options.sub,
-          options.scope.split(' '),
-          { save: options.save },
-          options.json
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin generate-rfc7523-authz-grant-artefacts'
   );
 
-program.parse();
+  program
+    .description('Generate RFC7523 authorization grant artefacts.')
+    .addOption(new Option('--client-id [id]', 'Client id.'))
+    .addOption(
+      new Option(
+        '--jwk-file [file]',
+        'Path to JSON Web Key (JWK) file containing private key.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--sub [subject]',
+        'Subject identifier, typically a UUID. Must resolve to a valid user in the realm. Restricts the trusted issuer to only this subject by adding the identifier to the list of allowed subjects. Omitting this option allows the trusted issuer to request tokens for any realm user without restrictions.'
+      )
+    )
+    .addOption(new Option('--iss [issuer]', 'Trusted issuer, typically a URL.'))
+    .addOption(
+      new Option('--scope [scope]', 'Space-delimited list of scopes.').default(
+        'openid fr:am:* fr:idm:*'
+      )
+    )
+    .addOption(
+      new Option(
+        '--no-save',
+        'Do not save artefacts in AM and to file By default this command creates a fully configured oauth2 client and trusted issuer in AM and saves the generated JWK (private key) and JWKS (public key set) to files.'
+      )
+    )
+    .addOption(new Option('--json', 'Output in JSON format.'))
+    .addHelpText(
+      'after',
+      `Usage Examples:\n` +
+        `  Generate, output to console, and save all the artefacts for an RFC7523 authorization grant flow configuration limited to one particular subject:\n` +
+        `  - Fully configured OAuth2 client - named '<clientId>'\n` +
+        `  - Fully configured OAuth2 trusted issuer - named '<clientId>-issuer'\n` +
+        `  - Private Key as Json Web Key (JWK) - named '<clientId>_private.jwk.json'\n` +
+        `  - Public Key as Json Web Key Set (JWKS) - named '<clientId>_public.jwks.json'\n` +
+        `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d ${s.amBaseUrl}\n`[
+          'brightCyan'
+        ] +
+        `  Same as above but use an existing JWK file instead of creating one.\n` +
+        `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --jwk-file rfc7523-client1_private.jwk.json ${s.amBaseUrl}\n`[
+          'brightCyan'
+        ] +
+        `  Generate and output to console all the artefacts for an RFC7523 authorization grant flow configuration but do not create any configuration or files.\n` +
+        `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --no-save ${s.amBaseUrl}\n`[
+          'brightCyan'
+        ] +
+        `  Generate and output in json format all the artefacts for an RFC7523 authorization grant flow configuration.\n` +
+        `  $ frodo admin generate-rfc7523-authz-grant-artefacts --client-id rfc7523-client1 --iss https://my-issuer.com/issuer --sub 146c2230-9448-4442-b86d-eb4a81a0121d --json ${s.amBaseUrl}\n`[
+          'brightCyan'
+        ] +
+        `\nRelated Commands:\n` +
+        `  Run ${'frodo admin execute-rfc7523-authz-grant-flow --help'['brightCyan']} to see how to test your configuration created with ${'frodo admin generate-rfc7523-authz-grant-artefacts'['brightCyan']}:\n`
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage(
+            `Generating RFC7523 authorization grant artefacts in realm "${state.getRealm()}"...`
+          );
+          let clientId = uuidv4();
+          if (options.clientId) {
+            clientId = options.clientId;
+          }
+          let jwk: JwkRsa = undefined;
+          if (options.jwkFile) {
+            try {
+              const data = fs.readFileSync(options.jwkFile);
+              jwk = JSON.parse(data.toString());
+            } catch (error) {
+              printMessage(
+                `Error parsing JWK from file ${options.jwkFile}: ${error.message}`,
+                'error'
+              );
+            }
+          }
+          const outcome = await generateRfc7523AuthZGrantArtefacts(
+            clientId,
+            options.iss,
+            jwk,
+            options.sub,
+            options.scope.split(' '),
+            { save: options.save },
+            options.json
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
+      }
+      // end command logic inside action handler
+    );
+
+  return program;
+}

--- a/src/cli/admin/admin-get-access-token.ts
+++ b/src/cli/admin/admin-get-access-token.ts
@@ -6,53 +6,54 @@ import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
 const { clientCredentialsGrant } = frodo.oauth2oidc.endpoint;
+export default function setup() {
+  const program = new FrodoCommand('frodo admin get-access-token');
 
-const program = new FrodoCommand('frodo admin get-access-token');
-
-program
-  .description('Get an access token using client credentials grant type.')
-  .addOption(
-    new Option('-i, --client-id [id]', 'Client id.').makeOptionMandatory()
-  )
-  .addOption(
-    new Option(
-      '-s, --client-secret [secret]',
-      'Client secret.'
-    ).makeOptionMandatory()
-  )
-  .addOption(
-    new Option('--scope [scope]', 'Request the following scope(s).').default(
-      'fr:idm:*',
-      'fr:idm:*'
+  program
+    .description('Get an access token using client credentials grant type.')
+    .addOption(
+      new Option('-i, --client-id [id]', 'Client id.').makeOptionMandatory()
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Getting an access token using client "${options.clientId}"...`
+    .addOption(
+      new Option(
+        '-s, --client-secret [secret]',
+        'Client secret.'
+      ).makeOptionMandatory()
+    )
+    .addOption(
+      new Option('--scope [scope]', 'Request the following scope(s).').default(
+        'fr:idm:*',
+        'fr:idm:*'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const response = await clientCredentialsGrant(
-          state.getHost(),
-          options.clientId,
-          options.clientSecret,
-          options.scope
-        );
-        printMessage(`Token: ${response.access_token}`);
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          printMessage(
+            `Getting an access token using client "${options.clientId}"...`
+          );
+          const response = await clientCredentialsGrant(
+            state.getHost(),
+            options.clientId,
+            options.clientSecret,
+            options.scope
+          );
+          printMessage(`Token: ${response.access_token}`);
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-grant-oauth2-client-admin-privileges.ts
+++ b/src/cli/admin/admin-grant-oauth2-client-admin-privileges.ts
@@ -6,45 +6,47 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand(
-  'frodo admin grant-oauth2-client-admin-privileges'
-);
-
-program
-  .description('Grant an oauth2 client admin privileges.')
-  .addOption(new Option('-i, --client-id <id>', 'OAuth2 client id.'))
-  .addOption(
-    new Option(
-      '-t, --target <target name or id>',
-      'Name of the oauth2 client.'
-    ).hideHelp()
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Granting oauth2 client "${
-            options.clientId || options.target
-          }" in realm "${state.getRealm()}" admin privileges...`
-        );
-        const outcome = await grantOAuth2ClientAdminPrivileges(
-          options.clientId || options.target
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin grant-oauth2-client-admin-privileges'
   );
 
-program.parse();
+  program
+    .description('Grant an oauth2 client admin privileges.')
+    .addOption(new Option('-i, --client-id <id>', 'OAuth2 client id.'))
+    .addOption(
+      new Option(
+        '-t, --target <target name or id>',
+        'Name of the oauth2 client.'
+      ).hideHelp()
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage(
+            `Granting oauth2 client "${
+              options.clientId || options.target
+            }" in realm "${state.getRealm()}" admin privileges...`
+          );
+          const outcome = await grantOAuth2ClientAdminPrivileges(
+            options.clientId || options.target
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
+      }
+      // end command logic inside action handler
+    );
+
+  return program;
+}

--- a/src/cli/admin/admin-hide-generic-extension-attributes.ts
+++ b/src/cli/admin/admin-hide-generic-extension-attributes.ts
@@ -6,41 +6,43 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand(
-  'frodo admin hide-generic-extension-attributes'
-);
-
-program
-  .description('Hide generic extension attributes.')
-  .addOption(
-    new Option('--include-customized', 'Include customized attributes.')
-  )
-  .addOption(new Option('--dry-run', 'Dry-run only, do not perform changes.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Hiding generic extension attributes in realm "${state.getRealm()}"...`
-        );
-        const outcome = await hideGenericExtensionAttributes(
-          options.includeCustomized,
-          options.dryRun
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin hide-generic-extension-attributes'
   );
 
-program.parse();
+  program
+    .description('Hide generic extension attributes.')
+    .addOption(
+      new Option('--include-customized', 'Include customized attributes.')
+    )
+    .addOption(new Option('--dry-run', 'Dry-run only, do not perform changes.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage(
+            `Hiding generic extension attributes in realm "${state.getRealm()}"...`
+          );
+          const outcome = await hideGenericExtensionAttributes(
+            options.includeCustomized,
+            options.dryRun
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
+      }
+      // end command logic inside action handler
+    );
+
+  return program;
+}

--- a/src/cli/admin/admin-list-oauth2-clients-with-admin-privileges.ts
+++ b/src/cli/admin/admin-list-oauth2-clients-with-admin-privileges.ts
@@ -5,32 +5,34 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand(
-  'frodo admin list-oauth2-clients-with-admin-privileges'
-);
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin list-oauth2-clients-with-admin-privileges'
+  );
 
-program.description('List oauth2 clients with admin privileges.').action(
-  // implement command logic inside action handler
-  async (host, realm, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(
-      host,
-      realm,
-      user,
-      password,
-      options,
-      command
-    );
-    if (await getTokens()) {
-      printMessage(
-        `Listing oauth2 clients with admin privileges in realm "${state.getRealm()}"...`
+  program.description('List oauth2 clients with admin privileges.').action(
+    // implement command logic inside action handler
+    async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
       );
-      const outcome = await listOAuth2AdminClients();
-      if (!outcome) process.exitCode = 1;
-    } else {
-      process.exitCode = 1;
+      if (await getTokens()) {
+        printMessage(
+          `Listing oauth2 clients with admin privileges in realm "${state.getRealm()}"...`
+        );
+        const outcome = await listOAuth2AdminClients();
+        if (!outcome) process.exitCode = 1;
+      } else {
+        process.exitCode = 1;
+      }
     }
-  }
-  // end command logic inside action handler
-);
+    // end command logic inside action handler
+  );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-list-oauth2-clients-with-custom-privileges.ts
+++ b/src/cli/admin/admin-list-oauth2-clients-with-custom-privileges.ts
@@ -5,32 +5,34 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand(
-  'frodo admin list-oauth2-clients-with-custom-privileges'
-);
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin list-oauth2-clients-with-custom-privileges'
+  );
 
-program.description('List oauth2 clients with custom privileges.').action(
-  // implement command logic inside action handler
-  async (host, realm, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(
-      host,
-      realm,
-      user,
-      password,
-      options,
-      command
-    );
-    if (await getTokens()) {
-      printMessage(
-        `Listing oauth2 clients with custom privileges in realm "${state.getRealm()}"...`
+  program.description('List oauth2 clients with custom privileges.').action(
+    // implement command logic inside action handler
+    async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
       );
-      const outcome = await listOAuth2CustomClients();
-      if (!outcome) process.exitCode = 1;
-    } else {
-      process.exitCode = 1;
+      if (await getTokens()) {
+        printMessage(
+          `Listing oauth2 clients with custom privileges in realm "${state.getRealm()}"...`
+        );
+        const outcome = await listOAuth2CustomClients();
+        if (!outcome) process.exitCode = 1;
+      } else {
+        process.exitCode = 1;
+      }
     }
-  }
-  // end command logic inside action handler
-);
+    // end command logic inside action handler
+  );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-list-static-user-mappings.ts
+++ b/src/cli/admin/admin-list-static-user-mappings.ts
@@ -5,42 +5,44 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin list-static-user-mappings');
+export default function setup() {
+  const program = new FrodoCommand('frodo admin list-static-user-mappings');
 
-program
-  .description(
-    'List all subjects of static user mappings that are not oauth2 clients.'
-  )
-  .addOption(
-    new Option('--show-protected', 'Show protected (system) subjects.').default(
-      false,
-      'false'
+  program
+    .description(
+      'List all subjects of static user mappings that are not oauth2 clients.'
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          'Listing all non-oauth2 client subjects of static user mappings...'
+    .addOption(
+      new Option(
+        '--show-protected',
+        'Show protected (system) subjects.'
+      ).default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await listNonOAuth2AdminStaticUserMappings(
-          options.showProtected
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          printMessage(
+            'Listing all non-oauth2 client subjects of static user mappings...'
+          );
+          const outcome = await listNonOAuth2AdminStaticUserMappings(
+            options.showProtected
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-remove-static-user-mapping.ts
+++ b/src/cli/admin/admin-remove-static-user-mapping.ts
@@ -5,31 +5,33 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin remove-static-user-mapping');
+export default function setup() {
+  const program = new FrodoCommand('frodo admin remove-static-user-mapping');
 
-program
-  .description("Remove a subject's static user mapping.")
-  .addOption(new Option('-i, --sub-id <id>', 'Subject identifier.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage("Removing a subject's static user mapping...");
-        const outcome = await removeStaticUserMapping(options.subId);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description("Remove a subject's static user mapping.")
+    .addOption(new Option('-i, --sub-id <id>', 'Subject identifier.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage("Removing a subject's static user mapping...");
+          const outcome = await removeStaticUserMapping(options.subId);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-repair-org-model.ts
+++ b/src/cli/admin/admin-repair-org-model.ts
@@ -6,47 +6,49 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo admin repair-org-model');
+export default function setup() {
+  const program = new FrodoCommand('frodo admin repair-org-model');
 
-program
-  .description('Repair org model.')
-  .addOption(
-    new Option(
-      '--exclude-customized',
-      'Exclude customized properties from repair.'
+  program
+    .description('Repair org model.')
+    .addOption(
+      new Option(
+        '--exclude-customized',
+        'Exclude customized properties from repair.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--extend-permissions',
-      'Extend permissions to include custom attributes.'
+    .addOption(
+      new Option(
+        '--extend-permissions',
+        'Extend permissions to include custom attributes.'
+      )
     )
-  )
-  .addOption(new Option('--dry-run', 'Dry-run only, do not perform changes.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(`Repairing org model in realm "${state.getRealm()}"...`);
-        const outcome = await repairOrgModel(
-          options.excludeCustomized,
-          options.extendPermissions,
-          options.dryRun
+    .addOption(new Option('--dry-run', 'Dry-run only, do not perform changes.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          printMessage(`Repairing org model in realm "${state.getRealm()}"...`);
+          const outcome = await repairOrgModel(
+            options.excludeCustomized,
+            options.extendPermissions,
+            options.dryRun
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin-revoke-oauth2-client-admin-privileges.ts
+++ b/src/cli/admin/admin-revoke-oauth2-client-admin-privileges.ts
@@ -6,45 +6,47 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand(
-  'frodo admin revoke-oauth2-client-admin-privileges'
-);
-
-program
-  .description('Revoke admin privileges from an oauth2 client.')
-  .addOption(new Option('-i, --client-id <id>', 'OAuth2 client id.'))
-  .addOption(
-    new Option(
-      '-t, --target <target name or id>',
-      'Name of the oauth2 client.'
-    ).hideHelp()
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Revoking admin privileges from oauth2 client "${
-            options.target
-          }" in realm "${state.getRealm()}"...`
-        );
-        const outcome = await revokeOAuth2ClientAdminPrivileges(
-          options.clientId || options.target
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin revoke-oauth2-client-admin-privileges'
   );
 
-program.parse();
+  program
+    .description('Revoke admin privileges from an oauth2 client.')
+    .addOption(new Option('-i, --client-id <id>', 'OAuth2 client id.'))
+    .addOption(
+      new Option(
+        '-t, --target <target name or id>',
+        'Name of the oauth2 client.'
+      ).hideHelp()
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage(
+            `Revoking admin privileges from oauth2 client "${
+              options.target
+            }" in realm "${state.getRealm()}"...`
+          );
+          const outcome = await revokeOAuth2ClientAdminPrivileges(
+            options.clientId || options.target
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
+      }
+      // end command logic inside action handler
+    );
+
+  return program;
+}

--- a/src/cli/admin/admin-show-generic-extension-attributes.ts
+++ b/src/cli/admin/admin-show-generic-extension-attributes.ts
@@ -6,49 +6,51 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand(
-  'frodo admin show-generic-extension-attributes'
-);
-
-program
-  .description('Show generic extension attributes.')
-  .addOption(
-    new Option(
-      '--include-customized',
-      'Include customized attributes.'
-    ).default(false, 'false')
-  )
-  .addOption(
-    new Option('--dry-run', 'Dry-run only, do not perform changes.').default(
-      false,
-      'false'
-    )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Showing generic extension attributes in realm "${state.getRealm()}"...`
-        );
-        const outcome = await showGenericExtensionAttributes(
-          options.includeCustomized,
-          options.dryRun
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo admin show-generic-extension-attributes'
   );
 
-program.parse();
+  program
+    .description('Show generic extension attributes.')
+    .addOption(
+      new Option(
+        '--include-customized',
+        'Include customized attributes.'
+      ).default(false, 'false')
+    )
+    .addOption(
+      new Option('--dry-run', 'Dry-run only, do not perform changes.').default(
+        false,
+        'false'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          printMessage(
+            `Showing generic extension attributes in realm "${state.getRealm()}"...`
+          );
+          const outcome = await showGenericExtensionAttributes(
+            options.includeCustomized,
+            options.dryRun
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
+      }
+      // end command logic inside action handler
+    );
+
+  return program;
+}

--- a/src/cli/admin/admin-train-auto-access-model.ts
+++ b/src/cli/admin/admin-train-auto-access-model.ts
@@ -7,74 +7,76 @@ import { FrodoCommand } from '../FrodoCommand.js';
 
 const { trainAA } = frodo.admin;
 
-const program = new FrodoCommand('frodo admin train-auto-access-model');
+export default function setup() {
+  const program = new FrodoCommand('frodo admin train-auto-access-model');
 
-program
-  .description('Train Auto Access model.')
-  .addOption(
-    new Option(
-      '--api-key <key>',
-      'API key to authenticate to training journey.'
-    ).default('')
-  )
-  .addOption(
-    new Option(
-      '--api-secret <secret>',
-      'API secret to authenticate to training journey.'
-    ).default('')
-  )
-  .addOption(
-    new Option(
-      '--usernames [usernames]',
-      'Comma-delimited list of custom usernames.'
-    ).default('')
-  )
-  .addOption(
-    new Option(
-      '--user-agents [usernames]',
-      'Comma-delimited list of custom user agents.'
-    ).default('')
-  )
-  .addOption(
-    new Option(
-      '--ip-addresses [usernames]',
-      'Comma-delimited list of custom IP addresses.'
-    ).default('')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        printMessage(
-          `Training Auto Access model in realm "${state.getRealm()}"...`
+  program
+    .description('Train Auto Access model.')
+    .addOption(
+      new Option(
+        '--api-key <key>',
+        'API key to authenticate to training journey.'
+      ).default('')
+    )
+    .addOption(
+      new Option(
+        '--api-secret <secret>',
+        'API secret to authenticate to training journey.'
+      ).default('')
+    )
+    .addOption(
+      new Option(
+        '--usernames [usernames]',
+        'Comma-delimited list of custom usernames.'
+      ).default('')
+    )
+    .addOption(
+      new Option(
+        '--user-agents [usernames]',
+        'Comma-delimited list of custom user agents.'
+      ).default('')
+    )
+    .addOption(
+      new Option(
+        '--ip-addresses [usernames]',
+        'Comma-delimited list of custom IP addresses.'
+      ).default('')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        try {
-          await trainAA(
-            options.apiKey,
-            options.apiSecret,
-            options.usernames.split(','),
-            options.userAgents.split(','),
-            options.ipAddresses.split(','),
-            100
+        if (await getTokens()) {
+          printMessage(
+            `Training Auto Access model in realm "${state.getRealm()}"...`
           );
-          printMessage(`Done.`);
-        } catch (error) {
-          printMessage(error, 'error');
+          try {
+            await trainAA(
+              options.apiKey,
+              options.apiSecret,
+              options.usernames.split(','),
+              options.userAgents.split(','),
+              options.ipAddresses.split(','),
+              100
+            );
+            printMessage(`Done.`);
+          } catch (error) {
+            printMessage(error, 'error');
+            process.exitCode = 1;
+          }
+        } else {
           process.exitCode = 1;
         }
-      } else {
-        process.exitCode = 1;
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/admin/admin.ts
+++ b/src/cli/admin/admin.ts
@@ -1,85 +1,97 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import AddAutoidStaticUserMappingCmd from './admin-add-autoid-static-user-mapping.js';
+import CreateOAuth2ClientWithAdminPrivilegesCmd from './admin-create-oauth2-client-with-admin-privileges.js';
+import ExecuteRfc7523AuthzGrantFlowCmd from './admin-execute-rfc7523-authz-grant-flow.js';
+import FederationCmd from './admin-federation.js';
+import GenerateRfc7523AuthzGrantArtefactsCmd from './admin-generate-rfc7523-authz-grant-artefacts.js';
+import GetAccessTokenCmd from './admin-get-access-token.js';
+import GrantOauth2ClientAdminPrivilegesCmd from './admin-grant-oauth2-client-admin-privileges.js';
+import HideGenericExtensionAttributesCmd from './admin-hide-generic-extension-attributes.js';
+import ListOauth2ClientsWithAdminPrivilegesCmd from './admin-list-oauth2-clients-with-admin-privileges.js';
+import ListOauth2ClientsWithCustomPrivilegesCmd from './admin-list-oauth2-clients-with-custom-privileges.js';
+import ListStaticUserMappingsCmd from './admin-list-static-user-mappings.js';
+import RemoveStaticUserMappingCmd from './admin-remove-static-user-mapping.js';
+import RepairOrgModelCmd from './admin-repair-org-model.js';
+import RevokeOauth2ClientAdminPrivilegesCmd from './admin-revoke-oauth2-client-admin-privileges.js';
+import ShowGenericExtensionAttributesCmd from './admin-show-generic-extension-attributes.js';
+// import TrainAutoAccessModelCmd from './admin-train-auto-access-model.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('admin')
-    .description('Platform admin tasks.')
-    .executableDir(__dirname);
-
-  program.command('federation', 'Manage admin federation configuration.');
-
-  program.command(
-    'create-oauth2-client-with-admin-privileges',
-    'Create an oauth2 client with admin privileges.'
+  const program = new FrodoStubCommand('admin').description(
+    'Platform admin tasks.'
   );
 
-  program.command(
-    'generate-rfc7523-authz-grant-artefacts',
-    'Generate RFC7523 authorization grant artefacts.'
+  program.addCommand(FederationCmd().name('federation'));
+
+  program.addCommand(
+    CreateOAuth2ClientWithAdminPrivilegesCmd().name(
+      'create-oauth2-client-with-admin-privileges'
+    )
   );
 
-  program.command(
-    'execute-rfc7523-authz-grant-flow',
-    'Execute RFC7523 authorization grant flow.'
+  program.addCommand(
+    GenerateRfc7523AuthzGrantArtefactsCmd().name(
+      'generate-rfc7523-authz-grant-artefacts'
+    )
   );
 
-  program.command(
-    'get-access-token',
-    'Get an access token using client credentials grant type.'
+  program.addCommand(
+    ExecuteRfc7523AuthzGrantFlowCmd().name('execute-rfc7523-authz-grant-flow')
   );
 
-  program.command(
-    'list-oauth2-clients-with-admin-privileges',
-    'List oauth2 clients with admin privileges.'
+  program.addCommand(GetAccessTokenCmd().name('get-access-token'));
+
+  program.addCommand(
+    ListOauth2ClientsWithAdminPrivilegesCmd().name(
+      'list-oauth2-clients-with-admin-privileges'
+    )
   );
 
-  program.command(
-    'grant-oauth2-client-admin-privileges',
-    'Grant an oauth2 client admin privileges.'
+  program.addCommand(
+    GrantOauth2ClientAdminPrivilegesCmd().name(
+      'grant-oauth2-client-admin-privileges'
+    )
   );
 
-  program.command(
-    'revoke-oauth2-client-admin-privileges',
-    'Revoke admin privileges from an oauth2 client.'
+  program.addCommand(
+    RevokeOauth2ClientAdminPrivilegesCmd().name(
+      'revoke-oauth2-client-admin-privileges'
+    )
   );
 
-  program.command(
-    'list-oauth2-clients-with-custom-privileges',
-    'List oauth2 clients with custom privileges.'
+  program.addCommand(
+    ListOauth2ClientsWithCustomPrivilegesCmd().name(
+      'list-oauth2-clients-with-custom-privileges'
+    )
   );
 
-  program.command(
-    'list-static-user-mappings',
-    'List all subjects of static user mappings that are not oauth2 clients.'
+  program.addCommand(
+    ListStaticUserMappingsCmd().name('list-static-user-mappings')
   );
 
-  program.command(
-    'remove-static-user-mapping',
-    "Remove a subject's static user mapping."
+  program.addCommand(
+    RemoveStaticUserMappingCmd().name('remove-static-user-mapping')
   );
 
-  program.command(
-    'add-autoid-static-user-mapping',
-    'Add AutoId static user mapping to enable dashboards and other AutoId-based functionality.'
+  program.addCommand(
+    AddAutoidStaticUserMappingCmd().name('add-autoid-static-user-mapping')
   );
 
-  program.command(
-    'hide-generic-extension-attributes',
-    'Hide generic extension attributes.'
+  program.addCommand(
+    HideGenericExtensionAttributesCmd().name(
+      'hide-generic-extension-attributes'
+    )
   );
 
-  program.command(
-    'show-generic-extension-attributes',
-    'Show generic extension attributes.'
+  program.addCommand(
+    ShowGenericExtensionAttributesCmd().name(
+      'show-generic-extension-attributes'
+    )
   );
 
-  program.command('repair-org-model', 'Repair org model.');
+  program.addCommand(RepairOrgModelCmd().name('repair-org-model'));
 
-  // program.command('train-auto-access-model', 'Train Auto Access model.');
+  // program.addCommand(TrainAutoAccessModelCmd().name('train-auto-access-model'));
 
   return program;
 }

--- a/src/cli/agent/agent-delete.ts
+++ b/src/cli/agent/agent-delete.ts
@@ -6,58 +6,60 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent delete');
 
-program
-  .description('Delete agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a is ignored.'
+  program
+    .description('Delete agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(new Option('-a, --all', 'Delete all agents. Ignored with -i.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // delete by id
-        if (options.agentId) {
-          verboseMessage(
-            `Deleting agent '${
-              options.agentId
-            }' in realm "${state.getRealm()}"...`
-          );
-          const outcome = await deleteAgent(options.agentId);
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage(
-            `Deleting all agents in realm "${state.getRealm()}"...`
-          );
-          const outcome = await deleteAgents();
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .addOption(new Option('-a, --all', 'Delete all agents. Ignored with -i.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // delete by id
+          if (options.agentId) {
+            verboseMessage(
+              `Deleting agent '${
+                options.agentId
+              }' in realm "${state.getRealm()}"...`
+            );
+            const outcome = await deleteAgent(options.agentId);
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage(
+              `Deleting all agents in realm "${state.getRealm()}"...`
+            );
+            const outcome = await deleteAgents();
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-describe.ts
+++ b/src/cli/agent/agent-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent describe');
 
-program
-  .description('Describe agents.')
-  .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe agents.')
+    .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-export.ts
+++ b/src/cli/agent/agent-export.ts
@@ -9,83 +9,85 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent export');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent export');
 
-program
-  .description('Export agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a and -A are ignored.'
+  program
+    .description('Export agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all agents to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all agents to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all agents to separate files (*.<type>.agent.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all agents to separate files (*.<type>.agent.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // export
-        if (options.agentId) {
-          verboseMessage('Exporting agent...');
-          const outcome = await exportAgentToFile(
-            options.agentId,
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Exporting all agents to a single file...');
-          const outcome = await exportAgentsToFile(
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate) {
-          verboseMessage('Exporting all agents to separate files...');
-          const outcome = await exportAgentsToFiles(options.metadata);
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // export
+          if (options.agentId) {
+            verboseMessage('Exporting agent...');
+            const outcome = await exportAgentToFile(
+              options.agentId,
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Exporting all agents to a single file...');
+            const outcome = await exportAgentsToFile(
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate) {
+            verboseMessage('Exporting all agents to separate files...');
+            const outcome = await exportAgentsToFiles(options.metadata);
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-gateway-delete.ts
+++ b/src/cli/agent/agent-gateway-delete.ts
@@ -9,61 +9,63 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent gateway delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent gateway delete');
 
-program
-  .description('Delete identity gateway agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a is ignored.'
+  program
+    .description('Delete identity gateway agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Delete all identity gateway agents. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all identity gateway agents. Ignored with -i.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // delete by id
-        if (options.agentId) {
-          verboseMessage(
-            `Deleting agent '${
-              options.agentId
-            }' in realm "${state.getRealm()}"...`
-          );
-          const outcome = await deleteIdentityGatewayAgent(options.agentId);
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Deleting all agents...');
-          const outcome = await deleteIdentityGatewayAgents();
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // delete by id
+          if (options.agentId) {
+            verboseMessage(
+              `Deleting agent '${
+                options.agentId
+              }' in realm "${state.getRealm()}"...`
+            );
+            const outcome = await deleteIdentityGatewayAgent(options.agentId);
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Deleting all agents...');
+            const outcome = await deleteIdentityGatewayAgents();
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-gateway-describe.ts
+++ b/src/cli/agent/agent-gateway-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent gateway describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent gateway describe');
 
-program
-  .description('Describe gateway agents.')
-  .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe gateway agents.')
+    .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-gateway-export.ts
+++ b/src/cli/agent/agent-gateway-export.ts
@@ -9,89 +9,91 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent gateway export');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent gateway export');
 
-program
-  .description('Export gateway agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a and -A are ignored.'
+  program
+    .description('Export gateway agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all gateway agents to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all gateway agents to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all gateway agents to separate files (*.identitygatewayagent.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all gateway agents to separate files (*.identitygatewayagent.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // export
-        if (options.agentId) {
-          verboseMessage('Exporting identity gateway agent...');
-          const outcome = await exportIdentityGatewayAgentToFile(
-            options.agentId,
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage(
-            'Exporting all identity gateway agents to a single file...'
-          );
-          const outcome = await exportIdentityGatewayAgentsToFile(
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate) {
-          verboseMessage(
-            'Exporting all identity gateway agents to separate files...'
-          );
-          const outcome = await exportIdentityGatewayAgentsToFiles(
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // export
+          if (options.agentId) {
+            verboseMessage('Exporting identity gateway agent...');
+            const outcome = await exportIdentityGatewayAgentToFile(
+              options.agentId,
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage(
+              'Exporting all identity gateway agents to a single file...'
+            );
+            const outcome = await exportIdentityGatewayAgentsToFile(
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate) {
+            verboseMessage(
+              'Exporting all identity gateway agents to separate files...'
+            );
+            const outcome = await exportIdentityGatewayAgentsToFiles(
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-gateway-import.ts
+++ b/src/cli/agent/agent-gateway-import.ts
@@ -10,85 +10,89 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent gateway import');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent gateway import');
 
-program
-  .description('Import gateway agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+  program
+    .description('Import gateway agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all agents from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all agents from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all agents from separate files (*.identitygatewayagent.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all agents from separate files (*.identitygatewayagent.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // import
-        if (options.agentId) {
-          verboseMessage(`Importing web agent ${options.agentId} from file...`);
-          const outcome = await importIdentityGatewayAgentFromFile(
-            options.agentId,
-            options.file
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all && options.file) {
-          verboseMessage(
-            `Importing all web agents from a single file (${options.file})...`
-          );
-          const outcome = await importIdentityGatewayAgentsFromFile(
-            options.file
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate && !options.file) {
-          verboseMessage('Importing all web agents from separate files...');
-          const outcome = await importIdentityGatewayAgentsFromFiles();
-          if (!outcome) process.exitCode = 1;
-        }
-        // import first journey in file
-        else if (options.file) {
-          verboseMessage('Importing first web agent in file...');
-          const outcome = await importFirstIdentityGatewayAgentFromFile(
-            options.file
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // import
+          if (options.agentId) {
+            verboseMessage(
+              `Importing web agent ${options.agentId} from file...`
+            );
+            const outcome = await importIdentityGatewayAgentFromFile(
+              options.agentId,
+              options.file
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all && options.file) {
+            verboseMessage(
+              `Importing all web agents from a single file (${options.file})...`
+            );
+            const outcome = await importIdentityGatewayAgentsFromFile(
+              options.file
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate && !options.file) {
+            verboseMessage('Importing all web agents from separate files...');
+            const outcome = await importIdentityGatewayAgentsFromFiles();
+            if (!outcome) process.exitCode = 1;
+          }
+          // import first journey in file
+          else if (options.file) {
+            verboseMessage('Importing first web agent in file...');
+            const outcome = await importFirstIdentityGatewayAgentFromFile(
+              options.file
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-gateway-list.ts
+++ b/src/cli/agent/agent-gateway-list.ts
@@ -4,32 +4,34 @@ import { listIdentityGatewayAgents } from '../../ops/AgentOps.js';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent gateway list');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent gateway list');
 
-program
-  .description('List gateway agents.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        const outcome = await listIdentityGatewayAgents(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List gateway agents.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          const outcome = await listIdentityGatewayAgents(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-gateway.ts
+++ b/src/cli/agent/agent-gateway.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './agent-gateway-delete.js';
+import DescribeCmd from './agent-gateway-describe.js';
+import ExportCmd from './agent-gateway-export.js';
+import ImportCmd from './agent-gateway-import.js';
+import ListCmd from './agent-gateway-list.js';
 
-const program = new FrodoStubCommand('frodo agent gateway');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo agent gateway');
 
-program.description('Manage gateway agents.').alias('ig');
+  program.description('Manage gateway agents.').alias('ig');
 
-program.command('list', 'List gateway agents.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('describe', 'Describe gateway agents.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export gateway agents.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import gateway agents.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('delete', 'Delete gateway agents.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-import.ts
+++ b/src/cli/agent/agent-import.ts
@@ -10,81 +10,83 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent import');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent import');
 
-program
-  .description('Import agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+  program
+    .description('Import agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all cmds from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all cmds from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all cmds from separate files (*.cmd.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all cmds from separate files (*.cmd.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // import
-        if (options.agentId) {
-          verboseMessage(`Importing agent ${options.agentId}...`);
-          const outcome = await importAgentFromFile(
-            options.agentId,
-            options.file
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all && options.file) {
-          verboseMessage(
-            `Importing all agents from a single file (${options.file})...`
-          );
-          const outcome = await importAgentsFromFile(options.file);
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate && !options.file) {
-          verboseMessage('Importing all agents from separate files...');
-          const outcome = await importAgentsFromFiles();
-          if (!outcome) process.exitCode = 1;
-        }
-        // import first journey in file
-        else if (options.file) {
-          verboseMessage('Importing first agent in file...');
-          const outcome = await importFirstAgentFromFile(options.file);
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // import
+          if (options.agentId) {
+            verboseMessage(`Importing agent ${options.agentId}...`);
+            const outcome = await importAgentFromFile(
+              options.agentId,
+              options.file
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all && options.file) {
+            verboseMessage(
+              `Importing all agents from a single file (${options.file})...`
+            );
+            const outcome = await importAgentsFromFile(options.file);
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate && !options.file) {
+            verboseMessage('Importing all agents from separate files...');
+            const outcome = await importAgentsFromFiles();
+            if (!outcome) process.exitCode = 1;
+          }
+          // import first journey in file
+          else if (options.file) {
+            verboseMessage('Importing first agent in file...');
+            const outcome = await importFirstAgentFromFile(options.file);
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-java-delete.ts
+++ b/src/cli/agent/agent-java-delete.ts
@@ -6,58 +6,60 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent java delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent java delete');
 
-program
-  .description('Delete java agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a is ignored.'
+  program
+    .description('Delete java agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all java agents. Ignored with -i.')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // delete by id
-        if (options.agentId) {
-          verboseMessage(
-            `Deleting agent '${
-              options.agentId
-            }' in realm "${state.getRealm()}"...`
-          );
-          const outcome = await deleteJavaAgent(options.agentId);
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Deleting all agents...');
-          const outcome = await deleteJavaAgents();
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .addOption(
+      new Option('-a, --all', 'Delete all java agents. Ignored with -i.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // delete by id
+          if (options.agentId) {
+            verboseMessage(
+              `Deleting agent '${
+                options.agentId
+              }' in realm "${state.getRealm()}"...`
+            );
+            const outcome = await deleteJavaAgent(options.agentId);
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Deleting all agents...');
+            const outcome = await deleteJavaAgents();
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-java-describe.ts
+++ b/src/cli/agent/agent-java-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent java describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent java describe');
 
-program
-  .description('Describe java agents.')
-  .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe java agents.')
+    .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-java-export.ts
+++ b/src/cli/agent/agent-java-export.ts
@@ -9,83 +9,85 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent java export');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent java export');
 
-program
-  .description('Export java agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a and -A are ignored.'
+  program
+    .description('Export java agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all java agents to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all java agents to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all java agents to separate files (*.javaagent.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all java agents to separate files (*.javaagent.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // export
-        if (options.agentId) {
-          verboseMessage('Exporting java agent...');
-          const outcome = await exportJavaAgentToFile(
-            options.agentId,
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Exporting all java agents to a single file...');
-          const outcome = await exportJavaAgentsToFile(
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate) {
-          verboseMessage('Exporting all java agents to separate files...');
-          const outcome = await exportJavaAgentsToFiles(options.metadata);
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // export
+          if (options.agentId) {
+            verboseMessage('Exporting java agent...');
+            const outcome = await exportJavaAgentToFile(
+              options.agentId,
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Exporting all java agents to a single file...');
+            const outcome = await exportJavaAgentsToFile(
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate) {
+            verboseMessage('Exporting all java agents to separate files...');
+            const outcome = await exportJavaAgentsToFiles(options.metadata);
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-java-import.ts
+++ b/src/cli/agent/agent-java-import.ts
@@ -10,81 +10,85 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent java import');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent java import');
 
-program
-  .description('Import java agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+  program
+    .description('Import java agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all agents from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all agents from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all agents from separate files (*.javaagent.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all agents from separate files (*.javaagent.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // import
-        if (options.agentId) {
-          verboseMessage(`Importing web agent ${options.agentId} from file...`);
-          const outcome = await importJavaAgentFromFile(
-            options.agentId,
-            options.file
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all && options.file) {
-          verboseMessage(
-            `Importing all web agents from a single file (${options.file})...`
-          );
-          const outcome = await importJavaAgentsFromFile(options.file);
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate && !options.file) {
-          verboseMessage('Importing all web agents from separate files...');
-          const outcome = await importJavaAgentsFromFiles();
-          if (!outcome) process.exitCode = 1;
-        }
-        // import first journey in file
-        else if (options.file) {
-          verboseMessage('Importing first web agent in file...');
-          const outcome = await importFirstJavaAgentFromFile(options.file);
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // import
+          if (options.agentId) {
+            verboseMessage(
+              `Importing web agent ${options.agentId} from file...`
+            );
+            const outcome = await importJavaAgentFromFile(
+              options.agentId,
+              options.file
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all && options.file) {
+            verboseMessage(
+              `Importing all web agents from a single file (${options.file})...`
+            );
+            const outcome = await importJavaAgentsFromFile(options.file);
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate && !options.file) {
+            verboseMessage('Importing all web agents from separate files...');
+            const outcome = await importJavaAgentsFromFiles();
+            if (!outcome) process.exitCode = 1;
+          }
+          // import first journey in file
+          else if (options.file) {
+            verboseMessage('Importing first web agent in file...');
+            const outcome = await importFirstJavaAgentFromFile(options.file);
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-java-list.ts
+++ b/src/cli/agent/agent-java-list.ts
@@ -4,32 +4,34 @@ import { listJavaAgents } from '../../ops/AgentOps.js';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent java list');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent java list');
 
-program
-  .description('List java agents.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        const outcome = await listJavaAgents(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List java agents.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          const outcome = await listJavaAgents(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-java.ts
+++ b/src/cli/agent/agent-java.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './agent-java-delete.js';
+import DescribeCmd from './agent-java-describe.js';
+import ExportCmd from './agent-java-export.js';
+import ImportCmd from './agent-java-import.js';
+import ListCmd from './agent-java-list.js';
 
-const program = new FrodoStubCommand('frodo agent java');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo agent java');
 
-program.description('Manage java agents.');
+  program.description('Manage java agents.');
 
-program.command('list', 'List java agents.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('describe', 'Describe java agents.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export java agents.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import java agents.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('delete', 'Delete java agents.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-list.ts
+++ b/src/cli/agent/agent-list.ts
@@ -4,32 +4,34 @@ import { listAgents } from '../../ops/AgentOps.js';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent list');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent list');
 
-program
-  .description('List agents.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        const outcome = await listAgents(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List agents.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          const outcome = await listAgents(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-web-delete.ts
+++ b/src/cli/agent/agent-web-delete.ts
@@ -6,56 +6,60 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent web delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent web delete');
 
-program
-  .description('Delete web agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a and -A are ignored.'
+  program
+    .description('Delete web agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-a, --all', 'Delete all web agents. Ignored with -i.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // delete by id
-        if (options.agentId) {
-          verboseMessage(
-            `Deleting agent '${
-              options.agentId
-            }' in realm "${state.getRealm()}"...`
-          );
-          const outcome = await deleteWebAgent(options.agentId);
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Deleting all agents...');
-          const outcome = await deleteWebAgents();
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .addOption(
+      new Option('-a, --all', 'Delete all web agents. Ignored with -i.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // delete by id
+          if (options.agentId) {
+            verboseMessage(
+              `Deleting agent '${
+                options.agentId
+              }' in realm "${state.getRealm()}"...`
+            );
+            const outcome = await deleteWebAgent(options.agentId);
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Deleting all agents...');
+            const outcome = await deleteWebAgents();
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-web-describe.ts
+++ b/src/cli/agent/agent-web-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent web describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent web describe');
 
-program
-  .description('Describe web agents.')
-  .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe web agents.')
+    .addOption(new Option('-i, --agent-id <agent-id>', 'Agent id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-web-export.ts
+++ b/src/cli/agent/agent-web-export.ts
@@ -9,83 +9,85 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent web export');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent web export');
 
-program
-  .description('Export web agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, -a and -A are ignored.'
+  program
+    .description('Export web agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all web agents to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all web agents to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all web agents to separate files (*.webagent.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all web agents to separate files (*.webagent.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // export
-        if (options.agentId) {
-          verboseMessage('Exporting web agent...');
-          const outcome = await exportWebAgentToFile(
-            options.agentId,
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Exporting all web agents to a single file...');
-          const outcome = await exportWebAgentsToFile(
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate) {
-          verboseMessage('Exporting all web agents to separate files...');
-          const outcome = await exportWebAgentsToFiles(options.metadata);
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // export
+          if (options.agentId) {
+            verboseMessage('Exporting web agent...');
+            const outcome = await exportWebAgentToFile(
+              options.agentId,
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Exporting all web agents to a single file...');
+            const outcome = await exportWebAgentsToFile(
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate) {
+            verboseMessage('Exporting all web agents to separate files...');
+            const outcome = await exportWebAgentsToFiles(options.metadata);
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-web-import.ts
+++ b/src/cli/agent/agent-web-import.ts
@@ -10,81 +10,85 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent web import');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent web import');
 
-program
-  .description('Import web agents.')
-  .addOption(
-    new Option(
-      '-i, --agent-id <agent-id>',
-      'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+  program
+    .description('Import web agents.')
+    .addOption(
+      new Option(
+        '-i, --agent-id <agent-id>',
+        'Agent id. If specified, only one agent is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all agents from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all agents from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all agents from separate files (*.webagent.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all agents from separate files (*.webagent.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // import
-        if (options.agentId) {
-          verboseMessage(`Importing web agent ${options.agentId} from file...`);
-          const outcome = await importWebAgentFromFile(
-            options.agentId,
-            options.file
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all && options.file) {
-          verboseMessage(
-            `Importing all web agents from a single file (${options.file})...`
-          );
-          const outcome = await importWebAgentsFromFile(options.file);
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate && !options.file) {
-          verboseMessage('Importing all web agents from separate files...');
-          const outcome = await importWebAgentsFromFiles();
-          if (!outcome) process.exitCode = 1;
-        }
-        // import first journey in file
-        else if (options.file) {
-          verboseMessage('Importing first web agent in file...');
-          const outcome = await importFirstWebAgentFromFile(options.file);
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          verboseMessage(
-            'Unrecognized combination of options or no options...'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // import
+          if (options.agentId) {
+            verboseMessage(
+              `Importing web agent ${options.agentId} from file...`
+            );
+            const outcome = await importWebAgentFromFile(
+              options.agentId,
+              options.file
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all && options.file) {
+            verboseMessage(
+              `Importing all web agents from a single file (${options.file})...`
+            );
+            const outcome = await importWebAgentsFromFile(options.file);
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate && !options.file) {
+            verboseMessage('Importing all web agents from separate files...');
+            const outcome = await importWebAgentsFromFiles();
+            if (!outcome) process.exitCode = 1;
+          }
+          // import first journey in file
+          else if (options.file) {
+            verboseMessage('Importing first web agent in file...');
+            const outcome = await importFirstWebAgentFromFile(options.file);
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            verboseMessage(
+              'Unrecognized combination of options or no options...'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-web-list.ts
+++ b/src/cli/agent/agent-web-list.ts
@@ -4,32 +4,34 @@ import { listWebAgents } from '../../ops/AgentOps.js';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo agent web list');
+export default function setup() {
+  const program = new FrodoCommand('frodo agent web list');
 
-program
-  .description('List web agents.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        const outcome = await listWebAgents(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List web agents.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          const outcome = await listWebAgents(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent-web.ts
+++ b/src/cli/agent/agent-web.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './agent-web-delete.js';
+import DescribeCmd from './agent-web-describe.js';
+import ExportCmd from './agent-web-export.js';
+import ImportCmd from './agent-web-import.js';
+import ListCmd from './agent-web-list.js';
 
-const program = new FrodoStubCommand('frodo agent web');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo agent web');
 
-program.description('Manage web agents.');
+  program.description('Manage web agents.');
 
-program.command('list', 'List web agents.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('describe', 'Describe web agents.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export web agents.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import web agents.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('delete', 'Delete web agents.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/agent/agent.ts
+++ b/src/cli/agent/agent.ts
@@ -1,30 +1,31 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './agent-delete.js';
+import DescribeCmd from './agent-describe.js';
+import ExportCmd from './agent-export.js';
+import GatewayCmd from './agent-gateway.js';
+import ImportCmd from './agent-import.js';
+import JavaCmd from './agent-java.js';
+import ListCmd from './agent-list.js';
+import WebCmd from './agent-web.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('agent')
-    .description('Manage agents.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('agent').description('Manage agents.');
 
-  program.command('gateway', 'Manage gateway agents.').alias('ig');
+  program.addCommand(GatewayCmd().name('gateway').alias('ig'));
 
-  program.command('java', 'Manage java agents.');
+  program.addCommand(JavaCmd().name('java'));
 
-  program.command('web', 'Manage web agents.');
+  program.addCommand(WebCmd().name('web'));
 
-  program.command('list', 'List agents.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('describe', 'Describe agents.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('export', 'Export agents.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import agents.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('delete', 'Delete agents.');
+  program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/app/app-delete.ts
+++ b/src/cli/app/app-delete.ts
@@ -9,67 +9,71 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo app delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo app delete');
 
-program
-  .description('Delete applications.')
-  .addOption(
-    new Option(
-      '-i, --app-id <id>',
-      'Application name. If specified, -a and -A are ignored.'
+  program
+    .description('Delete applications.')
+    .addOption(
+      new Option(
+        '-i, --app-id <id>',
+        'Application name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all applications. Ignored with -i.')
-  )
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(
+      new Option('-a, --all', 'Delete all applications. Ignored with -i.')
     )
-  )
-  .addHelpText(
-    'after',
-    `Important Note:\n`['brightYellow'] +
-      `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
-      `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
-      `Usage Examples:\n` +
-      `  Delete application 'myApp':\n` +
-      `  $ frodo app delete -i 'myApp' ${s.amBaseUrl}\n`['brightCyan'] +
-      `  Delete all applications:\n` +
-      `  $ frodo app delete -a ${s.connId}\n`['brightCyan']
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete app by name
-      if (options.appId && (await getTokens())) {
-        verboseMessage('Deleting application...');
-        const outcome = await deleteApplication(options.appId, options.deep);
-        if (!outcome) process.exitCode = 1;
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
+    )
+    .addHelpText(
+      'after',
+      `Important Note:\n`['brightYellow'] +
+        `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
+        `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
+        `Usage Examples:\n` +
+        `  Delete application 'myApp':\n` +
+        `  $ frodo app delete -i 'myApp' ${s.amBaseUrl}\n`['brightCyan'] +
+        `  Delete all applications:\n` +
+        `  $ frodo app delete -a ${s.connId}\n`['brightCyan']
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // delete app by name
+        if (options.appId && (await getTokens())) {
+          verboseMessage('Deleting application...');
+          const outcome = await deleteApplication(options.appId, options.deep);
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all applications...');
+          const outcome = await deleteApplications(options.deep);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a/--all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all applications...');
-        const outcome = await deleteApplications(options.deep);
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/app/app-describe.ts
+++ b/src/cli/app/app-describe.ts
@@ -4,40 +4,42 @@ import * as s from '../../help/SampleData';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo app describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo app describe');
 
-program
-  .description('Describe application.')
-  .addOption(new Option('-i, --app-id <id>', 'Application name.'))
-  .addHelpText(
-    'after',
-    `Important Note:\n`['brightYellow'] +
-      `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
-      `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
-      `Usage Examples:\n` +
-      `  Describe application 'myApp':\n` +
-      `  $ frodo app describe -i myApp ${s.connId}\n`['brightCyan'] +
-      `  Describe application 'myApp' in raw JSON:\n` +
-      `  $ frodo app describe -i myApp --json ${s.connId}\n`['brightCyan']
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe application.')
+    .addOption(new Option('-i, --app-id <id>', 'Application name.'))
+    .addHelpText(
+      'after',
+      `Important Note:\n`['brightYellow'] +
+        `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
+        `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
+        `Usage Examples:\n` +
+        `  Describe application 'myApp':\n` +
+        `  $ frodo app describe -i myApp ${s.connId}\n`['brightCyan'] +
+        `  Describe application 'myApp' in raw JSON:\n` +
+        `  $ frodo app describe -i myApp --json ${s.connId}\n`['brightCyan']
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/app/app-export.ts
+++ b/src/cli/app/app-export.ts
@@ -10,112 +10,116 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo app export');
+export default function setup() {
+  const program = new FrodoCommand('frodo app export');
 
-program
-  .description('Export applications.')
-  .addOption(
-    new Option(
-      '-i, --app-id <app-id>',
-      'Application name. If specified, -a and -A are ignored.'
+  program
+    .description('Export applications.')
+    .addOption(
+      new Option(
+        '-i, --app-id <app-id>',
+        'Application name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all applications to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all applications to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all applications to separate files (*.application.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all applications to separate files (*.application.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .addOption(
-    new Option('--no-deps', 'Do not include any dependencies (scripts).')
-  )
-  .addHelpText(
-    'after',
-    `Important Note:\n`['brightYellow'] +
-      `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
-      `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
-      `Usage Examples:\n` +
-      `  Export all applications to a single export file with an auto-generated filename using a connection profile:\n` +
-      `  $ frodo app export -a ${s.connId}\n`['brightCyan'] +
-      `  Export the first application to a single export file with a custom filename:\n` +
-      `  $ frodo app export -f ./allMyApplications.application.json ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Export all applications to separate export files with an auto-generated filenames:\n` +
-      `  $ frodo app export -A ${s.connId}\n`['brightCyan'] +
-      `  Export all applications without dependencies to a single export file:\n` +
-      `  $ frodo app export --no-deps -a ${s.connId}\n`['brightCyan'] +
-      `  Export the application 'myApp' to a file with an auto-generated filename of 'myApp.application.json':\n` +
-      `  $ frodo app export -i myApp ${s.connId}\n`['brightCyan']
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export
-      if (options.appId && (await getTokens())) {
-        verboseMessage('Exporting application...');
-        const outcome = await exportApplicationToFile(
-          options.appId,
-          options.file,
-          options.metadata,
-          {
+    .addOption(
+      new Option('--no-deps', 'Do not include any dependencies (scripts).')
+    )
+    .addHelpText(
+      'after',
+      `Important Note:\n`['brightYellow'] +
+        `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
+        `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
+        `Usage Examples:\n` +
+        `  Export all applications to a single export file with an auto-generated filename using a connection profile:\n` +
+        `  $ frodo app export -a ${s.connId}\n`['brightCyan'] +
+        `  Export the first application to a single export file with a custom filename:\n` +
+        `  $ frodo app export -f ./allMyApplications.application.json ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Export all applications to separate export files with an auto-generated filenames:\n` +
+        `  $ frodo app export -A ${s.connId}\n`['brightCyan'] +
+        `  Export all applications without dependencies to a single export file:\n` +
+        `  $ frodo app export --no-deps -a ${s.connId}\n`['brightCyan'] +
+        `  Export the application 'myApp' to a file with an auto-generated filename of 'myApp.application.json':\n` +
+        `  $ frodo app export -i myApp ${s.connId}\n`['brightCyan']
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // export
+        if (options.appId && (await getTokens())) {
+          verboseMessage('Exporting application...');
+          const outcome = await exportApplicationToFile(
+            options.appId,
+            options.file,
+            options.metadata,
+            {
+              useStringArrays: true,
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all applications to file...');
+          const outcome = await exportApplicationsToFile(
+            options.file,
+            options.metadata,
+            {
+              useStringArrays: true,
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A/--all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all applications to separate files...');
+          const outcome = await exportApplicationsToFiles(options.metadata, {
             useStringArrays: true,
             deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a/--all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all applications to file...');
-        const outcome = await exportApplicationsToFile(
-          options.file,
-          options.metadata,
-          {
-            useStringArrays: true,
-            deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A/--all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all applications to separate files...');
-        const outcome = await exportApplicationsToFiles(options.metadata, {
-          useStringArrays: true,
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/app/app-import.ts
+++ b/src/cli/app/app-import.ts
@@ -11,118 +11,120 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo app import');
+export default function setup() {
+  const program = new FrodoCommand('frodo app import');
 
-program
-  .description('Import applications.')
-  .addOption(
-    new Option(
-      '-i, --app-id <id>',
-      'Application name. If specified, only one application is imported and the options -a and -A are ignored.'
+  program
+    .description('Import applications.')
+    .addOption(
+      new Option(
+        '-i, --app-id <id>',
+        'Application name. If specified, only one application is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all applications from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all applications from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all applications from separate files (*.app.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all applications from separate files (*.app.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option('--no-deps', 'Do not include any dependencies (scripts).')
-  )
-  .addHelpText(
-    'after',
-    `Important Note:\n`['brightYellow'] +
-      `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
-      `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
-      `Usage Examples:\n` +
-      `  Import all applications from a single export file using a connection profile:\n` +
-      `  $ frodo app import -a -f ./allAlphaApplications.application.json ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Import the first application from a single export file:\n` +
-      `  $ frodo app import -f ./allAlphaApplications.application.json ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Import all applications from separate export files:\n` +
-      `  $ frodo app import -A ${s.connId}\n`['brightCyan'] +
-      `  Import all applications without dependencies from a single export file:\n` +
-      `  $ frodo app import --no-deps -a -f ./allAlphaApplications.application.json ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Import only the application 'myApp' from a file with an export file containing multiple applications:\n` +
-      `  $ frodo app import -i myApp -f ./allAlphaApplications.application.json ${s.connId}\n`[
-        'brightCyan'
-      ]
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import by id
-      if (options.file && options.appId && (await getTokens())) {
-        verboseMessage(`Importing application "${options.appId}"...`);
-        const outcome = await importApplicationFromFile(
-          options.appId,
-          options.file,
-          {
+    .addOption(
+      new Option('--no-deps', 'Do not include any dependencies (scripts).')
+    )
+    .addHelpText(
+      'after',
+      `Important Note:\n`['brightYellow'] +
+        `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
+        `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
+        `Usage Examples:\n` +
+        `  Import all applications from a single export file using a connection profile:\n` +
+        `  $ frodo app import -a -f ./allAlphaApplications.application.json ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Import the first application from a single export file:\n` +
+        `  $ frodo app import -f ./allAlphaApplications.application.json ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Import all applications from separate export files:\n` +
+        `  $ frodo app import -A ${s.connId}\n`['brightCyan'] +
+        `  Import all applications without dependencies from a single export file:\n` +
+        `  $ frodo app import --no-deps -a -f ./allAlphaApplications.application.json ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Import only the application 'myApp' from a file with an export file containing multiple applications:\n` +
+        `  $ frodo app import -i myApp -f ./allAlphaApplications.application.json ${s.connId}\n`[
+          'brightCyan'
+        ]
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // import by id
+        if (options.file && options.appId && (await getTokens())) {
+          verboseMessage(`Importing application "${options.appId}"...`);
+          const outcome = await importApplicationFromFile(
+            options.appId,
+            options.file,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing all applications from a single file (${options.file})...`
+          );
+          const outcome = await importApplicationsFromFile(options.file, {
             deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          verboseMessage(
+            'Importing all applications from separate files in current directory...'
+          );
+          const outcome = await importApplicationsFromFiles({
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first provider from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first application from file "${options.file}"...`
+          );
+          const outcome = await importFirstApplicationFromFile(options.file, {
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing all applications from a single file (${options.file})...`
-        );
-        const outcome = await importApplicationsFromFile(options.file, {
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        verboseMessage(
-          'Importing all applications from separate files in current directory...'
-        );
-        const outcome = await importApplicationsFromFiles({
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first provider from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first application from file "${options.file}"...`
-        );
-        const outcome = await importFirstApplicationFromFile(options.file, {
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/app/app-list.ts
+++ b/src/cli/app/app-list.ts
@@ -6,48 +6,50 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo app list');
+export default function setup() {
+  const program = new FrodoCommand('frodo app list');
 
-program
-  .description('List applications.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .addHelpText(
-    'after',
-    `Important Note:\n`['brightYellow'] +
-      `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
-      `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
-      `Usage Examples:\n` +
-      `  List applications using AM base URL, username, and password (note the quotes around password to allow special characters):\n` +
-      `  $ frodo app list ${s.amBaseUrl} ${s.username} '${s.password}'\n`[
-        'brightCyan'
-      ] +
-      `  List applications using a connection profile (identified by the full AM base URL):\n` +
-      `  $ frodo app list ${s.amBaseUrl}\n`['brightCyan'] +
-      `  List applications using a connection profile (identified by a unique substring of the AM base URL):\n` +
-      `  $ frodo app list ${s.connId}\n`['brightCyan']
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Listing applications...`);
-        const outcome = await listApplications(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List applications.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .addHelpText(
+      'after',
+      `Important Note:\n`['brightYellow'] +
+        `  The ${'frodo app'['brightCyan']} command to manage OAuth2 clients in v1.x has been renamed to ${'frodo oauth client'['brightCyan']} in v2.x\n` +
+        `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n` +
+        `Usage Examples:\n` +
+        `  List applications using AM base URL, username, and password (note the quotes around password to allow special characters):\n` +
+        `  $ frodo app list ${s.amBaseUrl} ${s.username} '${s.password}'\n`[
+          'brightCyan'
+        ] +
+        `  List applications using a connection profile (identified by the full AM base URL):\n` +
+        `  $ frodo app list ${s.amBaseUrl}\n`['brightCyan'] +
+        `  List applications using a connection profile (identified by a unique substring of the AM base URL):\n` +
+        `  $ frodo app list ${s.connId}\n`['brightCyan']
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Listing applications...`);
+          const outcome = await listApplications(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/app/app.ts
+++ b/src/cli/app/app.ts
@@ -1,14 +1,13 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './app-delete.js';
+// import DescribeCmd from './app-describe.js';
+import ExportCmd from './app-export.js';
+import ImportCmd from './app-import.js';
+import ListCmd from './app-list.js';
 
 export default function setup() {
   const program = new FrodoStubCommand('app')
     .description('Manage applications.')
-    .executableDir(__dirname)
     .addHelpText(
       'after',
       `\nImportant Note:\n`['brightYellow'] +
@@ -16,16 +15,15 @@ export default function setup() {
         `  The ${'frodo app'['brightCyan']} command in v2.x manages the new applications created using the new application templates in ForgeRock Identity Cloud. To manage oauth clients, use the ${'frodo oauth client'['brightCyan']} command.\n\n`
     );
 
-  program.command('list', 'List applications.');
+  program.addCommand(ListCmd().name('list'));
 
-  // program
-  //   .command('describe', 'Describe applications.');
+  // program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('export', 'Export applications.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import applications.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('delete', 'Delete applications.');
+  program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/authn/authn-describe.ts
+++ b/src/cli/authn/authn-describe.ts
@@ -5,35 +5,39 @@ import { describeAuthenticationSettings } from '../../ops/AuthenticationSettings
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authn describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo authn describe');
 
-program
-  .description('Describe authentication settings.')
-  .addOption(new Option('--json', 'Output in JSON format.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Describing authentication settings...`);
-        const outcome = await describeAuthenticationSettings(options.json);
-        if (!outcome) process.exitCode = 1;
+  program
+    .description('Describe authentication settings.')
+    .addOption(new Option('--json', 'Output in JSON format.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Describing authentication settings...`);
+          const outcome = await describeAuthenticationSettings(options.json);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authn/authn-export.ts
+++ b/src/cli/authn/authn-export.ts
@@ -5,40 +5,42 @@ import { exportAuthenticationSettingsToFile } from '../../ops/AuthenticationSett
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authn export');
+export default function setup() {
+  const program = new FrodoCommand('frodo authn export');
 
-program
-  .description('Export authentication settings.')
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+  program
+    .description('Export authentication settings.')
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Exporting authentication settings to file...');
-        const outcome = exportAuthenticationSettingsToFile(
-          options.file,
-          options.metadata
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage('Exporting authentication settings to file...');
+          const outcome = exportAuthenticationSettingsToFile(
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authn/authn-import.ts
+++ b/src/cli/authn/authn-import.ts
@@ -5,31 +5,33 @@ import { importAuthenticationSettingsFromFile } from '../../ops/AuthenticationSe
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authn import');
+export default function setup() {
+  const program = new FrodoCommand('frodo authn import');
 
-program
-  .description('Import authentication settings.')
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Importing authentication settings from file...');
-        const outcome = importAuthenticationSettingsFromFile(options.file);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Import authentication settings.')
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage('Importing authentication settings from file...');
+          const outcome = importAuthenticationSettingsFromFile(options.file);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authn/authn.ts
+++ b/src/cli/authn/authn.ts
@@ -1,20 +1,18 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DescribeCmd from './authn-describe.js';
+import ExportCmd from './authn-export.js';
+import ImportCmd from './authn-import.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('authn')
-    .description('Manage authentication settings.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('authn').description(
+    'Manage authentication settings.'
+  );
 
-  program.command('describe', 'Describe authentication settings.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('export', 'Export authentication settings.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import authentication settings.');
+  program.addCommand(ImportCmd().name('import'));
 
   return program;
 }

--- a/src/cli/authz/authz-policy-delete.ts
+++ b/src/cli/authz/authz-policy-delete.ts
@@ -9,61 +9,66 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz policy delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz policy delete');
 
-program
-  .description('Delete authorization policies.')
-  .addOption(
-    new Option(
-      '-i, --policy-id <policy-id>',
-      'Policy id/name. If specified, -a is ignored.'
+  program
+    .description('Delete authorization policies.')
+    .addOption(
+      new Option(
+        '-i, --policy-id <policy-id>',
+        'Policy id/name. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all policies in a realm. Ignored with -i.')
-  )
-  .addOption(
-    new Option('--set-id <set-id>', 'Policy set id/name. Ignored with -i.')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by id
-      if (options.policyId && (await getTokens())) {
-        verboseMessage('Deleting authorization policy...');
-        const outcome = await deletePolicyById(options.policyId);
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all -a by policy set
-      else if (options.setId && options.all && (await getTokens())) {
-        verboseMessage(
-          `Deleting all authorization policies in policy set ${options.setId}...`
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all policies in a realm. Ignored with -i.'
+      )
+    )
+    .addOption(
+      new Option('--set-id <set-id>', 'Policy set id/name. Ignored with -i.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await deletePoliciesByPolicySet(options.setId);
-        if (!outcome) process.exitCode = 1;
+        // delete by id
+        if (options.policyId && (await getTokens())) {
+          verboseMessage('Deleting authorization policy...');
+          const outcome = await deletePolicyById(options.policyId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a by policy set
+        else if (options.setId && options.all && (await getTokens())) {
+          verboseMessage(
+            `Deleting all authorization policies in policy set ${options.setId}...`
+          );
+          const outcome = await deletePoliciesByPolicySet(options.setId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all authorization policies...');
+          const outcome = await deletePolicies();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all authorization policies...');
-        const outcome = await deletePolicies();
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-policy-describe.ts
+++ b/src/cli/authz/authz-policy-describe.ts
@@ -5,43 +5,47 @@ import { describePolicy } from '../../ops/PolicyOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz policy describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz policy describe');
 
-program
-  .description('Describe authorization policies.')
-  .addOption(
-    new Option(
-      '-i, --policy-id <policy-id>',
-      'Policy id/name.'
-    ).makeOptionMandatory()
-  )
-  .addOption(new Option('--json', 'Output in JSON format.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (options.policyId && (await getTokens())) {
-        verboseMessage(
-          `Describing authorization policy ${options.policyId}...`
+  program
+    .description('Describe authorization policies.')
+    .addOption(
+      new Option(
+        '-i, --policy-id <policy-id>',
+        'Policy id/name.'
+      ).makeOptionMandatory()
+    )
+    .addOption(new Option('--json', 'Output in JSON format.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await describePolicy(options.policyId, options.json);
-        if (!outcome) process.exitCode = 1;
+        if (options.policyId && (await getTokens())) {
+          verboseMessage(
+            `Describing authorization policy ${options.policyId}...`
+          );
+          const outcome = await describePolicy(options.policyId, options.json);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-policy-export.ts
+++ b/src/cli/authz/authz-policy-export.ts
@@ -11,141 +11,147 @@ import {
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz policy export');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz policy export');
 
-program
-  .description('Export authorization policies.')
-  .addOption(
-    new Option(
-      '-i, --policy-id <policy-id>',
-      'Policy id. If specified, -a and -A are ignored.'
+  program
+    .description('Export authorization policies.')
+    .addOption(
+      new Option(
+        '-i, --policy-id <policy-id>',
+        'Policy id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--set-id <set-id>',
-      'Export policies in policy set only. Ignored with -i.'
+    .addOption(
+      new Option(
+        '--set-id <set-id>',
+        'Export policies in policy set only. Ignored with -i.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export policies to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export policies to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export policies to separate files (*.policy.authz.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export policies to separate files (*.policy.authz.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .addOption(new Option('--no-deps', 'Do not include dependencies (scripts).'))
-  .addOption(
-    new Option(
-      '--prereqs',
-      'Include prerequisites (policy sets, resource types).'
+    .addOption(
+      new Option('--no-deps', 'Do not include dependencies (scripts).')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export
-      if (options.policyId && (await getTokens())) {
-        verboseMessage('Exporting authorization policy to file...');
-        const outcome = await exportPolicyToFile(
-          options.policyId,
-          options.file,
-          options.metadata,
-          {
+    .addOption(
+      new Option(
+        '--prereqs',
+        'Include prerequisites (policy sets, resource types).'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // export
+        if (options.policyId && (await getTokens())) {
+          verboseMessage('Exporting authorization policy to file...');
+          const outcome = await exportPolicyToFile(
+            options.policyId,
+            options.file,
+            options.metadata,
+            {
+              deps: options.deps,
+              prereqs: options.prereqs,
+              useStringArrays: true,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all by policy set
+        else if (options.setId && options.all && (await getTokens())) {
+          verboseMessage(
+            `Exporting all authorization policies in policy set ${options.setId} to file...`
+          );
+          const outcome = await exportPoliciesByPolicySetToFile(
+            options.setId,
+            options.file,
+            options.metadata,
+            {
+              deps: options.deps,
+              prereqs: options.prereqs,
+              useStringArrays: true,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all authorization policies to file...');
+          const outcome = await exportPoliciesToFile(
+            options.file,
+            options.metadata,
+            {
+              deps: options.deps,
+              prereqs: options.prereqs,
+              useStringArrays: true,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A/--all-separate by policy set
+        else if (options.setId && options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            `Exporting all authorization policies in policy set ${options.setId} to separate files...`
+          );
+          const outcome = await exportPoliciesByPolicySetToFiles(
+            options.setId,
+            options.metadata,
+            {
+              deps: options.deps,
+              prereqs: options.prereqs,
+              useStringArrays: true,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A/--all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            'Exporting all authorization policies to separate files...'
+          );
+          const outcome = await exportPoliciesToFiles(options.metadata, {
             deps: options.deps,
             prereqs: options.prereqs,
             useStringArrays: true,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a/--all by policy set
-      else if (options.setId && options.all && (await getTokens())) {
-        verboseMessage(
-          `Exporting all authorization policies in policy set ${options.setId} to file...`
-        );
-        const outcome = await exportPoliciesByPolicySetToFile(
-          options.setId,
-          options.file,
-          options.metadata,
-          {
-            deps: options.deps,
-            prereqs: options.prereqs,
-            useStringArrays: true,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -a/--all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all authorization policies to file...');
-        const outcome = await exportPoliciesToFile(
-          options.file,
-          options.metadata,
-          {
-            deps: options.deps,
-            prereqs: options.prereqs,
-            useStringArrays: true,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A/--all-separate by policy set
-      else if (options.setId && options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          `Exporting all authorization policies in policy set ${options.setId} to separate files...`
-        );
-        const outcome = await exportPoliciesByPolicySetToFiles(
-          options.setId,
-          options.metadata,
-          {
-            deps: options.deps,
-            prereqs: options.prereqs,
-            useStringArrays: true,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A/--all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          'Exporting all authorization policies to separate files...'
-        );
-        const outcome = await exportPoliciesToFiles(options.metadata, {
-          deps: options.deps,
-          prereqs: options.prereqs,
-          useStringArrays: true,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-policy-import.ts
+++ b/src/cli/authz/authz-policy-import.ts
@@ -10,111 +10,115 @@ import {
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz policy import');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz policy import');
 
-program
-  .description('Import authorization policies.')
-  .addOption(
-    new Option(
-      '-i, --policy-id <policy-id>',
-      'Policy id. If specified, only one policy is imported and the options -a and -A are ignored.'
+  program
+    .description('Import authorization policies.')
+    .addOption(
+      new Option(
+        '-i, --policy-id <policy-id>',
+        'Policy id. If specified, only one policy is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('--set-id <set-id>', 'Import policies into this policy set.')
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all policies from single file. Ignored with -i.'
+    .addOption(
+      new Option('--set-id <set-id>', 'Import policies into this policy set.')
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all policies from separate files (*.policy.authz.json) in the current directory. Ignored with -i or -a.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all policies from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--no-deps',
-      'Do not import dependencies (scripts) even if they are available in the import file.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all policies from separate files (*.policy.authz.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--prereqs',
-      'Import prerequisites (policy sets, resource types) if they are available in the import file.'
+    .addOption(
+      new Option(
+        '--no-deps',
+        'Do not import dependencies (scripts) even if they are available in the import file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import
-      if (options.policyId && (await getTokens())) {
-        verboseMessage('Importing authorization policy from file...');
-        const outcome = await importPolicyFromFile(
-          options.policyId,
-          options.file,
-          {
+    .addOption(
+      new Option(
+        '--prereqs',
+        'Import prerequisites (policy sets, resource types) if they are available in the import file.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // import
+        if (options.policyId && (await getTokens())) {
+          verboseMessage('Importing authorization policy from file...');
+          const outcome = await importPolicyFromFile(
+            options.policyId,
+            options.file,
+            {
+              deps: options.deps,
+              prereqs: options.prereqs,
+              policySetName: options.setId,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Importing all authorization policies from file...');
+          const outcome = await importPoliciesFromFile(options.file, {
             deps: options.deps,
             prereqs: options.prereqs,
             policySetName: options.setId,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A/--all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            'Importing all authorization policies from separate files...'
+          );
+          const outcome = await importPoliciesFromFiles({
+            deps: options.deps,
+            prereqs: options.prereqs,
+            policySetName: options.setId,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first policy set from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first authorization policy from file "${options.file}"...`
+          );
+          const outcome = await importFirstPolicyFromFile(options.file, {
+            deps: options.deps,
+            prereqs: options.prereqs,
+            policySetName: options.setId,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a/--all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Importing all authorization policies from file...');
-        const outcome = await importPoliciesFromFile(options.file, {
-          deps: options.deps,
-          prereqs: options.prereqs,
-          policySetName: options.setId,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A/--all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          'Importing all authorization policies from separate files...'
-        );
-        const outcome = await importPoliciesFromFiles({
-          deps: options.deps,
-          prereqs: options.prereqs,
-          policySetName: options.setId,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first policy set from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first authorization policy from file "${options.file}"...`
-        );
-        const outcome = await importFirstPolicyFromFile(options.file, {
-          deps: options.deps,
-          prereqs: options.prereqs,
-          policySetName: options.setId,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-policy-list.ts
+++ b/src/cli/authz/authz-policy-list.ts
@@ -5,50 +5,54 @@ import { listPolicies, listPoliciesByPolicySet } from '../../ops/PolicyOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz policy list');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz policy list');
 
-program
-  .description('List authorization policies.')
-  .addOption(new Option('--set-id <set-id>', 'Policy set id/name.'))
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // by policy set
-      if (options.setId && (await getTokens())) {
-        verboseMessage(
-          `Listing authorization policies in policy set ${options.setId}...`
+  program
+    .description('List authorization policies.')
+    .addOption(new Option('--set-id <set-id>', 'Policy set id/name.'))
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await listPoliciesByPolicySet(
-          options.setId,
-          options.long
-        );
-        if (!outcome) process.exitCode = 1;
+        // by policy set
+        if (options.setId && (await getTokens())) {
+          verboseMessage(
+            `Listing authorization policies in policy set ${options.setId}...`
+          );
+          const outcome = await listPoliciesByPolicySet(
+            options.setId,
+            options.long
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // all policies
+        else if (await getTokens()) {
+          verboseMessage(`Listing authorization policies...`);
+          const outcome = await listPolicies(options.long);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // all policies
-      else if (await getTokens()) {
-        verboseMessage(`Listing authorization policies...`);
-        const outcome = await listPolicies(options.long);
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-policy.ts
+++ b/src/cli/authz/authz-policy.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './authz-policy-delete.js';
+import DescribeCmd from './authz-policy-describe.js';
+import ExportCmd from './authz-policy-export.js';
+import ImportCmd from './authz-policy-import.js';
+import ListCmd from './authz-policy-list.js';
 
-const program = new FrodoStubCommand('frodo authz policy');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo authz policy');
 
-program.description('Manages authorization policies.');
+  program.description('Manages authorization policies.');
 
-program.command('delete', 'Delete authorization policies.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.command('describe', 'Describe authorization policies.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export authorization policies.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import authorization policies.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('list', 'List authorization policies.');
+  program.addCommand(ListCmd().name('list'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-set-delete.ts
+++ b/src/cli/authz/authz-set-delete.ts
@@ -5,48 +5,50 @@ import { deletePolicySetById, deletePolicySets } from '../../ops/PolicySetOps';
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz set delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz set delete');
 
-program
-  .description('Delete authorization policy sets.')
-  .addOption(new Option('-i, --set-id <set-id>', 'Policy set id/name.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Delete all policy sets in a realm. Ignored with -i.'
+  program
+    .description('Delete authorization policy sets.')
+    .addOption(new Option('-i, --set-id <set-id>', 'Policy set id/name.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all policy sets in a realm. Ignored with -i.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by id
-      if (options.setId && (await getTokens())) {
-        verboseMessage('Deleting authorization policy set...');
-        const outcome = await deletePolicySetById(options.setId);
-        if (!outcome) process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // delete by id
+        if (options.setId && (await getTokens())) {
+          verboseMessage('Deleting authorization policy set...');
+          const outcome = await deletePolicySetById(options.setId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all authorization policy sets...');
+          const outcome = await deletePolicySets();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all authorization policy sets...');
-        const outcome = await deletePolicySets();
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-set-describe.ts
+++ b/src/cli/authz/authz-set-describe.ts
@@ -5,43 +5,47 @@ import { describePolicySet } from '../../ops/PolicySetOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz set describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz set describe');
 
-program
-  .description('Describe authorization policy sets.')
-  .addOption(
-    new Option(
-      '-i, --set-id <set-id>',
-      'Policy set id/name.'
-    ).makeOptionMandatory()
-  )
-  .addOption(new Option('--json', 'Output in JSON format.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (options.setId && (await getTokens())) {
-        verboseMessage(
-          `Describing authorization policy set ${options.setId}...`
+  program
+    .description('Describe authorization policy sets.')
+    .addOption(
+      new Option(
+        '-i, --set-id <set-id>',
+        'Policy set id/name.'
+      ).makeOptionMandatory()
+    )
+    .addOption(new Option('--json', 'Output in JSON format.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await describePolicySet(options.setId, options.json);
-        if (!outcome) process.exitCode = 1;
+        if (options.setId && (await getTokens())) {
+          verboseMessage(
+            `Describing authorization policy set ${options.setId}...`
+          );
+          const outcome = await describePolicySet(options.setId, options.json);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-set-export.ts
+++ b/src/cli/authz/authz-set-export.ts
@@ -9,102 +9,108 @@ import {
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz set export');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz set export');
 
-program
-  .description('Export authorization policy sets.')
-  .addOption(
-    new Option(
-      '-i, --set-id <set-id>',
-      'Policy set id/name. If specified, -a and -A are ignored.'
+  program
+    .description('Export authorization policy sets.')
+    .addOption(
+      new Option(
+        '-i, --set-id <set-id>',
+        'Policy set id/name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all applications/policy sets to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all applications/policy sets to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all applications/policy sets to separate files (*.authz.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all applications/policy sets to separate files (*.authz.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--no-deps',
-      'Do not include any dependencies (policies, scripts).'
+    .addOption(
+      new Option(
+        '--no-deps',
+        'Do not include any dependencies (policies, scripts).'
+      )
     )
-  )
-  .addOption(new Option('--prereqs', 'Include prerequisites (resource types).'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export
-      if (options.setId && (await getTokens())) {
-        verboseMessage('Exporting authorization policy set to file...');
-        const outcome = await exportPolicySetToFile(
-          options.setId,
-          options.file,
-          options.metadata,
-          {
+    .addOption(
+      new Option('--prereqs', 'Include prerequisites (resource types).')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // export
+        if (options.setId && (await getTokens())) {
+          verboseMessage('Exporting authorization policy set to file...');
+          const outcome = await exportPolicySetToFile(
+            options.setId,
+            options.file,
+            options.metadata,
+            {
+              useStringArrays: true,
+              deps: options.deps,
+              prereqs: options.prereqs,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all authorization policy sets to file...');
+          const outcome = await exportPolicySetsToFile(
+            options.file,
+            options.metadata,
+            {
+              useStringArrays: true,
+              deps: options.deps,
+              prereqs: options.prereqs,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A/--all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            'Exporting all authorization policy sets to separate files...'
+          );
+          const outcome = await exportPolicySetsToFiles(options.metadata, {
             useStringArrays: true,
             deps: options.deps,
             prereqs: options.prereqs,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a/--all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all authorization policy sets to file...');
-        const outcome = await exportPolicySetsToFile(
-          options.file,
-          options.metadata,
-          {
-            useStringArrays: true,
-            deps: options.deps,
-            prereqs: options.prereqs,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A/--all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          'Exporting all authorization policy sets to separate files...'
-        );
-        const outcome = await exportPolicySetsToFiles(options.metadata, {
-          useStringArrays: true,
-          deps: options.deps,
-          prereqs: options.prereqs,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-set-import.ts
+++ b/src/cli/authz/authz-set-import.ts
@@ -10,99 +10,107 @@ import {
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz set import');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz set import');
 
-program
-  .description('Import authorization policy sets.')
-  .addOption(
-    new Option(
-      '-i, --set-id <set-id>',
-      'Policy set id/name. If specified, only one policy set is imported and the options -a and -A are ignored.'
+  program
+    .description('Import authorization policy sets.')
+    .addOption(
+      new Option(
+        '-i, --set-id <set-id>',
+        'Policy set id/name. If specified, only one policy set is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all policy sets from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all policy sets from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all policy sets from separate files (*.policyset.authz.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all policy sets from separate files (*.policyset.authz.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--no-deps',
-      'Do not include any dependencies (policies, scripts).'
+    .addOption(
+      new Option(
+        '--no-deps',
+        'Do not include any dependencies (policies, scripts).'
+      )
     )
-  )
-  .addOption(new Option('--prereqs', 'Include prerequisites (resource types).'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import
-      if (options.setId && (await getTokens())) {
-        verboseMessage('Importing authorization policy set from file...');
-        const outcome = await importPolicySetFromFile(
-          options.setId,
-          options.file,
-          {
+    .addOption(
+      new Option('--prereqs', 'Include prerequisites (resource types).')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // import
+        if (options.setId && (await getTokens())) {
+          verboseMessage('Importing authorization policy set from file...');
+          const outcome = await importPolicySetFromFile(
+            options.setId,
+            options.file,
+            {
+              deps: options.deps,
+              prereqs: options.prereqs,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all
+        else if (options.all && (await getTokens())) {
+          verboseMessage(
+            'Importing all authorization policy sets from file...'
+          );
+          const outcome = await importPolicySetsFromFile(options.file, {
             deps: options.deps,
             prereqs: options.prereqs,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A/--all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            'Importing all authorization policy sets from separate files...'
+          );
+          const outcome = await importPolicySetsFromFiles({
+            deps: options.deps,
+            prereqs: options.prereqs,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first policy set from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first authorization policy set from file "${options.file}"...`
+          );
+          const outcome = await importFirstPolicySetFromFile(options.file, {
+            deps: options.deps,
+            prereqs: options.prereqs,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a/--all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Importing all authorization policy sets from file...');
-        const outcome = await importPolicySetsFromFile(options.file, {
-          deps: options.deps,
-          prereqs: options.prereqs,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A/--all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          'Importing all authorization policy sets from separate files...'
-        );
-        const outcome = await importPolicySetsFromFiles({
-          deps: options.deps,
-          prereqs: options.prereqs,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first policy set from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first authorization policy set from file "${options.file}"...`
-        );
-        const outcome = await importFirstPolicySetFromFile(options.file, {
-          deps: options.deps,
-          prereqs: options.prereqs,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-set-list.ts
+++ b/src/cli/authz/authz-set-list.ts
@@ -3,28 +3,30 @@ import { listPolicySets } from '../../ops/PolicySetOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz set list');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz set list');
 
-program.description('List authorization policy sets.').action(
-  // implement command logic inside action handler
-  async (host, realm, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(
-      host,
-      realm,
-      user,
-      password,
-      options,
-      command
-    );
-    if (await getTokens()) {
-      verboseMessage('Listing authorization policy sets...');
-      const outcome = await listPolicySets();
-      if (!outcome) process.exitCode = 1;
-    } else {
-      process.exitCode = 1;
+  program.description('List authorization policy sets.').action(
+    // implement command logic inside action handler
+    async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
+      );
+      if (await getTokens()) {
+        verboseMessage('Listing authorization policy sets...');
+        const outcome = await listPolicySets();
+        if (!outcome) process.exitCode = 1;
+      } else {
+        process.exitCode = 1;
+      }
     }
-  }
-  // end command logic inside action handler
-);
+    // end command logic inside action handler
+  );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-set.ts
+++ b/src/cli/authz/authz-set.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './authz-set-delete.js';
+import DescribeCmd from './authz-set-describe.js';
+import ExportCmd from './authz-set-export.js';
+import ImportCmd from './authz-set-import.js';
+import ListCmd from './authz-set-list.js';
 
-const program = new FrodoStubCommand('frodo authz set').alias('policyset');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo authz set').alias('policyset');
 
-program.description('Manage authorization policy sets.');
+  program.description('Manage authorization policy sets.');
 
-program.command('delete', 'Delete authorization policy sets.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.command('describe', 'Describe authorization policy sets.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export authorization policy sets.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import authorization policy sets.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('list', 'List authorization policy sets.');
+  program.addCommand(ListCmd().name('list'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-type-delete.ts
+++ b/src/cli/authz/authz-type-delete.ts
@@ -9,65 +9,67 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz type delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz type delete');
 
-program
-  .description('Delete authorization resource types.')
-  .addOption(
-    new Option(
-      '-i, --type-id <type-id>',
-      'Variable id. If specified, -a is ignored.'
+  program
+    .description('Delete authorization resource types.')
+    .addOption(
+      new Option(
+        '-i, --type-id <type-id>',
+        'Variable id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-n, --type-name <type-name>',
-      'Resource type name. If specified, -a is ignored.'
+    .addOption(
+      new Option(
+        '-n, --type-name <type-name>',
+        'Resource type name. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Delete all resource types in a realm. Ignored with -i and -n.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all resource types in a realm. Ignored with -i and -n.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by uuid
-      if (options.typeId && (await getTokens())) {
-        verboseMessage('Deleting authorization resource type...');
-        const outcome = await deleteResourceTypeById(options.typeId);
-        if (!outcome) process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // delete by uuid
+        if (options.typeId && (await getTokens())) {
+          verboseMessage('Deleting authorization resource type...');
+          const outcome = await deleteResourceTypeById(options.typeId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // delete by name
+        else if (options.typeName && (await getTokens())) {
+          verboseMessage('Deleting authorization resource type...');
+          const outcome = await deleteResourceTypeUsingName(options.typeName);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all authorization resource types...');
+          const outcome = await deleteResourceTypes();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // delete by name
-      else if (options.typeName && (await getTokens())) {
-        verboseMessage('Deleting authorization resource type...');
-        const outcome = await deleteResourceTypeUsingName(options.typeName);
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all authorization resource types...');
-        const outcome = await deleteResourceTypes();
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-type-describe.ts
+++ b/src/cli/authz/authz-type-describe.ts
@@ -8,47 +8,51 @@ import {
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz type describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz type describe');
 
-program
-  .description('Describe authorization resource types.')
-  .addOption(new Option('-i, --type-id <type-uuid>', 'Resource type uuid.'))
-  .addOption(new Option('-n, --type-name <type-name>', 'Resource type name.'))
-  .addOption(new Option('--json', 'Output in JSON format.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (options.typeId && (await getTokens())) {
-        verboseMessage(`Describing authorization resource type by uuid...`);
-        const outcome = await describeResourceType(
-          options.typeId,
-          options.json
+  program
+    .description('Describe authorization resource types.')
+    .addOption(new Option('-i, --type-id <type-uuid>', 'Resource type uuid.'))
+    .addOption(new Option('-n, --type-name <type-name>', 'Resource type name.'))
+    .addOption(new Option('--json', 'Output in JSON format.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else if (options.typeName && (await getTokens())) {
-        verboseMessage(`Describing authorization resource type by name...`);
-        const outcome = await describeResourceTypeByName(
-          options.typeName,
-          options.json
-        );
-        if (!outcome) process.exitCode = 1;
+        if (options.typeId && (await getTokens())) {
+          verboseMessage(`Describing authorization resource type by uuid...`);
+          const outcome = await describeResourceType(
+            options.typeId,
+            options.json
+          );
+          if (!outcome) process.exitCode = 1;
+        } else if (options.typeName && (await getTokens())) {
+          verboseMessage(`Describing authorization resource type by name...`);
+          const outcome = await describeResourceTypeByName(
+            options.typeName,
+            options.json
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-type-export.ts
+++ b/src/cli/authz/authz-type-export.ts
@@ -10,97 +10,103 @@ import {
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz type export');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz type export');
 
-program
-  .description('Export authorization resource types.')
-  .addOption(
-    new Option(
-      '-i, --type-id <type-uuid>',
-      'Resource type uuid. If specified, -a and -A are ignored.'
+  program
+    .description('Export authorization resource types.')
+    .addOption(
+      new Option(
+        '-i, --type-id <type-uuid>',
+        'Resource type uuid. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-n, --type-name <type-name>',
-      'Resource type name. If specified, -a and -A are ignored.'
+    .addOption(
+      new Option(
+        '-n, --type-name <type-name>',
+        'Resource type name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all resource types to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all resource types to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all resource types to separate files (*.resourcetype.authz.json) in the current directory. Ignored with -i, -n, or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all resource types to separate files (*.resourcetype.authz.json) in the current directory. Ignored with -i, -n, or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by uuid
-      if (options.typeId && (await getTokens())) {
-        verboseMessage('Exporting authorization resource type to file...');
-        const outcome = await exportResourceTypeToFile(
-          options.typeId,
-          options.file,
-          options.metadata
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // export by uuid
+        if (options.typeId && (await getTokens())) {
+          verboseMessage('Exporting authorization resource type to file...');
+          const outcome = await exportResourceTypeToFile(
+            options.typeId,
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // export by name
+        else if (options.typeName && (await getTokens())) {
+          verboseMessage('Exporting authorization resource type to file...');
+          const outcome = await exportResourceTypeByNameToFile(
+            options.typeName,
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a/--all
+        else if (options.all && (await getTokens())) {
+          verboseMessage(
+            'Exporting all authorization resource types to file...'
+          );
+          const outcome = await exportResourceTypesToFile(
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A/--all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            'Exporting all authorization resource types to separate files...'
+          );
+          const outcome = await exportResourceTypesToFiles(options.metadata);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // export by name
-      else if (options.typeName && (await getTokens())) {
-        verboseMessage('Exporting authorization resource type to file...');
-        const outcome = await exportResourceTypeByNameToFile(
-          options.typeName,
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -a/--all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all authorization resource types to file...');
-        const outcome = await exportResourceTypesToFile(
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A/--all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          'Exporting all authorization resource types to separate files...'
-        );
-        const outcome = await exportResourceTypesToFiles(options.metadata);
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-type-list.ts
+++ b/src/cli/authz/authz-type-list.ts
@@ -5,33 +5,35 @@ import { listResourceTypes } from '../../ops/ResourceTypeOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo authz type list');
+export default function setup() {
+  const program = new FrodoCommand('frodo authz type list');
 
-program
-  .description('List authorization resource types.')
-  .addOption(
-    new Option('-l, --long', 'Long with more fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Listing resource types...');
-        const outcome = await listResourceTypes(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List authorization resource types.')
+    .addOption(
+      new Option('-l, --long', 'Long with more fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage('Listing resource types...');
+          const outcome = await listResourceTypes(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz-type.ts
+++ b/src/cli/authz/authz-type.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './authz-type-delete.js';
+import DescribeCmd from './authz-type-describe.js';
+import ExportCmd from './authz-type-export.js';
+import ImportCmd from './authz-type-import.js';
+import ListCmd from './authz-type-list.js';
 
-const program = new FrodoStubCommand('frodo authz type');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo authz type');
 
-program.description('Manage authorization resource types.');
+  program.description('Manage authorization resource types.');
 
-program.command('delete', 'Delete authorization resource types.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.command('describe', 'Describe authorization resource types.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export authorization resource types.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import authorization resource types.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.command('list', 'List authorization resource types.');
+  program.addCommand(ListCmd().name('list'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/authz/authz.ts
+++ b/src/cli/authz/authz.ts
@@ -1,22 +1,18 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import PolicyCmd from './authz-policy.js';
+import SetCmd from './authz-set.js';
+import TypeCmd from './authz-type.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('authz')
-    .description(
-      'Manage authotiztion policies, policy sets, and resource types.'
-    )
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('authz').description(
+    'Manage authotiztion policies, policy sets, and resource types.'
+  );
 
-  program.command('set', 'Manage policy sets.');
+  program.addCommand(SetCmd().name('set'));
 
-  program.command('policy', 'Manages policies.');
+  program.addCommand(PolicyCmd().name('policy'));
 
-  program.command('type', 'Manage resource types.');
+  program.addCommand(TypeCmd().name('type'));
 
   return program;
 }

--- a/src/cli/config/config-delete.ts
+++ b/src/cli/config/config-delete.ts
@@ -3,43 +3,48 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo config delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo config delete');
 
-program
-  .description('Delete full cloud configuration.')
-  .addOption(
-    new Option(
-      '-i, --config-id <config-id>',
-      'Configuration id. If specified, -a and -A are ignored.'
+  program
+    .description('Delete full cloud configuration.')
+    .addOption(
+      new Option(
+        '-i, --config-id <config-id>',
+        'Configuration id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete full cloud configuration. Ignored with -i.')
-  )
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete full cloud configuration. Ignored with -i.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/config/config-describe.ts
+++ b/src/cli/config/config-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo config describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo config describe');
 
-program
-  .description('Describe full cloud configuration.')
-  .addOption(new Option('-i, --config-id <config-id>', 'Configuration id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe full cloud configuration.')
+    .addOption(new Option('-i, --config-id <config-id>', 'Configuration id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/config/config-export.ts
+++ b/src/cli/config/config-export.ts
@@ -9,114 +9,118 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo config export');
+export default function setup() {
+  const program = new FrodoCommand('frodo config export');
 
-program
-  .description(
-    'Export full cloud configuration for all ops that currently support export.'
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(new Option('-a, --all', 'Export everything to a single file.'))
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export everything to separate files in the -D directory. Ignored with -a.'
+  program
+    .description(
+      'Export full cloud configuration for all ops that currently support export.'
     )
-  )
-  .addOption(
-    new Option(
-      '--use-string-arrays',
-      'Where applicable, use string arrays to store multi-line text (e.g. scripts).'
-    ).default(false, 'off')
-  )
-  .addOption(
-    new Option(
-      '--no-decode',
-      'Do not include decoded variable value in variable export'
-    ).default(false, 'false')
-  )
-  .addOption(
-    new Option(
-      '-x, --extract',
-      'Extract scripts from the exported file, and save it to a separate file. Ignored with -a.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(new Option('-a, --all', 'Export everything to a single file.'))
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export everything to separate files in the -D directory. Ignored with -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '--use-string-arrays',
+        'Where applicable, use string arrays to store multi-line text (e.g. scripts).'
+      ).default(false, 'off')
     )
-  )
-  .addOption(
-    new Option(
-      '--no-coords',
-      'Do not include the x and y coordinate positions of the journey/tree nodes.'
+    .addOption(
+      new Option(
+        '--no-decode',
+        'Do not include decoded variable value in variable export'
+      ).default(false, 'false')
     )
-  )
-  .addOption(
-    new Option(
-      '-d, --default',
-      'Export all scripts including the default scripts.'
+    .addOption(
+      new Option(
+        '-x, --extract',
+        'Extract scripts from the exported file, and save it to a separate file. Ignored with -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // --all -a
-      if (options.all && (await getTokens())) {
-        verboseMessage('Exporting everything to a single file...');
-        const outcome = await exportEverythingToFile(
-          options.file,
-          options.metadata,
-          {
-            useStringArrays: options.useStringArrays,
-            noDecode: options.decode,
-            coords: options.coords,
-            includeDefault: options.default,
-          }
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--no-coords',
+        'Do not include the x and y coordinate positions of the journey/tree nodes.'
+      )
+    )
+    .addOption(
+      new Option(
+        '-d, --default',
+        'Export all scripts including the default scripts.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // --all -a
+        if (options.all && (await getTokens())) {
+          verboseMessage('Exporting everything to a single file...');
+          const outcome = await exportEverythingToFile(
+            options.file,
+            options.metadata,
+            {
+              useStringArrays: options.useStringArrays,
+              noDecode: options.decode,
+              coords: options.coords,
+              includeDefault: options.default,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // require --directory -D for all-separate function
+        else if (options.allSeparate && !state.getDirectory()) {
+          printMessage(
+            '-D or --directory required when using -A or --all-separate',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting everything to separate files...');
+          const outcome = await exportEverythingToFiles(
+            options.extract,
+            options.metadata,
+            {
+              useStringArrays: options.useStringArrays,
+              noDecode: options.decode,
+              coords: options.coords,
+              includeDefault: options.default,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // require --directory -D for all-separate function
-      else if (options.allSeparate && !state.getDirectory()) {
-        printMessage(
-          '-D or --directory required when using -A or --all-separate',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting everything to separate files...');
-        const outcome = await exportEverythingToFiles(
-          options.extract,
-          options.metadata,
-          {
-            useStringArrays: options.useStringArrays,
-            noDecode: options.decode,
-            coords: options.coords,
-            includeDefault: options.default,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/config/config-import.ts
+++ b/src/cli/config/config-import.ts
@@ -9,113 +9,117 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo config import');
+export default function setup() {
+  const program = new FrodoCommand('frodo config import');
 
-program
-  .description('Import full cloud configuration.')
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all configuration from the single file -f. Ignored with -i.'
+  program
+    .description('Import full cloud configuration.')
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all configuration from the single file -f. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all configuration from separate (.json) files in the (working) directory -D. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all configuration from separate (.json) files in the (working) directory -D. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option('-C, --clean', 'Remove existing service(s) before importing.')
-  )
-  .addOption(
-    new Option('-g, --global', 'Import service(s) as global service(s).')
-  )
-  .addOption(
-    new Option(
-      '-r, --current-realm',
-      'Import service(s) into the current realm.'
+    .addOption(
+      new Option('-C, --clean', 'Remove existing service(s) before importing.')
     )
-  )
-  .addOption(
-    new Option(
-      '--re-uuid-journeys',
-      'Generate new UUIDs for all journey nodes during import.'
-    ).default(false, 'off')
-  )
-  .addOption(
-    new Option(
-      '--re-uuid-scripts',
-      'Create new UUIDs for the scripts upon import. Use this to duplicate scripts or create a new versions of the same scripts.'
-    ).default(false, 'off')
-  )
-  .addOption(
-    new Option(
-      '-d, --default',
-      'Import all scripts including the default scripts.'
+    .addOption(
+      new Option('-g, --global', 'Import service(s) as global service(s).')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // Require --file -f for all function
-      if (options.all && !options.file) {
-        printMessage('-f or --file required when using -a or --all', 'error');
-        program.help();
-        process.exitCode = 1;
-      }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting everything from a single file...');
-        const outcome = await importEverythingFromFile(options.file, {
-          reUuidJourneys: options.reUuidJourneys,
-          reUuidScripts: options.reUuidScripts,
-          cleanServices: options.clean,
-          global: options.global,
-          realm: options.realm,
-          includeDefault: options.default,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // require --directory -D for all-separate function
-      else if (options.allSeparate && !state.getDirectory()) {
-        printMessage(
-          '-D or --directory required when using -A or --all-separate',
-          'error'
+    .addOption(
+      new Option(
+        '-r, --current-realm',
+        'Import service(s) into the current realm.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--re-uuid-journeys',
+        'Generate new UUIDs for all journey nodes during import.'
+      ).default(false, 'off')
+    )
+    .addOption(
+      new Option(
+        '--re-uuid-scripts',
+        'Create new UUIDs for the scripts upon import. Use this to duplicate scripts or create a new versions of the same scripts.'
+      ).default(false, 'off')
+    )
+    .addOption(
+      new Option(
+        '-d, --default',
+        'Import all scripts including the default scripts.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        program.help();
-        process.exitCode = 1;
+        // Require --file -f for all function
+        if (options.all && !options.file) {
+          printMessage('-f or --file required when using -a or --all', 'error');
+          program.help();
+          process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting everything from a single file...');
+          const outcome = await importEverythingFromFile(options.file, {
+            reUuidJourneys: options.reUuidJourneys,
+            reUuidScripts: options.reUuidScripts,
+            cleanServices: options.clean,
+            global: options.global,
+            realm: options.realm,
+            includeDefault: options.default,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // require --directory -D for all-separate function
+        else if (options.allSeparate && !state.getDirectory()) {
+          printMessage(
+            '-D or --directory required when using -A or --all-separate',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Importing everything from separate files...');
+          const outcome = await importEverythingFromFiles({
+            reUuidJourneys: options.reUuidJourneys,
+            reUuidScripts: options.reUuidScripts,
+            cleanServices: options.clean,
+            global: options.global,
+            realm: options.realm,
+            includeDefault: options.default,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          verboseMessage(
+            'Unrecognized combination of options or no options...'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all-separate -A
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Importing everything from separate files...');
-        const outcome = await importEverythingFromFiles({
-          reUuidJourneys: options.reUuidJourneys,
-          reUuidScripts: options.reUuidScripts,
-          cleanServices: options.clean,
-          global: options.global,
-          realm: options.realm,
-          includeDefault: options.default,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        verboseMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/config/config-list.ts
+++ b/src/cli/config/config-list.ts
@@ -3,31 +3,33 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo config list');
+export default function setup() {
+  const program = new FrodoCommand('frodo config list');
 
-program
-  .description('List full cloud configuration.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List full cloud configuration.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/config/config.ts
+++ b/src/cli/config/config.ts
@@ -1,30 +1,24 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+//import ListCmd from './config-list.js';
+//import DescribeCmd from './config-describe.js';
+import ExportCmd from './config-export.js';
+import ImportCmd from './config-import.js';
+//import DeleteCmd from './config-delete.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('config')
-    .description('Manage full cloud configuration.')
-    .executableDir(__dirname);
-
-  //program.command('list', 'List full cloud configuration.');
-
-  //program.command('describe', 'Describe full cloud configuration.');
-
-  program.command(
-    'export',
-    'Export full cloud configuration for all ops that currently support export..'
+  const program = new FrodoStubCommand('config').description(
+    'Manage full cloud configuration.'
   );
 
-  program.command(
-    'import',
-    'Import full cloud configuration for all ops that currently support import.'
-  );
+  //program.addCommand(ListCmd().name('list'));
 
-  //program.command('delete', 'Delete full cloud configuration.');
+  //program.addCommand(DescribeCmd().name('describe'));
+
+  program.addCommand(ExportCmd().name('export'));
+
+  program.addCommand(ImportCmd().name('import'));
+
+  //program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/conn/conn-delete.ts
+++ b/src/cli/conn/conn-delete.ts
@@ -3,27 +3,29 @@ import { frodo } from '@rockcarver/frodo-lib';
 import { printError, printMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo conn delete', [
-  'realm',
-  'username',
-  'password',
-  'type',
-  'insecure',
-  'curlirize',
-]);
+export default function setup() {
+  const program = new FrodoCommand('frodo conn delete', [
+    'realm',
+    'username',
+    'password',
+    'type',
+    'insecure',
+    'curlirize',
+  ]);
 
-program.description('Delete connection profiles.').action(
-  // implement command logic inside action handler
-  async (host, options, command) => {
-    command.handleDefaultArgsAndOpts(host, options, command);
-    try {
-      frodo.conn.deleteConnectionProfile(host);
-      printMessage(`Deleted connection profile ${host}`);
-    } catch (error) {
-      printError(error);
+  program.description('Delete connection profiles.').action(
+    // implement command logic inside action handler
+    async (host, options, command) => {
+      command.handleDefaultArgsAndOpts(host, options, command);
+      try {
+        frodo.conn.deleteConnectionProfile(host);
+        printMessage(`Deleted connection profile ${host}`);
+      } catch (error) {
+        printError(error);
+      }
     }
-  }
-  // end command logic inside action handler
-);
+    // end command logic inside action handler
+  );
 
-program.parse();
+  return program;
+}

--- a/src/cli/conn/conn-describe.ts
+++ b/src/cli/conn/conn-describe.ts
@@ -3,25 +3,27 @@ import { Option } from 'commander';
 import { describeConnectionProfile } from '../../ops/ConnectionProfileOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo conn describe', [
-  'realm',
-  'username',
-  'password',
-  'type',
-  'insecure',
-  'curlirize',
-]);
+export default function setup() {
+  const program = new FrodoCommand('frodo conn describe', [
+    'realm',
+    'username',
+    'password',
+    'type',
+    'insecure',
+    'curlirize',
+  ]);
 
-program
-  .description('Describe connection profile.')
-  .addOption(new Option('--show-secrets', 'Show passwords and secrets.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, options, command) => {
-      command.handleDefaultArgsAndOpts(host, options, command);
-      describeConnectionProfile(host, options.showSecrets);
-    }
-    // end command logic inside action handler
-  );
+  program
+    .description('Describe connection profile.')
+    .addOption(new Option('--show-secrets', 'Show passwords and secrets.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, options, command) => {
+        command.handleDefaultArgsAndOpts(host, options, command);
+        describeConnectionProfile(host, options.showSecrets);
+      }
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/conn/conn-list.ts
+++ b/src/cli/conn/conn-list.ts
@@ -3,28 +3,30 @@ import { Option } from 'commander';
 import { listConnectionProfiles } from '../../ops/ConnectionProfileOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo conn list', [
-  'host',
-  'realm',
-  'username',
-  'password',
-  'type',
-  'insecure',
-  'curlirize',
-]);
+export default function setup() {
+  const program = new FrodoCommand('frodo conn list', [
+    'host',
+    'realm',
+    'username',
+    'password',
+    'type',
+    'insecure',
+    'curlirize',
+  ]);
 
-program
-  .description('List connection profiles.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (options, command) => {
-      command.handleDefaultArgsAndOpts(options, command);
-      listConnectionProfiles(options.long);
-    }
-    // end command logic inside action handler
-  );
+  program
+    .description('List connection profiles.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (options, command) => {
+        command.handleDefaultArgsAndOpts(options, command);
+        listConnectionProfiles(options.long);
+      }
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/conn/conn-save.ts
+++ b/src/cli/conn/conn-save.ts
@@ -12,192 +12,203 @@ const { CLOUD_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
 const { isServiceAccountsFeatureAvailable } = frodo.cloud.serviceAccount;
 const { addNewServiceAccount, saveConnectionProfile } = frodo.conn;
 
-const program = new FrodoCommand('frodo conn save', ['realm']);
+export default function setup() {
+  const program = new FrodoCommand('frodo conn save', ['realm']);
 
-program
-  .alias('add')
-  .description('Save connection profiles.')
-  .addOption(new Option('--no-sa', 'Do not create and add service account.'))
-  .addOption(
-    new Option(
-      '--log-api-key [key]',
-      'Log API key. If specified, must also include --log-api-secret. Ignored with --no-log-api.'
+  program
+    .alias('add')
+    .description('Save connection profiles.')
+    .addOption(new Option('--no-sa', 'Do not create and add service account.'))
+    .addOption(
+      new Option(
+        '--log-api-key [key]',
+        'Log API key. If specified, must also include --log-api-secret. Ignored with --no-log-api.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--log-api-secret [secret]',
-      'Log API secret. If specified, must also include --log-api-key. Ignored with --no-log-api.'
+    .addOption(
+      new Option(
+        '--log-api-secret [secret]',
+        'Log API secret. If specified, must also include --log-api-key. Ignored with --no-log-api.'
+      )
     )
-  )
-  .addOption(
-    new Option('--no-log-api', 'Do not create and add log API key and secret.')
-  )
-  .addOption(new Option('--no-validate', 'Do not validate connection.'))
-  .addOption(
-    new Option(
-      '--authentication-service [service]',
-      'Name of the authentication service/tree to use.'
+    .addOption(
+      new Option(
+        '--no-log-api',
+        'Do not create and add log API key and secret.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--authentication-header-overrides [headers]',
-      'Map of headers: {"host":"am.example.com:8081"}.'
+    .addOption(new Option('--no-validate', 'Do not validate connection.'))
+    .addOption(
+      new Option(
+        '--authentication-service [service]',
+        'Name of the authentication service/tree to use.'
+      )
     )
-  )
-  .addHelpText(
-    'after',
-    `Usage Examples:\n` +
-      `  Create a connection profile with a new log API key and secret and a new service account:\n` +
-      `  $ frodo conn save ${s.amBaseUrl} ${s.username} '${s.password}'\n`[
-        'brightCyan'
-      ] +
-      `  Save an existing service account to an existing or new connection profile:\n` +
-      `  $ frodo conn save --sa-id ${s.saId} --sa-jwk-file ${s.saJwkFile} ${s.amBaseUrl}'\n`[
-        'brightCyan'
-      ] +
-      `  Save an existing service account to an existing connection profile (partial host URL only updates an existing profile):\n` +
-      `  $ frodo conn save --sa-id ${s.saId} --sa-jwk-file ${s.saJwkFile} ${s.connId}'\n`[
-        'brightCyan'
-      ]
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(host, user, password, options, command);
-      state.setLogApiKey(options.logApiKey);
-      state.setLogApiSecret(options.logApiSecret);
-      if (options.authenticationService) {
-        state.setAuthenticationService(options.authenticationService);
-      }
-      if (options.authenticationHeaderOverrides) {
-        state.setAuthenticationHeaderOverrides(
-          JSON.parse(options.authenticationHeaderOverrides)
+    .addOption(
+      new Option(
+        '--authentication-header-overrides [headers]',
+        'Map of headers: {"host":"am.example.com:8081"}.'
+      )
+    )
+    .addHelpText(
+      'after',
+      `Usage Examples:\n` +
+        `  Create a connection profile with a new log API key and secret and a new service account:\n` +
+        `  $ frodo conn save ${s.amBaseUrl} ${s.username} '${s.password}'\n`[
+          'brightCyan'
+        ] +
+        `  Save an existing service account to an existing or new connection profile:\n` +
+        `  $ frodo conn save --sa-id ${s.saId} --sa-jwk-file ${s.saJwkFile} ${s.amBaseUrl}'\n`[
+          'brightCyan'
+        ] +
+        `  Save an existing service account to an existing connection profile (partial host URL only updates an existing profile):\n` +
+        `  $ frodo conn save --sa-id ${s.saId} --sa-jwk-file ${s.saJwkFile} ${s.connId}'\n`[
+          'brightCyan'
+        ]
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          user,
+          password,
+          options,
+          command
         );
-      }
-      const needSa =
-        options.sa &&
-        !state.getServiceAccountId() &&
-        !state.getServiceAccountJwk();
-      const needLogApiKey =
-        options.logApi &&
-        !state.getLogApiKey() &&
-        !state.getLogApiSecret() &&
-        needSa;
-      const forceLoginAsUser = needSa || needLogApiKey;
-      if (
-        (options.validate && (await getTokens(forceLoginAsUser))) ||
-        !options.validate
-      ) {
-        verboseMessage(
-          `Saving connection profile for tenant ${state.getHost()}...`
-        );
-        // if cloud deployment add service account
-        if (
-          options.validate &&
-          state.getDeploymentType() === CLOUD_DEPLOYMENT_TYPE_KEY &&
-          options.sa &&
-          (await isServiceAccountsFeatureAvailable())
-        ) {
-          // validate and add existing service account
-          if (options.saId && options.saJwkFile) {
-            verboseMessage(`Validating and adding service account...`);
-            if (
-              await addExistingServiceAccount(
-                options.saId,
-                options.saJwkFile,
-                options.validate
-              )
-            ) {
-              printMessage(
-                `Validated and added service account with id ${options.saId} to profile.`
-              );
-            }
-          }
-          // add new service account if none already exists in the profile
-          else if (!state.getServiceAccountId()) {
-            try {
-              verboseMessage(`Creating service account...`);
-              const sa = await addNewServiceAccount();
-              printMessage(
-                `Created and added service account ${sa.name} with id ${sa._id} to profile.`
-              );
-            } catch (error) {
-              printError(error);
-              process.exitCode = 1;
-            }
-          }
+        state.setLogApiKey(options.logApiKey);
+        state.setLogApiSecret(options.logApiSecret);
+        if (options.authenticationService) {
+          state.setAuthenticationService(options.authenticationService);
         }
-        // add existing service account without validation
-        else if (
-          !options.validate &&
-          options.saId &&
-          options.saJwkFile &&
-          options.sa
-        ) {
-          addExistingServiceAccount(
-            options.saId,
-            options.saJwkFile,
-            options.validate
+        if (options.authenticationHeaderOverrides) {
+          state.setAuthenticationHeaderOverrides(
+            JSON.parse(options.authenticationHeaderOverrides)
           );
         }
-        // if cloud deployment add log api key and secret
-        verboseMessage(options);
-        verboseMessage(state);
+        const needSa =
+          options.sa &&
+          !state.getServiceAccountId() &&
+          !state.getServiceAccountJwk();
+        const needLogApiKey =
+          options.logApi &&
+          !state.getLogApiKey() &&
+          !state.getLogApiSecret() &&
+          needSa;
+        const forceLoginAsUser = needSa || needLogApiKey;
         if (
-          options.validate &&
-          state.getDeploymentType() === CLOUD_DEPLOYMENT_TYPE_KEY &&
-          needLogApiKey
+          (options.validate && (await getTokens(forceLoginAsUser))) ||
+          !options.validate
         ) {
-          // validate and add existing log api key and secret
-          if (options.logApiKey && options.logApiSecret) {
-            verboseMessage(`Validating and adding log api key and secret...`);
-            if (
-              await addExistingServiceAccount(
-                options.logApiKey,
-                options.logApiSecret,
-                options.validate
-              )
-            ) {
-              printMessage(
-                `Added log API key ${options.logApiKey} to profile.`
-              );
+          verboseMessage(
+            `Saving connection profile for tenant ${state.getHost()}...`
+          );
+          // if cloud deployment add service account
+          if (
+            options.validate &&
+            state.getDeploymentType() === CLOUD_DEPLOYMENT_TYPE_KEY &&
+            options.sa &&
+            (await isServiceAccountsFeatureAvailable())
+          ) {
+            // validate and add existing service account
+            if (options.saId && options.saJwkFile) {
+              verboseMessage(`Validating and adding service account...`);
+              if (
+                await addExistingServiceAccount(
+                  options.saId,
+                  options.saJwkFile,
+                  options.validate
+                )
+              ) {
+                printMessage(
+                  `Validated and added service account with id ${options.saId} to profile.`
+                );
+              }
+            }
+            // add new service account if none already exists in the profile
+            else if (!state.getServiceAccountId()) {
+              try {
+                verboseMessage(`Creating service account...`);
+                const sa = await addNewServiceAccount();
+                printMessage(
+                  `Created and added service account ${sa.name} with id ${sa._id} to profile.`
+                );
+              } catch (error) {
+                printError(error);
+                process.exitCode = 1;
+              }
             }
           }
-          // add new log api key and secret if none already exists in the profile
-          else if (!state.getLogApiKey()) {
-            try {
-              const creds = await provisionCreds();
-              state.setLogApiKey(creds.api_key_id as string);
-              state.setLogApiSecret(creds.api_key_secret as string);
-              printMessage(
-                `Created log API key ${creds.api_key_id} and secret.`
-              );
-            } catch (error) {
-              printMessage(error.response?.data, 'error');
-              printMessage(
-                `Error creating log API key and secret: ${error.response?.data?.message}`,
-                'error'
-              );
-              process.exitCode = 1;
+          // add existing service account without validation
+          else if (
+            !options.validate &&
+            options.saId &&
+            options.saJwkFile &&
+            options.sa
+          ) {
+            addExistingServiceAccount(
+              options.saId,
+              options.saJwkFile,
+              options.validate
+            );
+          }
+          // if cloud deployment add log api key and secret
+          verboseMessage(options);
+          verboseMessage(state);
+          if (
+            options.validate &&
+            state.getDeploymentType() === CLOUD_DEPLOYMENT_TYPE_KEY &&
+            needLogApiKey
+          ) {
+            // validate and add existing log api key and secret
+            if (options.logApiKey && options.logApiSecret) {
+              verboseMessage(`Validating and adding log api key and secret...`);
+              if (
+                await addExistingServiceAccount(
+                  options.logApiKey,
+                  options.logApiSecret,
+                  options.validate
+                )
+              ) {
+                printMessage(
+                  `Added log API key ${options.logApiKey} to profile.`
+                );
+              }
+            }
+            // add new log api key and secret if none already exists in the profile
+            else if (!state.getLogApiKey()) {
+              try {
+                const creds = await provisionCreds();
+                state.setLogApiKey(creds.api_key_id as string);
+                state.setLogApiSecret(creds.api_key_secret as string);
+                printMessage(
+                  `Created log API key ${creds.api_key_id} and secret.`
+                );
+              } catch (error) {
+                printMessage(error.response?.data, 'error');
+                printMessage(
+                  `Error creating log API key and secret: ${error.response?.data?.message}`,
+                  'error'
+                );
+                process.exitCode = 1;
+              }
             }
           }
-        }
-        // add existing log api key and secret without validation
-        // storing log API key and secret in the connection profile is happening default, therefore no code required here
-        try {
-          await saveConnectionProfile(host);
-          printMessage(`Saved connection profile ${state.getHost()}`);
-        } catch (error) {
-          printError(error);
+          // add existing log api key and secret without validation
+          // storing log API key and secret in the connection profile is happening default, therefore no code required here
+          try {
+            await saveConnectionProfile(host);
+            printMessage(`Saved connection profile ${state.getHost()}`);
+          } catch (error) {
+            printError(error);
+            process.exitCode = 1;
+          }
+        } else {
           process.exitCode = 1;
         }
-      } else {
-        process.exitCode = 1;
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/conn/conn.ts
+++ b/src/cli/conn/conn.ts
@@ -1,25 +1,23 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './conn-delete.js';
+import DescribeCmd from './conn-describe.js';
+import ListCmd from './conn-list.js';
+import SaveCmd from './conn-save.js';
 
 export default function setup() {
   const program = new FrodoStubCommand('conn')
     .alias('connection')
     // for backwards compatibility
     .alias('connections')
-    .description('Manage connection profiles.')
-    .executableDir(__dirname);
+    .description('Manage connection profiles.');
 
-  program.command('save', 'Save connection profiles.').alias('add');
+  program.addCommand(SaveCmd().name('save'));
 
-  program.command('delete', 'Delete connection profiles.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-  program.command('describe', 'Describe connection profiles.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('list', 'List connection profiles.');
+  program.addCommand(ListCmd().name('list'));
 
   return program;
 }

--- a/src/cli/email/email-template-export.ts
+++ b/src/cli/email/email-template-export.ts
@@ -10,91 +10,93 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo email template export');
+export default function setup() {
+  const program = new FrodoCommand('frodo email template export');
 
-program
-  .description('Export email templates.')
-  .addOption(
-    new Option(
-      '-i, --template-id <template-id>',
-      'Email template id/name. If specified, -a and -A are ignored.'
+  program
+    .description('Export email templates.')
+    .addOption(
+      new Option(
+        '-i, --template-id <template-id>',
+        'Email template id/name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the export file. Ignored with -A. Defaults to <template-id>.template.email.json.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the export file. Ignored with -A. Defaults to <template-id>.template.email.json.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all email templates to a single file. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all email templates to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all email templates as separate files <template-id>.template.email.json. Ignored with -i, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all email templates as separate files <template-id>.template.email.json. Ignored with -i, and -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by id/name
-      if (options.templateId && (await getTokens())) {
-        verboseMessage(
-          `Exporting email template "${
-            options.templateId
-          }" from realm "${state.getRealm()}"...`
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await exportEmailTemplateToFile(
-          options.templateId,
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
+        // export by id/name
+        if (options.templateId && (await getTokens())) {
+          verboseMessage(
+            `Exporting email template "${
+              options.templateId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportEmailTemplateToFile(
+            options.templateId,
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all email templates to a single file...');
+          const outcome = await exportEmailTemplatesToFile(
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all email templates to separate files...');
+          const outcome = await exportEmailTemplatesToFiles(options.metadata);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all email templates to a single file...');
-        const outcome = await exportEmailTemplatesToFile(
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all email templates to separate files...');
-        const outcome = await exportEmailTemplatesToFiles(options.metadata);
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/email/email-template-import.ts
+++ b/src/cli/email/email-template-import.ts
@@ -10,94 +10,96 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo email template import');
+export default function setup() {
+  const program = new FrodoCommand('frodo email template import');
 
-program
-  .description('Import email templates.')
-  .addOption(
-    new Option(
-      '-i, --template-id <template-id>',
-      'Email template id/name. If specified, -a and -A are ignored.'
+  program
+    .description('Import email templates.')
+    .addOption(
+      new Option(
+        '-i, --template-id <template-id>',
+        'Email template id/name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the import file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all email templates from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the import file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all email templates from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all email templates from separate files (*.template.email.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all email templates from separate files (*.template.email.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--raw',
-      "Import raw email template files. Raw templates do not contain the id/name, therefore when using -A or -f without -i, the email template id/name is parsed from the file name; Make sure your template files are named 'emailTemplate-<id/name>.json' or use -f with -i. Ignored with -a."
+    .addOption(
+      new Option(
+        '--raw',
+        "Import raw email template files. Raw templates do not contain the id/name, therefore when using -A or -f without -i, the email template id/name is parsed from the file name; Make sure your template files are named 'emailTemplate-<id/name>.json' or use -f with -i. Ignored with -a."
+      )
     )
-  )
-  .action(
-    // implement program logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import by id
-      if (options.file && options.templateId && (await getTokens())) {
-        verboseMessage(`Importing email template "${options.templateId}"...`);
-        const outcome = await importEmailTemplateFromFile(
-          options.templateId,
-          options.file,
-          options.raw
+    .action(
+      // implement program logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // import by id
+        if (options.file && options.templateId && (await getTokens())) {
+          verboseMessage(`Importing email template "${options.templateId}"...`);
+          const outcome = await importEmailTemplateFromFile(
+            options.templateId,
+            options.file,
+            options.raw
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing all email templates from a single file (${options.file})...`
+          );
+          const outcome = await importEmailTemplatesFromFile(options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          verboseMessage(
+            'Importing all email templates from separate files (*.template.email.json) in current directory...'
+          );
+          const outcome = await importEmailTemplatesFromFiles(options.raw);
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first template from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first email template from file "${options.file}"...`
+          );
+          const outcome = await importFirstEmailTemplateFromFile(
+            options.file,
+            options.raw
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing all email templates from a single file (${options.file})...`
-        );
-        const outcome = await importEmailTemplatesFromFile(options.file);
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        verboseMessage(
-          'Importing all email templates from separate files (*.template.email.json) in current directory...'
-        );
-        const outcome = await importEmailTemplatesFromFiles(options.raw);
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first template from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first email template from file "${options.file}"...`
-        );
-        const outcome = await importFirstEmailTemplateFromFile(
-          options.file,
-          options.raw
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end program logic inside action handler
-  );
+      // end program logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/email/email-template-list.ts
+++ b/src/cli/email/email-template-list.ts
@@ -5,33 +5,35 @@ import { listEmailTemplates } from '../../ops/EmailTemplateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo email template list');
+export default function setup() {
+  const program = new FrodoCommand('frodo email template list');
 
-program
-  .description('List email templates.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Listing email templates ...`);
-        const outcome = await listEmailTemplates(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List email templates.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Listing email templates ...`);
+          const outcome = await listEmailTemplates(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/email/email-template.ts
+++ b/src/cli/email/email-template.ts
@@ -1,13 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import ExportCmd from './email-template-export.js';
+import ImportCmd from './email-template-import.js';
+import ListCmd from './email-template-list.js';
 
-const program = new FrodoStubCommand('frodo email template');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo email template');
 
-program.description('Manage email templates.');
+  program.description('Manage email templates.');
 
-program.command('list', 'List email templates.');
+  program.addCommand(
+    ListCmd().name('list').description('List email templates.')
+  );
 
-program.command('export', 'Export email templates.');
+  program.addCommand(
+    ExportCmd().name('export').description('Export email templates.')
+  );
 
-program.command('import', 'Import email templates.');
+  program.addCommand(
+    ImportCmd().name('import').description('Import email templates.')
+  );
 
-program.parse();
+  return program;
+}

--- a/src/cli/email/email.ts
+++ b/src/cli/email/email.ts
@@ -1,16 +1,12 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import TemplateCmd from './email-template';
 
 export default function setup() {
-  const program = new FrodoStubCommand('email')
-    .description('Manage email templates and configuration.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('email').description(
+    'Manage email templates and configuration.'
+  );
 
-  program.command('template', 'Manage email templates.').showHelpAfterError();
+  program.addCommand(TemplateCmd().name('template').showHelpAfterError());
 
   program.showHelpAfterError();
   return program;

--- a/src/cli/esv/esv-apply.ts
+++ b/src/cli/esv/esv-apply.ts
@@ -9,98 +9,105 @@ import { FrodoCommand } from '../FrodoCommand';
 const { checkForUpdates, applyUpdates } = frodo.cloud.startup;
 const { resolveUserName } = frodo.idm.managed;
 
-const program = new FrodoCommand('frodo esv apply');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv apply');
 
-program
-  .description(
-    'Apply pending changes to secrets and variables. Applying pending changes requires a restart of the AM and IDM pods and can take up to 10 minutes to complete.'
-  )
-  .addOption(
-    new Option(
-      '--check-only',
-      "Check if updated need to be apply but don't apply them."
-    ).default(false, 'false')
-  )
-  .addOption(
-    new Option('--force', 'Force restart of services if no updates are found.')
-  )
-  .addOption(
-    new Option('--no-wait', "Don't wait for the updates to finish applying.")
-  )
-  .addOption(
-    new Option(
-      '--timeout <seconds>',
-      'Specify a timeout in seconds how long the tool should wait for the apply command to finish. Only effective without --no-wait.'
-    ).default(600, '600 secs (10 mins)')
-  )
-  .addOption(new Option('-y, --yes', 'Answer y/yes to all prompts.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        const updates = await checkForUpdates();
-        const updatesTable = createTable([
-          'Type',
-          'Name',
-          'Modified',
-          'Modifier',
-        ]);
-        for (const secret of updates.secrets) {
-          if (!secret['loaded']) {
-            updatesTable.push([
-              'secret',
-              secret['_id'],
-              new Date(secret['lastChangeDate']).toLocaleString(),
-              // eslint-disable-next-line no-await-in-loop
-              await resolveUserName('teammember', secret['lastChangedBy']),
-            ]);
+  program
+    .description(
+      'Apply pending changes to secrets and variables. Applying pending changes requires a restart of the AM and IDM pods and can take up to 10 minutes to complete.'
+    )
+    .addOption(
+      new Option(
+        '--check-only',
+        "Check if updated need to be apply but don't apply them."
+      ).default(false, 'false')
+    )
+    .addOption(
+      new Option(
+        '--force',
+        'Force restart of services if no updates are found.'
+      )
+    )
+    .addOption(
+      new Option('--no-wait', "Don't wait for the updates to finish applying.")
+    )
+    .addOption(
+      new Option(
+        '--timeout <seconds>',
+        'Specify a timeout in seconds how long the tool should wait for the apply command to finish. Only effective without --no-wait.'
+      ).default(600, '600 secs (10 mins)')
+    )
+    .addOption(new Option('-y, --yes', 'Answer y/yes to all prompts.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          const updates = await checkForUpdates();
+          const updatesTable = createTable([
+            'Type',
+            'Name',
+            'Modified',
+            'Modifier',
+          ]);
+          for (const secret of updates.secrets) {
+            if (!secret['loaded']) {
+              updatesTable.push([
+                'secret',
+                secret['_id'],
+                new Date(secret['lastChangeDate']).toLocaleString(),
+                // eslint-disable-next-line no-await-in-loop
+                await resolveUserName('teammember', secret['lastChangedBy']),
+              ]);
+            }
           }
-        }
-        for (const variable of updates.variables) {
-          if (!variable['loaded']) {
-            updatesTable.push([
-              'variable',
-              variable['_id'],
-              new Date(variable['lastChangeDate']).toLocaleString(),
-              // eslint-disable-next-line no-await-in-loop
-              await resolveUserName('teammember', variable['lastChangedBy']),
-            ]);
+          for (const variable of updates.variables) {
+            if (!variable['loaded']) {
+              updatesTable.push([
+                'variable',
+                variable['_id'],
+                new Date(variable['lastChangeDate']).toLocaleString(),
+                // eslint-disable-next-line no-await-in-loop
+                await resolveUserName('teammember', variable['lastChangedBy']),
+              ]);
+            }
           }
-        }
-        if (updatesTable.length > 0) {
-          printMessage(updatesTable.toString(), 'data');
-        }
-        if (!options.checkOnly) {
-          if (
-            updates.secrets?.length ||
-            updates.variables?.length ||
-            options.force
-          ) {
-            const ok =
-              options.yes ||
-              (await yesno({
-                question: `\nChanges may take up to 10 minutes to propagate, during which time you will not be able to make further updates.\n\nApply updates? (y|n):`,
-              }));
-            if (ok) {
-              if (!(await applyUpdates(options.wait, options.timeout * 1000))) {
-                process.exitCode = 1;
+          if (updatesTable.length > 0) {
+            printMessage(updatesTable.toString(), 'data');
+          }
+          if (!options.checkOnly) {
+            if (
+              updates.secrets?.length ||
+              updates.variables?.length ||
+              options.force
+            ) {
+              const ok =
+                options.yes ||
+                (await yesno({
+                  question: `\nChanges may take up to 10 minutes to propagate, during which time you will not be able to make further updates.\n\nApply updates? (y|n):`,
+                }));
+              if (ok) {
+                if (
+                  !(await applyUpdates(options.wait, options.timeout * 1000))
+                ) {
+                  process.exitCode = 1;
+                }
               }
             }
           }
+        } else {
+          process.exitCode = 1;
         }
-      } else {
-        process.exitCode = 1;
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-delete.ts
+++ b/src/cli/esv/esv-secret-delete.ts
@@ -5,49 +5,51 @@ import { deleteSecret, deleteSecrets } from '../../ops/cloud/SecretsOps';
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret delete');
 
-program
-  .description('Delete secrets.')
-  .addOption(
-    new Option(
-      '-i, --secret-id <secret-id>',
-      'Secret id. If specified, -a is ignored.'
+  program
+    .description('Delete secrets.')
+    .addOption(
+      new Option(
+        '-i, --secret-id <secret-id>',
+        'Secret id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all secrets in a realm. Ignored with -i.')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by id
-      if (options.secretId && (await getTokens())) {
-        verboseMessage('Deleting secret...');
-        const outcome = await deleteSecret(options.secretId);
-        if (!outcome) process.exitCode = 1;
+    .addOption(
+      new Option('-a, --all', 'Delete all secrets in a realm. Ignored with -i.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // delete by id
+        if (options.secretId && (await getTokens())) {
+          verboseMessage('Deleting secret...');
+          const outcome = await deleteSecret(options.secretId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all secrets...');
+          const outcome = await deleteSecrets();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all secrets...');
-        const outcome = await deleteSecrets();
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-describe.ts
+++ b/src/cli/esv/esv-secret-describe.ts
@@ -5,36 +5,38 @@ import { describeSecret } from '../../ops/cloud/SecretsOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret describe');
 
-program
-  .description('Describe secrets.')
-  .addOption(
-    new Option(
-      '-i, --secret-id <secret-id>',
-      'Secret id.'
-    ).makeOptionMandatory()
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Describing secret ${options.secretId}...`);
-        const outcome = await describeSecret(options.secretId);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe secrets.')
+    .addOption(
+      new Option(
+        '-i, --secret-id <secret-id>',
+        'Secret id.'
+      ).makeOptionMandatory()
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Describing secret ${options.secretId}...`);
+          const outcome = await describeSecret(options.secretId);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-export.ts
+++ b/src/cli/esv/esv-secret-export.ts
@@ -10,78 +10,80 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret export');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret export');
 
-program
-  .description('Export secrets.')
-  .addOption(
-    new Option(
-      '-i, --secret-id <secret-id>',
-      'Secret id. If specified, -a and -A are ignored.'
+  program
+    .description('Export secrets.')
+    .addOption(
+      new Option(
+        '-i, --secret-id <secret-id>',
+        'Secret id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all secrets to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all secrets to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all sub1s to separate files (*.secret.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all sub1s to separate files (*.secret.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (options.secretId && (await getTokens())) {
-        verboseMessage(
-          `Exporting secret "${
-            options.secretId
-          }" from realm "${state.getRealm()}"...`
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await exportSecretToFile(
-          options.secretId,
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      } else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all secrets to a single file...');
-        const outcome = await exportSecretsToFile(
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      } else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all secrets to separate files...');
-        const outcome = await exportSecretsToFiles(options.metadata);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        process.exitCode = 1;
+        if (options.secretId && (await getTokens())) {
+          verboseMessage(
+            `Exporting secret "${
+              options.secretId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportSecretToFile(
+            options.secretId,
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        } else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all secrets to a single file...');
+          const outcome = await exportSecretsToFile(
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        } else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all secrets to separate files...');
+          const outcome = await exportSecretsToFiles(options.metadata);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-import.ts
+++ b/src/cli/esv/esv-secret-import.ts
@@ -3,47 +3,49 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret import');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret import');
 
-program
-  .description('Import secrets.')
-  .addOption(
-    new Option(
-      '-i, --secret-id <secret-id>',
-      'Secret id. If specified, only one secret is imported and the options -a and -A are ignored.'
+  program
+    .description('Import secrets.')
+    .addOption(
+      new Option(
+        '-i, --secret-id <secret-id>',
+        'Secret id. If specified, only one secret is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all secrets from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all secrets from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all secrets from separate files (*.secret.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all secrets from separate files (*.secret.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-list.ts
+++ b/src/cli/esv/esv-secret-list.ts
@@ -5,52 +5,54 @@ import { listSecrets } from '../../ops/cloud/SecretsOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret list');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret list');
 
-program
-  .description('List secrets.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields besides usage.').default(
-      false,
-      'false'
+  program
+    .description('List secrets.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields besides usage.').default(
+        false,
+        'false'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-u, --usage',
-      'Display usage field. If a file is provided with -f or --file, it will search for usage in the file. If a directory is provided with -D or --directory, it will search for usage in all .json files in the directory and sub-directories. If no file or directory is provided, it will perform a full export automatically to determine usage.'
-    ).default(false, 'false')
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Optional export file to use to determine usage. Overrides -D, --directory. Only used if -u or --usage is provided as well.'
+    .addOption(
+      new Option(
+        '-u, --usage',
+        'Display usage field. If a file is provided with -f or --file, it will search for usage in the file. If a directory is provided with -D or --directory, it will search for usage in all .json files in the directory and sub-directories. If no file or directory is provided, it will perform a full export automatically to determine usage.'
+      ).default(false, 'false')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Listing secrets...');
-        const outcome = await listSecrets(
-          options.long,
-          options.usage,
-          options.file
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Optional export file to use to determine usage. Overrides -D, --directory. Only used if -u or --usage is provided as well.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage('Listing secrets...');
+          const outcome = await listSecrets(
+            options.long,
+            options.usage,
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-set.ts
+++ b/src/cli/esv/esv-secret-set.ts
@@ -5,35 +5,37 @@ import { setSecretDescription } from '../../ops/cloud/SecretsOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret set');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret set');
 
-program
-  .description('Set secret description.')
-  .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
-  .addOption(new Option('--description <description>', 'Secret description.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Setting secret description...');
-        const outcome = await setSecretDescription(
-          options.secretId,
-          options.description
+  program
+    .description('Set secret description.')
+    .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
+    .addOption(new Option('--description <description>', 'Secret description.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage('Setting secret description...');
+          const outcome = await setSecretDescription(
+            options.secretId,
+            options.description
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-version-activate.ts
+++ b/src/cli/esv/esv-secret-version-activate.ts
@@ -5,39 +5,41 @@ import { activateVersionOfSecret } from '../../ops/cloud/SecretsOps';
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret version activate');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret version activate');
 
-program
-  .description('Activate versions of secrets.')
-  .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
-  .addOption(new Option('-v, --version <version>', 'Version of secret.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // activate by id
-      if (options.secretId && options.version && (await getTokens())) {
-        verboseMessage(`Activating version of secret...`);
-        const outcome = await activateVersionOfSecret(
-          options.secretId,
-          options.version
+  program
+    .description('Activate versions of secrets.')
+    .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
+    .addOption(new Option('-v, --version <version>', 'Version of secret.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // activate by id
+        if (options.secretId && options.version && (await getTokens())) {
+          verboseMessage(`Activating version of secret...`);
+          const outcome = await activateVersionOfSecret(
+            options.secretId,
+            options.version
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-version-create.ts
+++ b/src/cli/esv/esv-secret-version-create.ts
@@ -8,49 +8,51 @@ import {
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret version create');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret version create');
 
-program
-  .description('Create new version of secret.')
-  .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
-  .addOption(new Option('--value <value>', 'Secret value.'))
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the file to read pem or base64hmac encoded secret from. Ignored if --value is specified'
+  program
+    .description('Create new version of secret.')
+    .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
+    .addOption(new Option('--value <value>', 'Secret value.'))
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the file to read pem or base64hmac encoded secret from. Ignored if --value is specified'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Creating new version of secret...');
-        let outcome = null;
-        if (options.value) {
-          outcome = await createVersionOfSecret(
-            options.secretId,
-            options.value
-          );
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage('Creating new version of secret...');
+          let outcome = null;
+          if (options.value) {
+            outcome = await createVersionOfSecret(
+              options.secretId,
+              options.value
+            );
+          } else {
+            outcome = await createVersionOfSecretFromFile(
+              options.secretId,
+              options.file
+            );
+          }
+          if (!outcome) process.exitCode = 1;
         } else {
-          outcome = await createVersionOfSecretFromFile(
-            options.secretId,
-            options.file
-          );
+          process.exitCode = 1;
         }
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-version-deactivate.ts
+++ b/src/cli/esv/esv-secret-version-deactivate.ts
@@ -5,39 +5,41 @@ import { deactivateVersionOfSecret } from '../../ops/cloud/SecretsOps';
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret version deactivate');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret version deactivate');
 
-program
-  .description('Deactivate versions of secrets.')
-  .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
-  .addOption(new Option('-v, --version <version>', 'Version of secret.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // activate by id
-      if (options.secretId && options.version && (await getTokens())) {
-        verboseMessage(`Deactivating version of secret...`);
-        const outcome = await deactivateVersionOfSecret(
-          options.secretId,
-          options.version
+  program
+    .description('Deactivate versions of secrets.')
+    .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
+    .addOption(new Option('-v, --version <version>', 'Version of secret.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // activate by id
+        if (options.secretId && options.version && (await getTokens())) {
+          verboseMessage(`Deactivating version of secret...`);
+          const outcome = await deactivateVersionOfSecret(
+            options.secretId,
+            options.version
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-version-delete.ts
+++ b/src/cli/esv/esv-secret-version-delete.ts
@@ -5,53 +5,55 @@ import { deleteVersionOfSecret } from '../../ops/cloud/SecretsOps';
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret version delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret version delete');
 
-program
-  .description('Delete versions of secrets.')
-  .addOption(
-    new Option(
-      '-i, --secret-id <secret-id>',
-      'Secret id. If specified, -a is ignored.'
+  program
+    .description('Delete versions of secrets.')
+    .addOption(
+      new Option(
+        '-i, --secret-id <secret-id>',
+        'Secret id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(new Option('-v, --version <version>', 'Version of secret.'))
-  .addOption(
-    new Option('-a, --all', 'Delete all secrets in a realm. Ignored with -i.')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by id
-      if (options.secretId && options.version && (await getTokens())) {
-        verboseMessage(`Deleting version of secret...`);
-        const outcome = await deleteVersionOfSecret(
-          options.secretId,
-          options.version
+    .addOption(new Option('-v, --version <version>', 'Version of secret.'))
+    .addOption(
+      new Option('-a, --all', 'Delete all secrets in a realm. Ignored with -i.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
+        // delete by id
+        if (options.secretId && options.version && (await getTokens())) {
+          verboseMessage(`Deleting version of secret...`);
+          const outcome = await deleteVersionOfSecret(
+            options.secretId,
+            options.version
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        // else if (options.all && (await getTokens())) {
+        //   printMessage('Deleting all versions...');
+        //   const outcome = deleteJourneys(options);
+        //   if (!outcome) process.exitCode = 1;
+        // }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      // else if (options.all && (await getTokens())) {
-      //   printMessage('Deleting all versions...');
-      //   const outcome = deleteJourneys(options);
-      //   if (!outcome) process.exitCode = 1;
-      // }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-version-list.ts
+++ b/src/cli/esv/esv-secret-version-list.ts
@@ -5,34 +5,36 @@ import { listSecretVersions } from '../../ops/cloud/SecretsOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv secret version list');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv secret version list');
 
-program
-  .description('List versions of secret.')
-  .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Listing versions...');
-        const outcome = await listSecretVersions(options.secretId);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List versions of secret.')
+    .addOption(new Option('-i, --secret-id <secret-id>', 'Secret id.'))
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage('Listing versions...');
+          const outcome = await listSecretVersions(options.secretId);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret-version.ts
+++ b/src/cli/esv/esv-secret-version.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import ActivateCmd from './esv-secret-version-activate.js';
+import CreateCmd from './esv-secret-version-create.js';
+import DeactivateCmd from './esv-secret-version-deactivate.js';
+import DeleteCmd from './esv-secret-version-delete.js';
+import ListCmd from './esv-secret-version-list.js';
 
-const program = new FrodoStubCommand('frodo esv secret version');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo esv secret version');
 
-program.description('Manage secret versions.');
+  program.description('Manage secret versions.');
 
-program.command('activate', 'Activate version.');
+  program.addCommand(ActivateCmd().name('activate'));
 
-program.command('create', 'Create new version.');
+  program.addCommand(CreateCmd().name('create'));
 
-program.command('deactivate', 'Deactivate version.');
+  program.addCommand(DeactivateCmd().name('deactivate'));
 
-program.command('delete', 'Delete version.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.command('list', 'List versions.');
+  program.addCommand(ListCmd().name('list'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-secret.ts
+++ b/src/cli/esv/esv-secret.ts
@@ -1,23 +1,33 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import CreateCmd from './esv-secret-create.js';
+// import ImportCmd from './esv-secret-import.js';
+import DeleteCmd from './esv-secret-delete.js';
+import DescribeCmd from './esv-secret-describe.js';
+import ExportCmd from './esv-secret-export.js';
+import ListCmd from './esv-secret-list.js';
+import SetCmd from './esv-secret-set.js';
+import VersionCmd from './esv-secret-version.js';
 
-const program = new FrodoStubCommand('frodo esv secret');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo esv secret');
 
-program.description('Manages secrets.');
+  program.description('Manages secrets.');
 
-program.command('create', 'Create secrets.');
+  program.addCommand(CreateCmd().name('create'));
 
-program.command('delete', 'Delete secrets.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.command('describe', 'Describe secret.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export secrets.');
+  program.addCommand(ExportCmd().name('export'));
 
-// program.command('import', 'Import secrets.');
+  // program.addCommand(ImportCmd().name('import'));
 
-program.command('list', 'List secrets.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('set', 'Set secret descriptions.');
+  program.addCommand(SetCmd().name('set'));
 
-program.command('version', 'Manage secret versions.');
+  program.addCommand(VersionCmd().name('version'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable-create.ts
+++ b/src/cli/esv/esv-variable-create.ts
@@ -4,67 +4,69 @@ import { createVariable } from '../../ops/cloud/VariablesOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv variable create');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv variable create');
 
-program
-  .description('Create variables.')
-  .requiredOption('-i, --variable-id <variable-id>', 'Variable id.')
-  .requiredOption('--value <value>', 'Variable value.')
-  .option('--description [description]', 'Variable description.')
-  .option(
-    '--variable-type [variable-type]',
-    'Variable type. Must be one of "string", "list", "array", "object", "bool", "int", or "number".',
-    'string'
-  )
-  .addHelpText(
-    'after',
-    `Usage Examples:\n` +
-      `  Create an ESV variable using implied default type "string":\n` +
-      `  $ frodo esv variable create --variable-id "esv-trinity-phone" --value "(312)-555-0690" --description "Trinity's phone number." ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Create an ESV variable of type "array":\n` +
-      `  $ frodo esv variable create --variable-id "esv-nebuchadnezzar-crew" --variable-type array --value '["Morpheus","Trinity","Link","Tank","Dozer","Apoc","Cypher","Mouse","Neo","Switch"]' --description "The crew of the Nebuchadnezzar hovercraft." ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Create an ESV variable of type "object":\n` +
-      `  $ frodo esv variable create --variable-id "esv-nebuchadnezzar-crew-structure" --variable-type object --value '{"Captain":"Morpheus","FirstMate":"Trinity","Operator":["Link","Tank"],"Medic":"Dozer","Crewmen":["Apoc","Cypher","Mouse","Neo","Switch"]}' --description "The structure of the crew of the Nebuchadnezzar hovercraft." ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Create an ESV variable of type "int":\n` +
-      `  $ frodo esv variable create --variable-id "esv-neo-age" --variable-type int --value '28' --description "Neo's age in the matrix." ${s.connId}\n`[
-        'brightCyan'
-      ] +
-      `  Create an ESV variable of type "bool":\n` +
-      `  $ frodo esv variable create --variable-id "esv-blue-piller" --variable-type bool --value 'false' --description "Zion membership criteria." ${s.connId}\n`[
-        'brightCyan'
-      ]
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Creating variable...');
-        const outcome = await createVariable(
-          options.variableId,
-          options.value,
-          options.description,
-          options.variableType
+  program
+    .description('Create variables.')
+    .requiredOption('-i, --variable-id <variable-id>', 'Variable id.')
+    .requiredOption('--value <value>', 'Variable value.')
+    .option('--description [description]', 'Variable description.')
+    .option(
+      '--variable-type [variable-type]',
+      'Variable type. Must be one of "string", "list", "array", "object", "bool", "int", or "number".',
+      'string'
+    )
+    .addHelpText(
+      'after',
+      `Usage Examples:\n` +
+        `  Create an ESV variable using implied default type "string":\n` +
+        `  $ frodo esv variable create --variable-id "esv-trinity-phone" --value "(312)-555-0690" --description "Trinity's phone number." ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Create an ESV variable of type "array":\n` +
+        `  $ frodo esv variable create --variable-id "esv-nebuchadnezzar-crew" --variable-type array --value '["Morpheus","Trinity","Link","Tank","Dozer","Apoc","Cypher","Mouse","Neo","Switch"]' --description "The crew of the Nebuchadnezzar hovercraft." ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Create an ESV variable of type "object":\n` +
+        `  $ frodo esv variable create --variable-id "esv-nebuchadnezzar-crew-structure" --variable-type object --value '{"Captain":"Morpheus","FirstMate":"Trinity","Operator":["Link","Tank"],"Medic":"Dozer","Crewmen":["Apoc","Cypher","Mouse","Neo","Switch"]}' --description "The structure of the crew of the Nebuchadnezzar hovercraft." ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Create an ESV variable of type "int":\n` +
+        `  $ frodo esv variable create --variable-id "esv-neo-age" --variable-type int --value '28' --description "Neo's age in the matrix." ${s.connId}\n`[
+          'brightCyan'
+        ] +
+        `  Create an ESV variable of type "bool":\n` +
+        `  $ frodo esv variable create --variable-id "esv-blue-piller" --variable-type bool --value 'false' --description "Zion membership criteria." ${s.connId}\n`[
+          'brightCyan'
+        ]
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage('Creating variable...');
+          const outcome = await createVariable(
+            options.variableId,
+            options.value,
+            options.description,
+            options.variableType
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable-delete.ts
+++ b/src/cli/esv/esv-variable-delete.ts
@@ -8,56 +8,61 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo cmd sub2 delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo cmd sub2 delete');
 
-program
-  .description('Delete variables.')
-  .addOption(
-    new Option(
-      '-i, --variable-id <variable-id>',
-      'Variable id. If specified, -a is ignored.'
+  program
+    .description('Delete variables.')
+    .addOption(
+      new Option(
+        '-i, --variable-id <variable-id>',
+        'Variable id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all variable in a realm. Ignored with -i.')
-  )
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all variable in a realm. Ignored with -i.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by id
-      if (options.variableId && (await getTokens())) {
-        verboseMessage('Deleting variable...');
-        const outcome = await deleteVariableById(options.variableId);
-        if (!outcome) process.exitCode = 1;
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // delete by id
+        if (options.variableId && (await getTokens())) {
+          verboseMessage('Deleting variable...');
+          const outcome = await deleteVariableById(options.variableId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all variables...');
+          const outcome = await deleteVariables();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all variables...');
-        const outcome = await deleteVariables();
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable-describe.ts
+++ b/src/cli/esv/esv-variable-describe.ts
@@ -5,40 +5,42 @@ import { describeVariable } from '../../ops/cloud/VariablesOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv variable describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv variable describe');
 
-program
-  .description('Describe variables.')
-  .addOption(
-    new Option(
-      '-i, --variable-id <variable-id>',
-      'Variable id.'
-    ).makeOptionMandatory()
-  )
-  .addOption(new Option('--json', 'Output in JSON format.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Describing variable ${options.variableId}...`);
-        const outcome = await describeVariable(
-          options.variableId,
-          options.json
+  program
+    .description('Describe variables.')
+    .addOption(
+      new Option(
+        '-i, --variable-id <variable-id>',
+        'Variable id.'
+      ).makeOptionMandatory()
+    )
+    .addOption(new Option('--json', 'Output in JSON format.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage(`Describing variable ${options.variableId}...`);
+          const outcome = await describeVariable(
+            options.variableId,
+            options.json
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable-export.ts
+++ b/src/cli/esv/esv-variable-export.ts
@@ -10,90 +10,92 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv variable export');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv variable export');
 
-program
-  .description('Export variables.')
-  .addOption(
-    new Option(
-      '-i, --variable-id <variable-id>',
-      'Variable id. If specified, -a and -A are ignored.'
+  program
+    .description('Export variables.')
+    .addOption(
+      new Option(
+        '-i, --variable-id <variable-id>',
+        'Variable id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all variables to a single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all variables to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all variables to separate files (*.variable.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all variables to separate files (*.variable.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--no-decode',
-      'Do not include decoded variable value in export'
-    ).default(false, 'false')
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '--no-decode',
+        'Do not include decoded variable value in export'
+      ).default(false, 'false')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (options.variableId && (await getTokens())) {
-        verboseMessage(
-          `Exporting variable "${
-            options.variableId
-          }" from realm "${state.getRealm()}"...`
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await exportVariableToFile(
-          options.variableId,
-          options.file,
-          options.decode,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      } else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all variables to a single file...');
-        const outcome = await exportVariablesToFile(
-          options.file,
-          options.decode,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      } else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all variables to separate files...');
-        const outcome = await exportVariablesToFiles(
-          options.decode,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
+        if (options.variableId && (await getTokens())) {
+          verboseMessage(
+            `Exporting variable "${
+              options.variableId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportVariableToFile(
+            options.variableId,
+            options.file,
+            options.decode,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        } else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all variables to a single file...');
+          const outcome = await exportVariablesToFile(
+            options.file,
+            options.decode,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        } else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all variables to separate files...');
+          const outcome = await exportVariablesToFiles(
+            options.decode,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable-import.ts
+++ b/src/cli/esv/esv-variable-import.ts
@@ -3,47 +3,49 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv variable import');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv variable import');
 
-program
-  .description('Import variables.')
-  .addOption(
-    new Option(
-      '-i, --variable-id <variable-id>',
-      'Variable id. If specified, only one variable is imported and the options -a and -A are ignored.'
+  program
+    .description('Import variables.')
+    .addOption(
+      new Option(
+        '-i, --variable-id <variable-id>',
+        'Variable id. If specified, only one variable is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all variables from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all variables from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all variables from separate files (*.variable.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all variables from separate files (*.variable.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable-list.ts
+++ b/src/cli/esv/esv-variable-list.ts
@@ -5,52 +5,54 @@ import { listVariables } from '../../ops/cloud/VariablesOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv variable list');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv variable list');
 
-program
-  .description('List variables.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields besides usage.').default(
-      false,
-      'false'
+  program
+    .description('List variables.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields besides usage.').default(
+        false,
+        'false'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-u, --usage',
-      'Display usage field. If a file is provided with -f or --file, it will search for usage in the file. If a directory is provided with -D or --directory, it will search for usage in all .json files in the directory and sub-directories. If no file or directory is provided, it will perform a full export automatically to determine usage.'
-    ).default(false, 'false')
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Optional export file to use to determine usage. Overrides -D, --directory. Only used if -u or --usage is provided as well.'
+    .addOption(
+      new Option(
+        '-u, --usage',
+        'Display usage field. If a file is provided with -f or --file, it will search for usage in the file. If a directory is provided with -D or --directory, it will search for usage in all .json files in the directory and sub-directories. If no file or directory is provided, it will perform a full export automatically to determine usage.'
+      ).default(false, 'false')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Listing variables...');
-        const outcome = await listVariables(
-          options.long,
-          options.usage,
-          options.file
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Optional export file to use to determine usage. Overrides -D, --directory. Only used if -u or --usage is provided as well.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage('Listing variables...');
+          const outcome = await listVariables(
+            options.long,
+            options.usage,
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable-set.ts
+++ b/src/cli/esv/esv-variable-set.ts
@@ -6,59 +6,61 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo esv variable set');
+export default function setup() {
+  const program = new FrodoCommand('frodo esv variable set');
 
-program
-  .description('Set variable description.')
-  .requiredOption('-i, --variable-id <variable-id>', 'Variable id.')
-  .option('--value [value]', 'Variable value.')
-  .option('--description [description]', 'Variable description.')
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (
-        options.variableId &&
-        options.value &&
-        options.description &&
-        (await getTokens())
-      ) {
-        verboseMessage('Updating variable...');
-        const outcome = await updateVariable(
-          options.variableId,
-          options.value,
-          options.description
+  program
+    .description('Set variable description.')
+    .requiredOption('-i, --variable-id <variable-id>', 'Variable id.')
+    .option('--value [value]', 'Variable value.')
+    .option('--description [description]', 'Variable description.')
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else if (
-        options.variableId &&
-        options.description &&
-        (await getTokens())
-      ) {
-        verboseMessage('Updating variable...');
-        const outcome = await setVariableDescription(
-          options.variableId,
-          options.description
-        );
-        if (!outcome) process.exitCode = 1;
+        if (
+          options.variableId &&
+          options.value &&
+          options.description &&
+          (await getTokens())
+        ) {
+          verboseMessage('Updating variable...');
+          const outcome = await updateVariable(
+            options.variableId,
+            options.value,
+            options.description
+          );
+          if (!outcome) process.exitCode = 1;
+        } else if (
+          options.variableId &&
+          options.description &&
+          (await getTokens())
+        ) {
+          verboseMessage('Updating variable...');
+          const outcome = await setVariableDescription(
+            options.variableId,
+            options.description
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Provide --variable-id and either one or both of --value and --description.'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Provide --variable-id and either one or both of --value and --description.'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv-variable.ts
+++ b/src/cli/esv/esv-variable.ts
@@ -1,21 +1,30 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import CreateCmd from './esv-variable-create.js';
+// import ImportCmd from './esv-variable-import.js';
+import DeleteCmd from './esv-variable-delete.js';
+import DescribeCmd from './esv-variable-describe.js';
+import ExportCmd from './esv-variable-export.js';
+import ListCmd from './esv-variable-list.js';
+import SetCmd from './esv-variable-set.js';
 
-const program = new FrodoStubCommand('frodo esv variable');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo esv variable');
 
-program.description('Manage variables.');
+  program.description('Manage variables.');
 
-program.command('create', 'Create variables.');
+  program.addCommand(CreateCmd().name('create'));
 
-program.command('delete', 'Delete variables.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.command('describe', 'Describe variables.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export variables.');
+  program.addCommand(ExportCmd().name('export'));
 
-// program.command('import', 'Import variables.');
+  // program.addCommand(ImportCmd().name('import'));
 
-program.command('list', 'List variables.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('set', 'Set variable descriptions.');
+  program.addCommand(SetCmd().name('set'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/esv/esv.ts
+++ b/src/cli/esv/esv.ts
@@ -1,20 +1,18 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import ApplyCmd from './esv-apply.js';
+import SecretCmd from './esv-secret.js';
+import VariableCmd from './esv-variable.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('esv')
-    .description('Manage environment secrets and variables (ESVs).')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('esv').description(
+    'Manage environment secrets and variables (ESVs).'
+  );
 
-  program.command('apply', 'Apply pending changes.');
+  program.addCommand(ApplyCmd().name('apply'));
 
-  program.command('secret', 'Manage secrets.');
+  program.addCommand(SecretCmd().name('secret'));
 
-  program.command('variable', 'Manage variables.');
+  program.addCommand(VariableCmd().name('variable'));
 
   return program;
 }

--- a/src/cli/idm/idm-count.ts
+++ b/src/cli/idm/idm-count.ts
@@ -5,36 +5,40 @@ import { countManagedObjects } from '../../ops/IdmOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo idm count');
+export default function setup() {
+  const program = new FrodoCommand('frodo idm count');
 
-program
-  .description('Count managed objects.')
-  .addOption(
-    new Option(
-      '-o, --managed-object <type>',
-      'Type of managed object to count. E.g. "alpha_user", "alpha_role", "user", "role".'
+  program
+    .description('Count managed objects.')
+    .addOption(
+      new Option(
+        '-o, --managed-object <type>',
+        'Type of managed object to count. E.g. "alpha_user", "alpha_role", "user", "role".'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Counting managed ${options.managedObject} objects...`);
-        const outcome = await countManagedObjects(options.managedObject);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(
+            `Counting managed ${options.managedObject} objects...`
+          );
+          const outcome = await countManagedObjects(options.managedObject);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/idm/idm-export.ts
+++ b/src/cli/idm/idm-export.ts
@@ -11,108 +11,110 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo idm export');
+export default function setup() {
+  const program = new FrodoCommand('frodo idm export');
 
-program
-  .description('Export IDM configuration objects.')
-  .addOption(
-    new Option(
-      '-N, --name <name>',
-      'Config entity name. E.g. "managed", "sync", "provisioner-<connector-name>", etc.'
+  program
+    .description('Export IDM configuration objects.')
+    .addOption(
+      new Option(
+        '-N, --name <name>',
+        'Config entity name. E.g. "managed", "sync", "provisioner-<connector-name>", etc.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file [file]', 'Export file. Ignored with -A.'))
-  .addOption(
-    new Option(
-      '-E, --entities-file [entities-file]',
-      'Name of the entity file. Ignored with -A.'
+    .addOption(new Option('-f, --file [file]', 'Export file. Ignored with -A.'))
+    .addOption(
+      new Option(
+        '-E, --entities-file [entities-file]',
+        'Name of the entity file. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-e, --env-file [envfile]',
-      'Name of the env file. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-e, --env-file [envfile]',
+        'Name of the env file. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all IDM configuration objects into a single file in directory -D. Ignored with -N.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all IDM configuration objects into a single file in directory -D. Ignored with -N.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all IDM configuration objects into separate JSON files in directory -D. Ignored with -N, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all IDM configuration objects into separate JSON files in directory -D. Ignored with -N, and -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by id/name
-      if (options.name && (await getTokens())) {
-        verboseMessage(`Exporting object "${options.name}"...`);
-        const outcome = await exportConfigEntity(options.name, options.file);
-        if (!outcome) process.exitCode = 1;
-      }
-      // require --directory -D for all-separate functions
-      else if (options.allSeparate && !state.getDirectory()) {
-        printMessage(
-          '-D or --directory required when using -A or --all-separate',
-          'error'
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        program.help();
-        process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (
-        options.allSeparate &&
-        options.entitiesFile &&
-        options.envFile &&
-        (await getTokens())
-      ) {
-        verboseMessage(
-          `Exporting IDM configuration objects specified in ${
-            options.entitiesFile
-          } into separate files in ${state.getDirectory()} using ${
+        // export by id/name
+        if (options.name && (await getTokens())) {
+          verboseMessage(`Exporting object "${options.name}"...`);
+          const outcome = await exportConfigEntity(options.name, options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // require --directory -D for all-separate functions
+        else if (options.allSeparate && !state.getDirectory()) {
+          printMessage(
+            '-D or --directory required when using -A or --all-separate',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (
+          options.allSeparate &&
+          options.entitiesFile &&
+          options.envFile &&
+          (await getTokens())
+        ) {
+          verboseMessage(
+            `Exporting IDM configuration objects specified in ${
+              options.entitiesFile
+            } into separate files in ${state.getDirectory()} using ${
+              options.envFile
+            } for variable replacement...`
+          );
+          const outcome = await exportAllConfigEntities(
+            options.entitiesFile,
             options.envFile
-          } for variable replacement...`
-        );
-        const outcome = await exportAllConfigEntities(
-          options.entitiesFile,
-          options.envFile
-        );
-        if (!outcome) process.exitCode = 1;
-        await warnAboutOfflineConnectorServers();
+          );
+          if (!outcome) process.exitCode = 1;
+          await warnAboutOfflineConnectorServers();
+        }
+        // --all-separate -A without variable replacement
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            `Exporting all IDM configuration objects into separate files in ${state.getDirectory()}...`
+          );
+          const outcome = await exportAllRawConfigEntities();
+          if (!outcome) process.exitCode = 1;
+          await warnAboutOfflineConnectorServers();
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all-separate -A without variable replacement
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          `Exporting all IDM configuration objects into separate files in ${state.getDirectory()}...`
-        );
-        const outcome = await exportAllRawConfigEntities();
-        if (!outcome) process.exitCode = 1;
-        await warnAboutOfflineConnectorServers();
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/idm/idm-import.ts
+++ b/src/cli/idm/idm-import.ts
@@ -11,131 +11,133 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo idm import');
+export default function setup() {
+  const program = new FrodoCommand('frodo idm import');
 
-interface IdmImportOptions {
-  type?: string;
-  insecure?: boolean;
-  verbose?: boolean;
-  debug?: boolean;
-  curlirize?: boolean;
-  name?: string;
-  file?: string;
-  entitiesFile?: string;
-  envFile?: string;
-  all?: string;
-  allSeparate?: string;
-  directory?: string;
-}
+  interface IdmImportOptions {
+    type?: string;
+    insecure?: boolean;
+    verbose?: boolean;
+    debug?: boolean;
+    curlirize?: boolean;
+    name?: string;
+    file?: string;
+    entitiesFile?: string;
+    envFile?: string;
+    all?: string;
+    allSeparate?: string;
+    directory?: string;
+  }
 
-program
-  .description('Import IDM configuration objects.')
-  .addOption(
-    new Option(
-      '-N, --name <name>',
-      'Config entity name. E.g. "managed", "sync", "provisioner-<connector-name>", etc.'
+  program
+    .description('Import IDM configuration objects.')
+    .addOption(
+      new Option(
+        '-N, --name <name>',
+        'Config entity name. E.g. "managed", "sync", "provisioner-<connector-name>", etc.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file [file]', 'Import file. Ignored with -A.'))
-  .addOption(
-    new Option(
-      '-E, --entities-file [entities-file]',
-      'Name of the entity file. Ignored with -A.'
+    .addOption(new Option('-f, --file [file]', 'Import file. Ignored with -A.'))
+    .addOption(
+      new Option(
+        '-E, --entities-file [entities-file]',
+        'Name of the entity file. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-e, --env-file [envfile]',
-      'Name of the env file. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-e, --env-file [envfile]',
+        'Name of the env file. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all IDM configuration objects from separate files in directory -D. Ignored with -N, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all IDM configuration objects from separate files in directory -D. Ignored with -N, and -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (
-      host: string,
-      realm: string,
-      user: string,
-      password: string,
-      options: IdmImportOptions,
-      command
-    ) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
+    .action(
+      // implement command logic inside action handler
+      async (
+        host: string,
+        realm: string,
+        user: string,
+        password: string,
+        options: IdmImportOptions,
         command
-      );
-      // import by id/name
-      if (options.name && (await getTokens())) {
-        verboseMessage(`Importing object "${options.name}"...`);
-        const outcome = await importConfigEntityByIdFromFile(
-          options.name,
-          options.file
+      ) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      }
-      // import from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(`Importing object from file...`);
-        const outcome = await importConfigEntityFromFile(options.file);
-        if (!outcome) process.exitCode = 1;
-      }
-      // require --directory -D for all-separate functions
-      else if (options.allSeparate && !state.getDirectory()) {
-        printMessage(
-          '-D or --directory required when using -A or --all-separate',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (
-        options.allSeparate &&
-        options.entitiesFile &&
-        options.envFile &&
-        (await getTokens())
-      ) {
-        verboseMessage(
-          `Importing IDM configuration objects specified in ${
-            options.entitiesFile
-          } into separate files in ${state.getDirectory()} using ${
+        // import by id/name
+        if (options.name && (await getTokens())) {
+          verboseMessage(`Importing object "${options.name}"...`);
+          const outcome = await importConfigEntityByIdFromFile(
+            options.name,
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // import from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(`Importing object from file...`);
+          const outcome = await importConfigEntityFromFile(options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // require --directory -D for all-separate functions
+        else if (options.allSeparate && !state.getDirectory()) {
+          printMessage(
+            '-D or --directory required when using -A or --all-separate',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (
+          options.allSeparate &&
+          options.entitiesFile &&
+          options.envFile &&
+          (await getTokens())
+        ) {
+          verboseMessage(
+            `Importing IDM configuration objects specified in ${
+              options.entitiesFile
+            } into separate files in ${state.getDirectory()} using ${
+              options.envFile
+            } for variable replacement...`
+          );
+          const outcome = await importAllConfigEntities(
+            options.entitiesFile,
             options.envFile
-          } for variable replacement...`
-        );
-        const outcome = await importAllConfigEntities(
-          options.entitiesFile,
-          options.envFile
-        );
-        if (!outcome) process.exitCode = 1;
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A without variable replacement
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage(
+            `Importing all IDM configuration objects from separate files in ${state.getDirectory()}...`
+          );
+          const outcome = await importAllRawConfigEntities();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all-separate -A without variable replacement
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage(
-          `Importing all IDM configuration objects from separate files in ${state.getDirectory()}...`
-        );
-        const outcome = await importAllRawConfigEntities();
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/idm/idm-list.ts
+++ b/src/cli/idm/idm-list.ts
@@ -6,34 +6,36 @@ import {
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo idm list');
+export default function setup() {
+  const program = new FrodoCommand('frodo idm list');
 
-program
-  .description('List IDM configuration objects.')
-  // .addOption(
-  //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Listing all IDM configuration objects...');
-        const outcome = await listAllConfigEntities();
-        if (!outcome) process.exitCode = 1;
-        await warnAboutOfflineConnectorServers();
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List IDM configuration objects.')
+    // .addOption(
+    //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage('Listing all IDM configuration objects...');
+          const outcome = await listAllConfigEntities();
+          if (!outcome) process.exitCode = 1;
+          await warnAboutOfflineConnectorServers();
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/idm/idm.ts
+++ b/src/cli/idm/idm.ts
@@ -1,22 +1,21 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import CountCmd from './idm-count.js';
+import ExportCmd from './idm-export.js';
+import ImportCmd from './idm-import.js';
+import ListCmd from './idm-list.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('idm')
-    .description('Manage IDM configuration.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('idm').description(
+    'Manage IDM configuration.'
+  );
 
-  program.command('list', 'List all IDM configuration objects.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('export', 'Export IDM configuration objects.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import IDM configuration objects.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('count', 'Count number of managed objects of a given type.');
+  program.addCommand(CountCmd().name('count'));
 
   return program;
 }

--- a/src/cli/idp/idp-export.ts
+++ b/src/cli/idp/idp-export.ts
@@ -10,95 +10,97 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo idp export');
+export default function setup() {
+  const program = new FrodoCommand('frodo idp export');
 
-program
-  .description('Export (social) identity providers.')
-  .addOption(
-    new Option(
-      '-i, --idp-id <idp-id>',
-      'Id/name of a provider. If specified, -a and -A are ignored.'
+  program
+    .description('Export (social) identity providers.')
+    .addOption(
+      new Option(
+        '-i, --idp-id <idp-id>',
+        'Id/name of a provider. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the file to write the exported provider(s) to. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the file to write the exported provider(s) to. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all the providers in a realm to a single file. Ignored with -t and -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all the providers in a realm to a single file. Ignored with -t and -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all the providers in a realm as separate files <provider name>.idp.json. Ignored with -t, -i, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all the providers in a realm as separate files <provider name>.idp.json. Ignored with -t, -i, and -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // export by id/name
-        if (options.idpId) {
-          verboseMessage(
-            `Exporting provider "${
-              options.idpId
-            }" from realm "${state.getRealm()}"...`
-          );
-          const outcome = await exportSocialIdentityProviderToFile(
-            options.idpId,
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all -a
-        else if (options.all) {
-          verboseMessage('Exporting all providers to a single file...');
-          const outcome = await exportSocialIdentityProvidersToFile(
-            options.file,
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // --all-separate -A
-        else if (options.allSeparate) {
-          verboseMessage('Exporting all providers to separate files...');
-          const outcome = await exportSocialIdentityProvidersToFiles(
-            options.metadata
-          );
-          if (!outcome) process.exitCode = 1;
-        }
-        // unrecognized combination of options or no options
-        else {
-          printMessage(
-            'Unrecognized combination of options or no options...',
-            'error'
-          );
-          program.help();
-          process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // export by id/name
+          if (options.idpId) {
+            verboseMessage(
+              `Exporting provider "${
+                options.idpId
+              }" from realm "${state.getRealm()}"...`
+            );
+            const outcome = await exportSocialIdentityProviderToFile(
+              options.idpId,
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all -a
+          else if (options.all) {
+            verboseMessage('Exporting all providers to a single file...');
+            const outcome = await exportSocialIdentityProvidersToFile(
+              options.file,
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // --all-separate -A
+          else if (options.allSeparate) {
+            verboseMessage('Exporting all providers to separate files...');
+            const outcome = await exportSocialIdentityProvidersToFiles(
+              options.metadata
+            );
+            if (!outcome) process.exitCode = 1;
+          }
+          // unrecognized combination of options or no options
+          else {
+            printMessage(
+              'Unrecognized combination of options or no options...',
+              'error'
+            );
+            program.help();
+            process.exitCode = 1;
+          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/idp/idp-import.ts
+++ b/src/cli/idp/idp-import.ts
@@ -11,110 +11,112 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo idp import');
+export default function setup() {
+  const program = new FrodoCommand('frodo idp import');
 
-program
-  .description('Import (social) identity providers.')
-  .addOption(
-    new Option(
-      '-i, --idp-id <id>',
-      'Provider id. If specified, -a and -A are ignored.'
+  program
+    .description('Import (social) identity providers.')
+    .addOption(
+      new Option(
+        '-i, --idp-id <id>',
+        'Provider id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import the provider(s) from.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import the provider(s) from.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all the providers from single file. Ignored with -t or -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all the providers from single file. Ignored with -t or -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all the providers from separate files (*.json) in the current directory. Ignored with -t or -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all the providers from separate files (*.json) in the current directory. Ignored with -t or -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option('--no-deps', 'Do not include any dependencies (scripts).')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import by id
-      if (options.file && options.idpId && (await getTokens())) {
-        verboseMessage(
-          `Importing provider "${
-            options.idpId
-          }" into realm "${state.getRealm()}"...`
+    .addOption(
+      new Option('--no-deps', 'Do not include any dependencies (scripts).')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await importSocialIdentityProviderFromFile(
-          options.idpId,
-          options.file,
-          {
+        // import by id
+        if (options.file && options.idpId && (await getTokens())) {
+          verboseMessage(
+            `Importing provider "${
+              options.idpId
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importSocialIdentityProviderFromFile(
+            options.idpId,
+            options.file,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing all providers from a single file (${options.file})...`
+          );
+          const outcome = await importSocialIdentityProvidersFromFile(
+            options.file,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          verboseMessage(
+            'Importing all providers from separate files in current directory...'
+          );
+          const outcome = await importSocialIdentityProvidersFromFiles({
             deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first provider from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first provider from file "${
+              options.file
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importFirstSocialIdentityProviderFromFile(
+            options.file,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing all providers from a single file (${options.file})...`
-        );
-        const outcome = await importSocialIdentityProvidersFromFile(
-          options.file,
-          {
-            deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        verboseMessage(
-          'Importing all providers from separate files in current directory...'
-        );
-        const outcome = await importSocialIdentityProvidersFromFiles({
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first provider from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first provider from file "${
-            options.file
-          }" into realm "${state.getRealm()}"...`
-        );
-        const outcome = await importFirstSocialIdentityProviderFromFile(
-          options.file,
-          {
-            deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/idp/idp-list.ts
+++ b/src/cli/idp/idp-list.ts
@@ -5,33 +5,35 @@ import { listSocialProviders } from '../../ops/IdpOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo idp list');
+export default function setup() {
+  const program = new FrodoCommand('frodo idp list');
 
-program
-  .description('List (social) identity providers.')
-  // .addOption(
-  //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Listing providers in realm "${state.getRealm()}"...`);
-        const outcome = await listSocialProviders();
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List (social) identity providers.')
+    // .addOption(
+    //   new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Listing providers in realm "${state.getRealm()}"...`);
+          const outcome = await listSocialProviders();
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/idp/idp.ts
+++ b/src/cli/idp/idp.ts
@@ -1,20 +1,18 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import ExportCmd from './idp-export.js';
+import ImportCmd from './idp-import.js';
+import ListCmd from './idp-list.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('idp')
-    .description('Manage (social) identity providers.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('idp').description(
+    'Manage (social) identity providers.'
+  );
 
-  program.command('list', 'List identity providers.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('export', 'Export identity providers.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import identity providers.');
+  program.addCommand(ImportCmd().name('import'));
 
   return program;
 }

--- a/src/cli/journey/journey-delete.ts
+++ b/src/cli/journey/journey-delete.ts
@@ -6,72 +6,74 @@ import { deleteJourney, deleteJourneys } from '../../ops/JourneyOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo journey delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey delete');
 
-program
-  .description('Delete journeys/trees.')
-  .addOption(
-    new Option(
-      '-i, --journey-id <journey>',
-      'Name of a journey/tree. If specified, -a is ignored.'
+  program
+    .description('Delete journeys/trees.')
+    .addOption(
+      new Option(
+        '-i, --journey-id <journey>',
+        'Name of a journey/tree. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Delete all the journeys/trees in a realm. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all the journeys/trees in a realm. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--verbose',
-      'Verbose output during command execution. If specified, may or may not produce additional output.'
-    ).default(false, 'off')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by id
-      if (options.journeyId && (await getTokens())) {
-        verboseMessage(
-          `Deleting journey ${
-            options.journeyId
-          } in realm "${state.getRealm()}"...`
+    .addOption(
+      new Option(
+        '--verbose',
+        'Verbose output during command execution. If specified, may or may not produce additional output.'
+      ).default(false, 'off')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await deleteJourney(options.journeyId, options);
-        if (!outcome) process.exitCode = 1;
+        // delete by id
+        if (options.journeyId && (await getTokens())) {
+          verboseMessage(
+            `Deleting journey ${
+              options.journeyId
+            } in realm "${state.getRealm()}"...`
+          );
+          const outcome = await deleteJourney(options.journeyId, options);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all journeys...');
+          const outcome = await deleteJourneys(options);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all journeys...');
-        const outcome = await deleteJourneys(options);
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey-describe.ts
+++ b/src/cli/journey/journey-describe.ts
@@ -11,140 +11,168 @@ const { saveTextToFile } = frodo.utils;
 const { createFileParamTreeExportResolver, readJourneys, exportJourney } =
   frodo.authn.journey;
 
-const program = new FrodoCommand('frodo journey describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey describe');
 
-program
-  .description(
-    'If -h is supplied, describe the journey/tree indicated by -i, or all journeys/trees in the realm if no -i is supplied, otherwise describe the journey/tree export file indicated by -f.'
-  )
-  .addOption(
-    new Option(
-      '-i, --journey-id <journey>',
-      'Name of a journey/tree. If specified, -a and -A are ignored.'
+  program
+    .description(
+      'If -h is supplied, describe the journey/tree indicated by -i, or all journeys/trees in the realm if no -i is supplied, otherwise describe the journey/tree export file indicated by -f.'
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the journey export file to describe. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-i, --journey-id <journey>',
+        'Name of a journey/tree. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-F, --output-file <file>',
-      'Name of the file to write the output to.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the journey export file to describe. Ignored with -A.'
+      )
     )
-  )
-  .addOption(new Option('--markdown', 'Output in markdown.'))
-  .addOption(
-    new Option(
-      '-o, --override-version <version>',
-      "Override version. Notation: '<major>.<minor>.<patch>' e.g. '7.2.0'. Override detected version with any version. This is helpful in order to check if journeys in one environment would be compatible running in another environment (e.g. in preparation of migrating from on-prem to ForgeRock Identity Cloud."
+    .addOption(
+      new Option(
+        '-F, --output-file <file>',
+        'Name of the file to write the output to.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      host = host ? host : state.getHost();
-      if (options.outputFile) state.setOutputFile(options.outputFile);
-      // TODO: review checks for arguments
-      if (typeof host === 'undefined' || typeof options.file !== 'undefined') {
+    .addOption(new Option('--markdown', 'Output in markdown.'))
+    .addOption(
+      new Option(
+        '-o, --override-version <version>',
+        "Override version. Notation: '<major>.<minor>.<patch>' e.g. '7.2.0'. Override detected version with any version. This is helpful in order to check if journeys in one environment would be compatible running in another environment (e.g. in preparation of migrating from on-prem to ForgeRock Identity Cloud."
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        host = host ? host : state.getHost();
+        if (options.outputFile) state.setOutputFile(options.outputFile);
+        // TODO: review checks for arguments
         if (
-          typeof host === 'undefined' &&
-          typeof options.file === 'undefined'
+          typeof host === 'undefined' ||
+          typeof options.file !== 'undefined'
         ) {
-          printMessage('Need either [host] or -f.', 'error');
-          process.exitCode = 1;
-          return;
-        }
-        verboseMessage(`Describing local journey file ${options.file}...`);
-        try {
+          if (
+            typeof host === 'undefined' &&
+            typeof options.file === 'undefined'
+          ) {
+            printMessage('Need either [host] or -f.', 'error');
+            process.exitCode = 1;
+            return;
+          }
+          verboseMessage(`Describing local journey file ${options.file}...`);
+          try {
+            // override version
+            if (typeof options.overrideVersion !== 'undefined') {
+              state.setAmVersion(options.overrideVersion);
+            }
+            const fileData = JSON.parse(fs.readFileSync(options.file, 'utf8'));
+            let journeyData;
+            // single or multi tree export?
+            // multi - by id
+            if (
+              typeof options.journeyId !== 'undefined' &&
+              fileData.trees &&
+              fileData.trees[options.journeyId]
+            ) {
+              journeyData = fileData.trees[options.journeyId];
+            }
+            // multi - first
+            else if (
+              typeof options.journeyId === 'undefined' &&
+              fileData.trees
+            ) {
+              [journeyData] = Object.values(fileData.trees);
+            }
+            // single - by id
+            else if (
+              typeof options.journeyId !== 'undefined' &&
+              options.journeyId === fileData.tree?._id
+            ) {
+              journeyData = fileData;
+            }
+            // single
+            else if (
+              typeof options.journeyId === 'undefined' &&
+              fileData.tree?._id
+            ) {
+              journeyData = fileData;
+            }
+            // no journey/tree found
+            else {
+              throw new Error(
+                typeof options.journeyId === 'undefined'
+                  ? `No journey found in ${options.file}`
+                  : `Journey '${options.journeyId}' not found in ${options.file}`
+              );
+            }
+            // ANSI text output
+            if (!options.markdown) {
+              const outcome = await describeJourney(
+                journeyData,
+                createFileParamTreeExportResolver(options.file)
+              );
+              if (!outcome) process.exitCode = 1;
+            }
+            // Markdown output
+            else {
+              // reset output file
+              if (options.outputFile) saveTextToFile('', options.outputFile);
+              const outcome = await describeJourneyMd(
+                journeyData,
+                createFileParamTreeExportResolver(options.file)
+              );
+              if (!outcome) process.exitCode = 1;
+            }
+          } catch (error) {
+            printMessage(error.message, 'error');
+            process.exitCode = 1;
+          }
+        } else if (await getTokens()) {
+          verboseMessage(
+            `Describing journey(s) in realm "${state.getRealm()}"...`
+          );
           // override version
           if (typeof options.overrideVersion !== 'undefined') {
             state.setAmVersion(options.overrideVersion);
           }
-          const fileData = JSON.parse(fs.readFileSync(options.file, 'utf8'));
-          let journeyData;
-          // single or multi tree export?
-          // multi - by id
-          if (
-            typeof options.journeyId !== 'undefined' &&
-            fileData.trees &&
-            fileData.trees[options.journeyId]
-          ) {
-            journeyData = fileData.trees[options.journeyId];
-          }
-          // multi - first
-          else if (typeof options.journeyId === 'undefined' && fileData.trees) {
-            [journeyData] = Object.values(fileData.trees);
-          }
-          // single - by id
-          else if (
-            typeof options.journeyId !== 'undefined' &&
-            options.journeyId === fileData.tree?._id
-          ) {
-            journeyData = fileData;
-          }
-          // single
-          else if (
-            typeof options.journeyId === 'undefined' &&
-            fileData.tree?._id
-          ) {
-            journeyData = fileData;
-          }
-          // no journey/tree found
-          else {
-            throw new Error(
-              typeof options.journeyId === 'undefined'
-                ? `No journey found in ${options.file}`
-                : `Journey '${options.journeyId}' not found in ${options.file}`
-            );
-          }
-          // ANSI text output
-          if (!options.markdown) {
-            const outcome = await describeJourney(
-              journeyData,
-              createFileParamTreeExportResolver(options.file)
-            );
-            if (!outcome) process.exitCode = 1;
-          }
-          // Markdown output
-          else {
-            // reset output file
-            if (options.outputFile) saveTextToFile('', options.outputFile);
-            const outcome = await describeJourneyMd(
-              journeyData,
-              createFileParamTreeExportResolver(options.file)
-            );
-            if (!outcome) process.exitCode = 1;
-          }
-        } catch (error) {
-          printMessage(error.message, 'error');
-          process.exitCode = 1;
-        }
-      } else if (await getTokens()) {
-        verboseMessage(
-          `Describing journey(s) in realm "${state.getRealm()}"...`
-        );
-        // override version
-        if (typeof options.overrideVersion !== 'undefined') {
-          state.setAmVersion(options.overrideVersion);
-        }
-        if (typeof options.journeyId === 'undefined') {
-          let journeys = [];
-          journeys = await readJourneys();
-          for (const journey of journeys) {
+          if (typeof options.journeyId === 'undefined') {
+            let journeys = [];
+            journeys = await readJourneys();
+            for (const journey of journeys) {
+              try {
+                // eslint-disable-next-line no-await-in-loop, dot-notation
+                const treeData = await exportJourney(journey['_id']);
+                // ANSI text output
+                if (!options.markdown) {
+                  const outcome = await describeJourney(treeData);
+                  if (!outcome) process.exitCode = 1;
+                }
+                // Markdown output
+                else {
+                  // reset output file
+                  if (options.outputFile)
+                    saveTextToFile('', options.outputFile);
+                  const outcome = await describeJourneyMd(treeData);
+                  if (!outcome) process.exitCode = 1;
+                }
+              } catch (error) {
+                printError(error);
+                process.exitCode = 1;
+              }
+            }
+          } else {
             try {
-              // eslint-disable-next-line no-await-in-loop, dot-notation
-              const treeData = await exportJourney(journey['_id']);
+              const treeData = await exportJourney(options.journeyId);
               // ANSI text output
               if (!options.markdown) {
                 const outcome = await describeJourney(treeData);
@@ -162,29 +190,10 @@ program
               process.exitCode = 1;
             }
           }
-        } else {
-          try {
-            const treeData = await exportJourney(options.journeyId);
-            // ANSI text output
-            if (!options.markdown) {
-              const outcome = await describeJourney(treeData);
-              if (!outcome) process.exitCode = 1;
-            }
-            // Markdown output
-            else {
-              // reset output file
-              if (options.outputFile) saveTextToFile('', options.outputFile);
-              const outcome = await describeJourneyMd(treeData);
-              if (!outcome) process.exitCode = 1;
-            }
-          } catch (error) {
-            printError(error);
-            process.exitCode = 1;
-          }
         }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey-disable.ts
+++ b/src/cli/journey/journey-disable.ts
@@ -5,43 +5,45 @@ import { disableJourney } from '../../ops/JourneyOps';
 import { printMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo journey disable');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey disable');
 
-program
-  .description('Disable journeys/trees.')
-  .addOption(
-    new Option('-i, --journey-id <journey>', 'Name of a journey/tree.')
-  )
-  // .addOption(
-  //   new Option(
-  //     '-a, --all',
-  //     'Disable all the journeys/trees in a realm. Ignored with -i.'
-  //   )
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // disable
-      if (options.journeyId && (await getTokens())) {
-        const outcome = await disableJourney(options.journeyId);
-        if (!outcome) process.exitCode = 1;
+  program
+    .description('Disable journeys/trees.')
+    .addOption(
+      new Option('-i, --journey-id <journey>', 'Name of a journey/tree.')
+    )
+    // .addOption(
+    //   new Option(
+    //     '-a, --all',
+    //     'Disable all the journeys/trees in a realm. Ignored with -i.'
+    //   )
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // disable
+        if (options.journeyId && (await getTokens())) {
+          const outcome = await disableJourney(options.journeyId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey-enable.ts
+++ b/src/cli/journey/journey-enable.ts
@@ -5,43 +5,45 @@ import { enableJourney } from '../../ops/JourneyOps';
 import { printMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo journey enable');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey enable');
 
-program
-  .description('Enable journeys/trees.')
-  .addOption(
-    new Option('-i, --journey-id <journey>', 'Name of a journey/tree.')
-  )
-  // .addOption(
-  //   new Option(
-  //     '-a, --all',
-  //     'Enable all the journeys/trees in a realm. Ignored with -i.'
-  //   )
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // enable
-      if (options.journeyId && (await getTokens())) {
-        const outcome = await enableJourney(options.journeyId);
-        if (!outcome) process.exitCode = 1;
+  program
+    .description('Enable journeys/trees.')
+    .addOption(
+      new Option('-i, --journey-id <journey>', 'Name of a journey/tree.')
+    )
+    // .addOption(
+    //   new Option(
+    //     '-a, --all',
+    //     'Enable all the journeys/trees in a realm. Ignored with -i.'
+    //   )
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // enable
+        if (options.journeyId && (await getTokens())) {
+          const outcome = await enableJourney(options.journeyId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey-export.ts
+++ b/src/cli/journey/journey-export.ts
@@ -9,128 +9,130 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo journey export');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey export');
 
-program
-  .description('Export journeys/trees.')
-  .addOption(
-    new Option(
-      '-i, --journey-id <journey>',
-      'Name of a journey/tree. If specified, -a and -A are ignored.'
+  program
+    .description('Export journeys/trees.')
+    .addOption(
+      new Option(
+        '-i, --journey-id <journey>',
+        'Name of a journey/tree. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to write the exported journey(s) to. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to write the exported journey(s) to. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all the journeys/trees in a realm. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all the journeys/trees in a realm. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all the journeys/trees in a realm as separate files <journey/tree name>.json. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all the journeys/trees in a realm as separate files <journey/tree name>.json. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--use-string-arrays',
-      'Where applicable, use string arrays to store multi-line text (e.g. scripts).'
-    ).default(false, 'off')
-  )
-  .addOption(
-    new Option(
-      '--no-deps',
-      'Do not include any dependencies (scripts, email templates, SAML entity providers and circles of trust, social identity providers, themes).'
+    .addOption(
+      new Option(
+        '--use-string-arrays',
+        'Where applicable, use string arrays to store multi-line text (e.g. scripts).'
+      ).default(false, 'off')
     )
-  )
-  .addOption(
-    new Option(
-      '--no-coords',
-      'Do not include the x and y coordinate positions of the journey/tree nodes.'
+    .addOption(
+      new Option(
+        '--no-deps',
+        'Do not include any dependencies (scripts, email templates, SAML entity providers and circles of trust, social identity providers, themes).'
+      )
     )
-  )
-  // .addOption(
-  //   new Option(
-  //     '-O, --organize <method>',
-  //     'Organize exports into folders using the indicated method. Valid values for method:\n' +
-  //       'id: folders named by id of exported object\n' +
-  //       'type: folders named by type (e.g. script, journey, idp)\n' +
-  //       'type/id: folders named by type with sub-folders named by id'
-  //   )
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export
-      if (options.journeyId && (await getTokens())) {
-        verboseMessage('Exporting journey...');
-        const outcome = await exportJourneyToFile(
-          options.journeyId,
-          options.file,
-          options.metadata,
-          {
+    .addOption(
+      new Option(
+        '--no-coords',
+        'Do not include the x and y coordinate positions of the journey/tree nodes.'
+      )
+    )
+    // .addOption(
+    //   new Option(
+    //     '-O, --organize <method>',
+    //     'Organize exports into folders using the indicated method. Valid values for method:\n' +
+    //       'id: folders named by id of exported object\n' +
+    //       'type: folders named by type (e.g. script, journey, idp)\n' +
+    //       'type/id: folders named by type with sub-folders named by id'
+    //   )
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // export
+        if (options.journeyId && (await getTokens())) {
+          verboseMessage('Exporting journey...');
+          const outcome = await exportJourneyToFile(
+            options.journeyId,
+            options.file,
+            options.metadata,
+            {
+              useStringArrays: options.useStringArrays,
+              deps: options.deps,
+              coords: options.coords,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all journeys to a single file...');
+          const outcome = await exportJourneysToFile(
+            options.file,
+            options.metadata,
+            {
+              useStringArrays: options.useStringArrays,
+              deps: options.deps,
+              coords: options.coords,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all journeys to separate files...');
+          const outcome = await exportJourneysToFiles(options.metadata, {
             useStringArrays: options.useStringArrays,
             deps: options.deps,
             coords: options.coords,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all journeys to a single file...');
-        const outcome = await exportJourneysToFile(
-          options.file,
-          options.metadata,
-          {
-            useStringArrays: options.useStringArrays,
-            deps: options.deps,
-            coords: options.coords,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all journeys to separate files...');
-        const outcome = await exportJourneysToFiles(options.metadata, {
-          useStringArrays: options.useStringArrays,
-          deps: options.deps,
-          coords: options.coords,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey-import.ts
+++ b/src/cli/journey/journey-import.ts
@@ -10,109 +10,111 @@ import {
 import { printMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo journey import');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey import');
 
-program
-  .description('Import journey/tree.')
-  .addOption(
-    new Option(
-      '-i, --journey-id <journey>',
-      'Name of a journey/tree. If specified, -a and -A are ignored.'
+  program
+    .description('Import journey/tree.')
+    .addOption(
+      new Option(
+        '-i, --journey-id <journey>',
+        'Name of a journey/tree. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import the journey(s) from. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import the journey(s) from. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all the journeys/trees from single file. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all the journeys/trees from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all the journeys/trees from separate files (*.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all the journeys/trees from separate files (*.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '--re-uuid',
-      'Generate new UUIDs for all nodes during import.'
-    ).default(false, 'off')
-  )
-  .addOption(
-    new Option(
-      '--no-deps',
-      'Do not include any dependencies (scripts, email templates, SAML entity providers and circles of trust, social identity providers, themes).'
+    .addOption(
+      new Option(
+        '--re-uuid',
+        'Generate new UUIDs for all nodes during import.'
+      ).default(false, 'off')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import
-      if (options.journeyId && (await getTokens())) {
-        printMessage(`Importing journey ${options.journeyId}...`);
-        const outcome = await importJourneyFromFile(
-          options.journeyId,
-          options.file,
-          {
+    .addOption(
+      new Option(
+        '--no-deps',
+        'Do not include any dependencies (scripts, email templates, SAML entity providers and circles of trust, social identity providers, themes).'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // import
+        if (options.journeyId && (await getTokens())) {
+          printMessage(`Importing journey ${options.journeyId}...`);
+          const outcome = await importJourneyFromFile(
+            options.journeyId,
+            options.file,
+            {
+              reUuid: options.reUuid,
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          printMessage(
+            `Importing all journeys from a single file (${options.file})...`
+          );
+          const outcome = await importJourneysFromFile(options.file, {
             reUuid: options.reUuid,
             deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          printMessage(
+            'Importing all journeys from separate files in current directory...'
+          );
+          const outcome = await importJourneysFromFiles({
+            reUuid: options.reUuid,
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first journey in file
+        else if (options.file && (await getTokens())) {
+          printMessage('Importing first journey in file...');
+          const outcome = await importFirstJourneyFromFile(options.file, {
+            reUuid: options.reUuid,
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        printMessage(
-          `Importing all journeys from a single file (${options.file})...`
-        );
-        const outcome = await importJourneysFromFile(options.file, {
-          reUuid: options.reUuid,
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        printMessage(
-          'Importing all journeys from separate files in current directory...'
-        );
-        const outcome = await importJourneysFromFiles({
-          reUuid: options.reUuid,
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first journey in file
-      else if (options.file && (await getTokens())) {
-        printMessage('Importing first journey in file...');
-        const outcome = await importFirstJourneyFromFile(options.file, {
-          reUuid: options.reUuid,
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey-list.ts
+++ b/src/cli/journey/journey-list.ts
@@ -6,34 +6,38 @@ import { listJourneys } from '../../ops/JourneyOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo journey list');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey list');
 
-program
-  .description('List journeys/trees.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .addOption(new Option('-a, --analyze', 'Analyze journeys for custom nodes.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Listing journeys in realm "${state.getRealm()}"...`);
-        const outcome = await listJourneys(options.long, options.analyze);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List journeys/trees.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .addOption(
+      new Option('-a, --analyze', 'Analyze journeys for custom nodes.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Listing journeys in realm "${state.getRealm()}"...`);
+          const outcome = await listJourneys(options.long, options.analyze);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey-prune.ts
+++ b/src/cli/journey/journey-prune.ts
@@ -7,48 +7,50 @@ import { FrodoCommand } from '../FrodoCommand';
 
 const { findOrphanedNodes, removeOrphanedNodes } = frodo.authn.node;
 
-const program = new FrodoCommand('frodo journey prune');
+export default function setup() {
+  const program = new FrodoCommand('frodo journey prune');
 
-program
-  .description(
-    'Prune orphaned configuration artifacts left behind after deleting authentication trees. You will be prompted before any destructive operations are performed.'
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(
-          `Pruning orphaned configuration artifacts in realm "${state.getRealm()}"...`
+  program
+    .description(
+      'Prune orphaned configuration artifacts left behind after deleting authentication trees. You will be prompted before any destructive operations are performed.'
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        try {
-          const orphanedNodes = await findOrphanedNodes();
-          if (orphanedNodes.length > 0) {
-            const ok = await yesno({
-              question: 'Prune (permanently delete) orphaned nodes? (y|n):',
-            });
-            if (ok) {
-              await removeOrphanedNodes(orphanedNodes);
+        if (await getTokens()) {
+          verboseMessage(
+            `Pruning orphaned configuration artifacts in realm "${state.getRealm()}"...`
+          );
+          try {
+            const orphanedNodes = await findOrphanedNodes();
+            if (orphanedNodes.length > 0) {
+              const ok = await yesno({
+                question: 'Prune (permanently delete) orphaned nodes? (y|n):',
+              });
+              if (ok) {
+                await removeOrphanedNodes(orphanedNodes);
+              }
+            } else {
+              printMessage('No orphaned nodes found.');
             }
-          } else {
-            printMessage('No orphaned nodes found.');
+          } catch (error) {
+            printError(error);
+            process.exitCode = 1;
           }
-        } catch (error) {
-          printError(error);
+        } else {
           process.exitCode = 1;
         }
-      } else {
-        process.exitCode = 1;
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/journey/journey.ts
+++ b/src/cli/journey/journey.ts
@@ -1,36 +1,33 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './journey-delete.js';
+import DescribeCmd from './journey-describe.js';
+import DisableCmd from './journey-disable.js';
+import EnableCmd from './journey-enable.js';
+import ExportCmd from './journey-export.js';
+import ImportCmd from './journey-import.js';
+import ListCmd from './journey-list.js';
+import PruneCmd from './journey-prune.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('journey')
-    .description('Manage journeys/trees.')
-    .executableDir(__dirname);
-
-  program.command('list', 'List journeys/trees.');
-
-  program.command(
-    'describe',
-    'If host argument is supplied, describe the journey/tree indicated by -t, or all journeys/trees in the realm if no -t is supplied, otherwise describe the journey/tree export file indicated by -f.'
+  const program = new FrodoStubCommand('journey').description(
+    'Manage journeys/trees.'
   );
 
-  program.command('export', 'Export journeys/trees.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('import', 'Import journeys/trees.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('delete', 'Delete journeys/trees.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command(
-    'prune',
-    'Prune orphaned configuration artifacts left behind after deleting authentication trees. You will be prompted before any destructive operations are performed.'
-  );
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('enable', 'Enable journeys/trees.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-  program.command('disable', 'Disable journeys/trees.');
+  program.addCommand(PruneCmd().name('prune'));
+
+  program.addCommand(EnableCmd().name('enable'));
+
+  program.addCommand(DisableCmd().name('disable'));
 
   return program;
 }

--- a/src/cli/log/log-fetch.ts
+++ b/src/cli/log/log-fetch.ts
@@ -16,186 +16,188 @@ const SECONDS_IN_1_HOUR = 3600;
 const LOG_TIME_WINDOW_MAX = SECONDS_IN_30_DAYS;
 const LOG_TIME_WINDOW_INCREMENT = 1;
 
-const program = new FrodoCommand('frodo log fetch', ['realm', 'type']);
-program
-  .description(
-    'Fetch Identity Cloud logs between a specified begin and end time period.\
- WARNING: depending on filters and time period specified, this could take substantial time to complete.'
-  )
-  .addOption(sourcesOptionM)
-  .addOption(
-    new Option(
-      '-l, --level <level>',
-      'Set log level filter. You can specify the level as a number or a string. \
-Following values are possible (values on the same line are equivalent): \
-\n0, SEVERE, FATAL, or ERROR\n1, WARNING, WARN or CONFIG\
-\n2, INFO or INFORMATION\n3, DEBUG, FINE, FINER or FINEST\
-\n4 or ALL'
-    ).default('ERROR', `${resolveLevel('ERROR')}`)
-  )
-  .addOption(
-    new Option('-t, --transaction-id <txid>', 'Filter by transactionId')
-  )
-  .addOption(
-    new Option(
-      '-b, --begin-timestamp <beginTs>',
-      'Begin timestamp for period (in ISO8601, example: "2022-10-13T19:06:28Z", or "2022-09.30". \
-Cannot be more than 30 days in the past. If not specified, logs from one hour ago are fetched \
-(-e is ignored)'
+export default function setup() {
+  const program = new FrodoCommand('frodo log fetch', ['realm', 'type']);
+  program
+    .description(
+      'Fetch Identity Cloud logs between a specified begin and end time period.\
+  WARNING: depending on filters and time period specified, this could take substantial time to complete.'
     )
-  )
-  .addOption(
-    new Option(
-      '-e, --end-timestamp <endTs>',
-      'End timestamp for period. Default: "now"'
+    .addOption(sourcesOptionM)
+    .addOption(
+      new Option(
+        '-l, --level <level>',
+        'Set log level filter. You can specify the level as a number or a string. \
+  Following values are possible (values on the same line are equivalent): \
+  \n0, SEVERE, FATAL, or ERROR\n1, WARNING, WARN or CONFIG\
+  \n2, INFO or INFORMATION\n3, DEBUG, FINE, FINER or FINEST\
+  \n4 or ALL'
+      ).default('ERROR', `${resolveLevel('ERROR')}`)
     )
-  )
-  .addOption(
-    new Option(
-      '-s, --search-string <ss>',
-      'Filter by a specific string (ANDed with transactionID filter)'
+    .addOption(
+      new Option('-t, --transaction-id <txid>', 'Filter by transactionId')
     )
-  )
-  .addOption(
-    new Option('-d, --defaults', 'Use default logging noise filters').default(
-      false,
-      `Use custom logging noise filters defined in $HOME/${config.FRODO_LOG_NOISEFILTER_FILENAME}`
+    .addOption(
+      new Option(
+        '-b, --begin-timestamp <beginTs>',
+        'Begin timestamp for period (in ISO8601, example: "2022-10-13T19:06:28Z", or "2022-09.30". \
+  Cannot be more than 30 days in the past. If not specified, logs from one hour ago are fetched \
+  (-e is ignored)'
+      )
     )
-  )
-  .action(async (host, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(host, user, password, options, command);
+    .addOption(
+      new Option(
+        '-e, --end-timestamp <endTs>',
+        'End timestamp for period. Default: "now"'
+      )
+    )
+    .addOption(
+      new Option(
+        '-s, --search-string <ss>',
+        'Filter by a specific string (ANDed with transactionID filter)'
+      )
+    )
+    .addOption(
+      new Option('-d, --defaults', 'Use default logging noise filters').default(
+        false,
+        `Use custom logging noise filters defined in $HOME/${config.FRODO_LOG_NOISEFILTER_FILENAME}`
+      )
+    )
+    .action(async (host, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(host, user, password, options, command);
 
-    let foundCredentials = false;
+      let foundCredentials = false;
 
-    const conn = await getConnectionProfile();
-    if (conn) state.setHost(conn.tenant);
+      const conn = await getConnectionProfile();
+      if (conn) state.setHost(conn.tenant);
 
-    // log api creds have been supplied as username and password arguments
-    if (state.getUsername() && state.getPassword()) {
-      verboseMessage(`Using log api credentials from command line.`);
-      state.setLogApiKey(state.getUsername());
-      state.setLogApiSecret(state.getPassword());
-      foundCredentials = true;
-    }
-    // log api creds from connection profile
-    else if (conn && conn.logApiKey != null && conn.logApiSecret != null) {
-      verboseMessage(`Using log api credentials from connection profile.`);
-      state.setLogApiKey(conn.logApiKey);
-      state.setLogApiSecret(conn.logApiSecret);
-      foundCredentials = true;
-    }
-    // log api creds have been supplied via env variables
-    else if (state.getLogApiKey() && state.getLogApiSecret()) {
-      verboseMessage(`Using log api credentials from environment variables.`);
-      foundCredentials = true;
-    }
-    // no log api creds but got username and password, so can try to create them
-    else if (conn && conn.username && conn.password) {
-      printMessage(
-        `Found admin credentials in connection profile, attempting to create log api credentials...`
-      );
-      state.setUsername(conn.username);
-      state.setPassword(conn.password);
-      if (await getTokens(true)) {
-        const creds = await provisionCreds();
-        state.setLogApiKey(creds.api_key_id as string);
-        state.setLogApiSecret(creds.api_key_secret as string);
-        try {
-          await saveConnectionProfile(state.getHost());
-        } catch (error) {
-          printError(error);
-        }
+      // log api creds have been supplied as username and password arguments
+      if (state.getUsername() && state.getPassword()) {
+        verboseMessage(`Using log api credentials from command line.`);
+        state.setLogApiKey(state.getUsername());
+        state.setLogApiSecret(state.getPassword());
         foundCredentials = true;
       }
-      // unable to create credentials
+      // log api creds from connection profile
+      else if (conn && conn.logApiKey != null && conn.logApiSecret != null) {
+        verboseMessage(`Using log api credentials from connection profile.`);
+        state.setLogApiKey(conn.logApiKey);
+        state.setLogApiSecret(conn.logApiSecret);
+        foundCredentials = true;
+      }
+      // log api creds have been supplied via env variables
+      else if (state.getLogApiKey() && state.getLogApiSecret()) {
+        verboseMessage(`Using log api credentials from environment variables.`);
+        foundCredentials = true;
+      }
+      // no log api creds but got username and password, so can try to create them
+      else if (conn && conn.username && conn.password) {
+        printMessage(
+          `Found admin credentials in connection profile, attempting to create log api credentials...`
+        );
+        state.setUsername(conn.username);
+        state.setPassword(conn.password);
+        if (await getTokens(true)) {
+          const creds = await provisionCreds();
+          state.setLogApiKey(creds.api_key_id as string);
+          state.setLogApiSecret(creds.api_key_secret as string);
+          try {
+            await saveConnectionProfile(state.getHost());
+          } catch (error) {
+            printError(error);
+          }
+          foundCredentials = true;
+        }
+        // unable to create credentials
+        else {
+          printMessage(`Unable to create log api credentials.`);
+        }
+      }
+
+      if (foundCredentials) {
+        const now = Date.now() / 1000;
+        const nowString = new Date(now * 1000).toISOString();
+        if (
+          typeof options.beginTimestamp === 'undefined' ||
+          !options.beginTimestamp
+        ) {
+          // no beginTimestamp value specified, default is 1 hour ago
+          const tempStartDate = new Date();
+          tempStartDate.setTime((now - SECONDS_IN_1_HOUR) * 1000);
+          options.beginTimestamp = tempStartDate.toISOString();
+          // also override endTimestamp to now
+          const tempEndDate = new Date();
+          tempEndDate.setTime(now * 1000);
+          options.endTimestamp = tempEndDate;
+          printMessage(
+            'No timestamps specified, defaulting to logs from 1 hour ago',
+            'info'
+          );
+        }
+        if (
+          typeof options.endTimestamp === 'undefined' ||
+          !options.endTimestamp
+        ) {
+          // no endTimestamp value specified, default is now
+          options.endTimestamp = nowString;
+          printMessage(
+            'No end timestamp specified, defaulting end timestamp to "now"',
+            'info'
+          );
+        }
+        let beginTs = Date.parse(options.beginTimestamp) / 1000;
+        const endTs = Date.parse(options.endTimestamp) / 1000;
+        if (endTs < beginTs) {
+          printMessage(
+            'End timestamp can not be before begin timestamp',
+            'error'
+          );
+          process.exitCode = 1;
+          return;
+        }
+        if (now - beginTs > LOG_TIME_WINDOW_MAX) {
+          printMessage(
+            'Begin timestamp can not be more than 30 days in the past',
+            'error'
+          );
+          process.exitCode = 1;
+          return;
+        }
+        let intermediateEndTs = 0;
+        printMessage(
+          `Fetching ID Cloud logs from the following sources: ${
+            command.opts().sources
+          } and levels [${resolveLevel(command.opts().level)}] of ${
+            conn.tenant
+          }...`
+        );
+
+        let timeIncrement = LOG_TIME_WINDOW_INCREMENT;
+        if (endTs - beginTs > 30) {
+          timeIncrement = timeIncrement * 30;
+        }
+        do {
+          intermediateEndTs = beginTs + timeIncrement;
+          await fetchLogs(
+            command.opts().sources,
+            new Date(beginTs * 1000).toISOString(),
+            new Date(intermediateEndTs * 1000).toISOString(),
+            resolveLevel(command.opts().level),
+            command.opts().transactionId,
+            command.opts().searchString,
+            null,
+            config.getNoiseFilters(options.defaults)
+          );
+          beginTs = intermediateEndTs;
+        } while (intermediateEndTs < endTs);
+      }
+      // no log api credentials
       else {
-        printMessage(`Unable to create log api credentials.`);
-      }
-    }
-
-    if (foundCredentials) {
-      const now = Date.now() / 1000;
-      const nowString = new Date(now * 1000).toISOString();
-      if (
-        typeof options.beginTimestamp === 'undefined' ||
-        !options.beginTimestamp
-      ) {
-        // no beginTimestamp value specified, default is 1 hour ago
-        const tempStartDate = new Date();
-        tempStartDate.setTime((now - SECONDS_IN_1_HOUR) * 1000);
-        options.beginTimestamp = tempStartDate.toISOString();
-        // also override endTimestamp to now
-        const tempEndDate = new Date();
-        tempEndDate.setTime(now * 1000);
-        options.endTimestamp = tempEndDate;
-        printMessage(
-          'No timestamps specified, defaulting to logs from 1 hour ago',
-          'info'
-        );
-      }
-      if (
-        typeof options.endTimestamp === 'undefined' ||
-        !options.endTimestamp
-      ) {
-        // no endTimestamp value specified, default is now
-        options.endTimestamp = nowString;
-        printMessage(
-          'No end timestamp specified, defaulting end timestamp to "now"',
-          'info'
-        );
-      }
-      let beginTs = Date.parse(options.beginTimestamp) / 1000;
-      const endTs = Date.parse(options.endTimestamp) / 1000;
-      if (endTs < beginTs) {
-        printMessage(
-          'End timestamp can not be before begin timestamp',
-          'error'
-        );
+        printMessage('No log api credentials found!');
+        program.help();
         process.exitCode = 1;
-        return;
       }
-      if (now - beginTs > LOG_TIME_WINDOW_MAX) {
-        printMessage(
-          'Begin timestamp can not be more than 30 days in the past',
-          'error'
-        );
-        process.exitCode = 1;
-        return;
-      }
-      let intermediateEndTs = 0;
-      printMessage(
-        `Fetching ID Cloud logs from the following sources: ${
-          command.opts().sources
-        } and levels [${resolveLevel(command.opts().level)}] of ${
-          conn.tenant
-        }...`
-      );
+    });
 
-      let timeIncrement = LOG_TIME_WINDOW_INCREMENT;
-      if (endTs - beginTs > 30) {
-        timeIncrement = timeIncrement * 30;
-      }
-      do {
-        intermediateEndTs = beginTs + timeIncrement;
-        await fetchLogs(
-          command.opts().sources,
-          new Date(beginTs * 1000).toISOString(),
-          new Date(intermediateEndTs * 1000).toISOString(),
-          resolveLevel(command.opts().level),
-          command.opts().transactionId,
-          command.opts().searchString,
-          null,
-          config.getNoiseFilters(options.defaults)
-        );
-        beginTs = intermediateEndTs;
-      } while (intermediateEndTs < endTs);
-    }
-    // no log api credentials
-    else {
-      printMessage('No log api credentials found!');
-      program.help();
-      process.exitCode = 1;
-    }
-  });
-
-program.parse();
+  return program;
+}

--- a/src/cli/log/log-key-delete.ts
+++ b/src/cli/log/log-key-delete.ts
@@ -5,51 +5,53 @@ import { deleteLogApiKey, deleteLogApiKeys } from '../../ops/LogOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo log key delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo log key delete');
 
-program
-  .description('Delete log API keys.')
-  .addOption(
-    new Option('-i, --key-id <key-id>', 'Key id. Regex if specified with -a.')
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Delete all keys. Optionally specify regex filter -i.'
+  program
+    .description('Delete log API keys.')
+    .addOption(
+      new Option('-i, --key-id <key-id>', 'Key id. Regex if specified with -a.')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by id
-      if (options.keyId && (await getTokens(true))) {
-        verboseMessage(`Deleting key ${options.keyId}`);
-        deleteLogApiKey(options.keyId);
-      }
-      // --all -a
-      else if (options.all && (await getTokens(true))) {
-        verboseMessage('Deleting keys...');
-        deleteLogApiKeys();
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all keys. Optionally specify regex filter -i.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        program.help();
-        process.exitCode = 1;
+        // delete by id
+        if (options.keyId && (await getTokens(true))) {
+          verboseMessage(`Deleting key ${options.keyId}`);
+          deleteLogApiKey(options.keyId);
+        }
+        // --all -a
+        else if (options.all && (await getTokens(true))) {
+          verboseMessage('Deleting keys...');
+          deleteLogApiKeys();
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/log/log-key-describe.ts
+++ b/src/cli/log/log-key-describe.ts
@@ -3,34 +3,36 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo log key describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo log key describe');
 
-program
-  .description('Describe log API keys.')
-  .addOption(
-    new Option(
-      '-i, --key-id <key-id>',
-      'Key id. If specified, -a and -A are ignored.'
+  program
+    .description('Describe log API keys.')
+    .addOption(
+      new Option(
+        '-i, --key-id <key-id>',
+        'Key id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/log/log-key-list.ts
+++ b/src/cli/log/log-key-list.ts
@@ -5,33 +5,35 @@ import { listLogApiKeys } from '../../ops/LogOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo log key list');
+export default function setup() {
+  const program = new FrodoCommand('frodo log key list');
 
-program
-  .description('List log API keys.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens(true)) {
-        verboseMessage(`Listing log API keys...`);
-        const outcome = await listLogApiKeys(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List log API keys.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens(true)) {
+          verboseMessage(`Listing log API keys...`);
+          const outcome = await listLogApiKeys(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/log/log-key.ts
+++ b/src/cli/log/log-key.ts
@@ -1,13 +1,18 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import DeleteCmd from './log-key-delete.js';
+import DescribeCmd from './log-key-describe.js';
+import ListCmd from './log-key-list.js';
 
-const program = new FrodoStubCommand('frodo log key');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo log key');
 
-program.description('Manage Identity Cloud log API keys.');
+  program.description('Manage Identity Cloud log API keys.');
 
-program.command('list', 'List log API keys.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('describe', 'Describe log API keys.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-program.command('delete', 'Delete log API keys.');
+  program.addCommand(DeleteCmd().name('delete'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/log/log-list.ts
+++ b/src/cli/log/log-list.ts
@@ -9,95 +9,97 @@ import { FrodoCommand } from '../FrodoCommand';
 const { getConnectionProfile, saveConnectionProfile } = frodo.conn;
 const { getLogSources } = frodo.cloud.log;
 
-const program = new FrodoCommand('frodo log list', ['realm', 'type']);
-program
-  .description('List available ID Cloud log sources.')
-  .action(async (host, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(host, user, password, options, command);
+export default function setup() {
+  const program = new FrodoCommand('frodo log list', ['realm', 'type']);
+  program
+    .description('List available ID Cloud log sources.')
+    .action(async (host, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(host, user, password, options, command);
 
-    verboseMessage('Listing available ID Cloud log sources...');
+      verboseMessage('Listing available ID Cloud log sources...');
 
-    let foundCredentials = false;
+      let foundCredentials = false;
 
-    let conn: ConnectionProfileInterface;
-    try {
-      conn = await getConnectionProfile();
-    } catch (error) {
-      // ignore
-    }
-    if (conn) state.setHost(conn.tenant);
+      let conn: ConnectionProfileInterface;
+      try {
+        conn = await getConnectionProfile();
+      } catch (error) {
+        // ignore
+      }
+      if (conn) state.setHost(conn.tenant);
 
-    // log api creds have been supplied as username and password arguments
-    if (state.getUsername() && state.getPassword()) {
-      verboseMessage(`Using log api credentials from command line.`);
-      state.setLogApiKey(state.getUsername());
-      state.setLogApiSecret(state.getPassword());
-      foundCredentials = true;
-    }
-    // log api creds from connection profile
-    else if (conn && conn.logApiKey != null && conn.logApiSecret != null) {
-      verboseMessage(`Using log api credentials from connection profile.`);
-      state.setLogApiKey(conn.logApiKey);
-      state.setLogApiSecret(conn.logApiSecret);
-      foundCredentials = true;
-    }
-    // log api creds have been supplied via env variables
-    else if (state.getLogApiKey() && state.getLogApiSecret()) {
-      verboseMessage(`Using log api credentials from environment variables.`);
-      foundCredentials = true;
-    }
-    // no log api creds but got username and password, so can try to create them
-    else if (conn && conn.username && conn.password) {
-      printMessage(
-        `Found admin credentials in connection profile, attempting to create log api credentials...`
-      );
-      state.setUsername(conn.username);
-      state.setPassword(conn.password);
-      if (await getTokens(true)) {
-        const creds = await provisionCreds();
-        state.setLogApiKey(creds.api_key_id as string);
-        state.setLogApiSecret(creds.api_key_secret as string);
-        try {
-          await saveConnectionProfile(state.getHost());
-        } catch (error) {
-          printError(error);
-        }
+      // log api creds have been supplied as username and password arguments
+      if (state.getUsername() && state.getPassword()) {
+        verboseMessage(`Using log api credentials from command line.`);
+        state.setLogApiKey(state.getUsername());
+        state.setLogApiSecret(state.getPassword());
         foundCredentials = true;
       }
-      // unable to create credentials
-      else {
-        printMessage(`Unable to create log api credentials.`);
+      // log api creds from connection profile
+      else if (conn && conn.logApiKey != null && conn.logApiSecret != null) {
+        verboseMessage(`Using log api credentials from connection profile.`);
+        state.setLogApiKey(conn.logApiKey);
+        state.setLogApiSecret(conn.logApiSecret);
+        foundCredentials = true;
       }
-    }
-
-    if (foundCredentials) {
-      const sources = await getLogSources();
-      if (sources.length === 0) {
+      // log api creds have been supplied via env variables
+      else if (state.getLogApiKey() && state.getLogApiSecret()) {
+        verboseMessage(`Using log api credentials from environment variables.`);
+        foundCredentials = true;
+      }
+      // no log api creds but got username and password, so can try to create them
+      else if (conn && conn.username && conn.password) {
         printMessage(
-          "Can't get sources, possible cause - wrong API key or secret",
-          'error'
+          `Found admin credentials in connection profile, attempting to create log api credentials...`
         );
-      } else {
-        printMessage(`Log sources from ${state.getHost()}`);
-        for (const source of sources) {
-          printMessage(`${source}`, 'data');
+        state.setUsername(conn.username);
+        state.setPassword(conn.password);
+        if (await getTokens(true)) {
+          const creds = await provisionCreds();
+          state.setLogApiKey(creds.api_key_id as string);
+          state.setLogApiSecret(creds.api_key_secret as string);
+          try {
+            await saveConnectionProfile(state.getHost());
+          } catch (error) {
+            printError(error);
+          }
+          foundCredentials = true;
         }
-        printMessage(
-          'Use any combination of comma separated sources, example:',
-          'info'
-        );
-        printMessage(
-          `$ frodo logs tail -c am-core,idm-core ${state.getHost()}`,
-          'text'
-        );
+        // unable to create credentials
+        else {
+          printMessage(`Unable to create log api credentials.`);
+        }
       }
-    }
-    // no log api credentials
-    else {
-      printMessage('No log api credentials found!');
-      program.help();
-      process.exitCode = 1;
-    }
-  });
 
-program.parse();
+      if (foundCredentials) {
+        const sources = await getLogSources();
+        if (sources.length === 0) {
+          printMessage(
+            "Can't get sources, possible cause - wrong API key or secret",
+            'error'
+          );
+        } else {
+          printMessage(`Log sources from ${state.getHost()}`);
+          for (const source of sources) {
+            printMessage(`${source}`, 'data');
+          }
+          printMessage(
+            'Use any combination of comma separated sources, example:',
+            'info'
+          );
+          printMessage(
+            `$ frodo logs tail -c am-core,idm-core ${state.getHost()}`,
+            'text'
+          );
+        }
+      }
+      // no log api credentials
+      else {
+        printMessage('No log api credentials found!');
+        program.help();
+        process.exitCode = 1;
+      }
+    });
+
+  return program;
+}

--- a/src/cli/log/log-tail.ts
+++ b/src/cli/log/log-tail.ts
@@ -11,100 +11,104 @@ import { sourcesOptionM } from './log';
 const { resolveLevel } = frodo.cloud.log;
 const { getConnectionProfile, saveConnectionProfile } = frodo.conn;
 
-const program = new FrodoCommand('frodo log tail', ['realm', 'type']);
-program
-  .description('Tail Identity Cloud logs.')
-  .addOption(sourcesOptionM)
-  .addOption(
-    new Option(
-      '-l, --level <level>',
-      'Set log level filter. You can specify the level as a number or a string. \
-Following values are possible (values on the same line are equivalent): \
-\n0, SEVERE, FATAL, or ERROR\n1, WARNING, WARN or CONFIG\
-\n2, INFO or INFORMATION\n3, DEBUG, FINE, FINER or FINEST\
-\n4 or ALL'
-    ).default('ERROR', `${resolveLevel('ERROR')}`)
-  )
-  .addOption(
-    new Option('-t, --transaction-id <txid>', 'Filter by transactionId')
-  )
-  .addOption(
-    new Option('-d, --defaults', 'Use default logging noise filters').default(
-      false,
-      `Use custom logging noise filters defined in $HOME/${config.FRODO_LOG_NOISEFILTER_FILENAME}`
+export default function setup() {
+  const program = new FrodoCommand('frodo log tail', ['realm', 'type']);
+  program
+    .description('Tail Identity Cloud logs.')
+    .addOption(sourcesOptionM)
+    .addOption(
+      new Option(
+        '-l, --level <level>',
+        'Set log level filter. You can specify the level as a number or a string. \
+  Following values are possible (values on the same line are equivalent): \
+  \n0, SEVERE, FATAL, or ERROR\n1, WARNING, WARN or CONFIG\
+  \n2, INFO or INFORMATION\n3, DEBUG, FINE, FINER or FINEST\
+  \n4 or ALL'
+      ).default('ERROR', `${resolveLevel('ERROR')}`)
     )
-  )
-  .action(async (host, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(host, user, password, options, command);
+    .addOption(
+      new Option('-t, --transaction-id <txid>', 'Filter by transactionId')
+    )
+    .addOption(
+      new Option('-d, --defaults', 'Use default logging noise filters').default(
+        false,
+        `Use custom logging noise filters defined in $HOME/${config.FRODO_LOG_NOISEFILTER_FILENAME}`
+      )
+    )
+    .action(async (host, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(host, user, password, options, command);
 
-    let foundCredentials = false;
+      let foundCredentials = false;
 
-    const conn = await getConnectionProfile();
-    if (conn) state.setHost(conn.tenant);
+      const conn = await getConnectionProfile();
+      if (conn) state.setHost(conn.tenant);
 
-    // log api creds have been supplied as username and password arguments
-    if (state.getUsername() && state.getPassword()) {
-      verboseMessage(`Using log api credentials from command line.`);
-      state.setLogApiKey(state.getUsername());
-      state.setLogApiSecret(state.getPassword());
-      foundCredentials = true;
-    }
-    // log api creds from connection profile
-    else if (conn && conn.logApiKey != null && conn.logApiSecret != null) {
-      verboseMessage(`Using log api credentials from connection profile.`);
-      state.setLogApiKey(conn.logApiKey);
-      state.setLogApiSecret(conn.logApiSecret);
-      foundCredentials = true;
-    }
-    // log api creds have been supplied via env variables
-    else if (state.getLogApiKey() && state.getLogApiSecret()) {
-      verboseMessage(`Using log api credentials from environment variables.`);
-      foundCredentials = true;
-    }
-    // no log api creds but got username and password, so can try to create them
-    else if (conn && conn.username && conn.password) {
-      printMessage(
-        `Found admin credentials in connection profile, attempting to create log api credentials...`
-      );
-      state.setUsername(conn.username);
-      state.setPassword(conn.password);
-      if (await getTokens(true)) {
-        const creds = await provisionCreds();
-        state.setLogApiKey(creds.api_key_id as string);
-        state.setLogApiSecret(creds.api_key_secret as string);
-        try {
-          await saveConnectionProfile(state.getHost());
-        } catch (error) {
-          printError(error);
-        }
+      // log api creds have been supplied as username and password arguments
+      if (state.getUsername() && state.getPassword()) {
+        verboseMessage(`Using log api credentials from command line.`);
+        state.setLogApiKey(state.getUsername());
+        state.setLogApiSecret(state.getPassword());
         foundCredentials = true;
       }
-      // unable to create credentials
-      else {
-        printMessage(`Unable to create log api credentials.`);
+      // log api creds from connection profile
+      else if (conn && conn.logApiKey != null && conn.logApiSecret != null) {
+        verboseMessage(`Using log api credentials from connection profile.`);
+        state.setLogApiKey(conn.logApiKey);
+        state.setLogApiSecret(conn.logApiSecret);
+        foundCredentials = true;
       }
-    }
+      // log api creds have been supplied via env variables
+      else if (state.getLogApiKey() && state.getLogApiSecret()) {
+        verboseMessage(`Using log api credentials from environment variables.`);
+        foundCredentials = true;
+      }
+      // no log api creds but got username and password, so can try to create them
+      else if (conn && conn.username && conn.password) {
+        printMessage(
+          `Found admin credentials in connection profile, attempting to create log api credentials...`
+        );
+        state.setUsername(conn.username);
+        state.setPassword(conn.password);
+        if (await getTokens(true)) {
+          const creds = await provisionCreds();
+          state.setLogApiKey(creds.api_key_id as string);
+          state.setLogApiSecret(creds.api_key_secret as string);
+          try {
+            await saveConnectionProfile(state.getHost());
+          } catch (error) {
+            printError(error);
+          }
+          foundCredentials = true;
+        }
+        // unable to create credentials
+        else {
+          printMessage(`Unable to create log api credentials.`);
+        }
+      }
 
-    if (foundCredentials) {
-      printMessage(
-        `Tailing ID Cloud logs from the following sources: ${
-          options.sources
-        } and levels [${resolveLevel(options.level)}] of ${state.getHost()}...`
-      );
-      await tailLogs(
-        command.opts().sources,
-        resolveLevel(command.opts().level),
-        command.opts().transactionId,
-        null,
-        config.getNoiseFilters(options.defaults)
-      );
-    }
-    // no log api credentials
-    else {
-      printMessage('No log api credentials found!');
-      program.help();
-      process.exitCode = 1;
-    }
-  });
+      if (foundCredentials) {
+        printMessage(
+          `Tailing ID Cloud logs from the following sources: ${
+            options.sources
+          } and levels [${resolveLevel(
+            options.level
+          )}] of ${state.getHost()}...`
+        );
+        await tailLogs(
+          command.opts().sources,
+          resolveLevel(command.opts().level),
+          command.opts().transactionId,
+          null,
+          config.getNoiseFilters(options.defaults)
+        );
+      }
+      // no log api credentials
+      else {
+        printMessage('No log api credentials found!');
+        program.help();
+        process.exitCode = 1;
+      }
+    });
 
-program.parse();
+  return program;
+}

--- a/src/cli/log/log.ts
+++ b/src/cli/log/log.ts
@@ -1,10 +1,10 @@
 import { Option } from 'commander';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import FetchCmd from './log-fetch';
+import KeyCmd from './log-key.js';
+import ListCmd from './log-list.js';
+import TailCmd from './log-tail.js';
 
 export const sourcesOptionM = new Option(
   '-c, --sources <sources>',
@@ -20,16 +20,15 @@ export default function setup() {
     .summary('List/View Identity Cloud logs')
     .description(
       `View Identity Cloud logs. If valid tenant admin credentials are specified, a log API key and secret are automatically created for that admin user.`
-    )
-    .executableDir(__dirname);
+    );
 
-  program.command('list', 'List available ID Cloud log sources.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('tail', 'Tail Identity Cloud logs.');
+  program.addCommand(TailCmd().name('tail'));
 
-  program.command('fetch', 'Fetch Identity Cloud logs for a time window.');
+  program.addCommand(FetchCmd().name('fetch'));
 
-  program.command('key', 'Manage Identity Cloud log API keys.');
+  program.addCommand(KeyCmd().name('key'));
 
   return program;
 }

--- a/src/cli/oauth/oauth-client-delete.ts
+++ b/src/cli/oauth/oauth-client-delete.ts
@@ -3,43 +3,45 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo oauth client delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo oauth client delete');
 
-program
-  .description('Delete OAuth2 clients.')
-  .addOption(
-    new Option(
-      '-i, --app-id <id>',
-      'OAuth2 application id/name. If specified, -a and -A are ignored.'
+  program
+    .description('Delete OAuth2 clients.')
+    .addOption(
+      new Option(
+        '-i, --app-id <id>',
+        'OAuth2 client id/name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all cmds in a realm. Ignored with -i.')
-  )
-  .addOption(
-    new Option(
-      '--no-deep',
-      'No deep delete. This leaves orphaned configuration artifacts behind.'
+    .addOption(
+      new Option('-a, --all', 'Delete all cmds in a realm. Ignored with -i.')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+    .addOption(
+      new Option(
+        '--no-deep',
+        'No deep delete. This leaves orphaned configuration artifacts behind.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/oauth/oauth-client-describe.ts
+++ b/src/cli/oauth/oauth-client-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo oauth client describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo oauth client describe');
 
-program
-  .description('Describe OAuth2 application.')
-  .addOption(new Option('-i, --app-id <id>', 'OAuth2 application id/name.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe OAuth2 client.')
+    .addOption(new Option('-i, --app-id <id>', 'OAuth2 client id/name.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/oauth/oauth-client-import.ts
+++ b/src/cli/oauth/oauth-client-import.ts
@@ -10,93 +10,95 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo oauth client import');
+export default function setup() {
+  const program = new FrodoCommand('frodo oauth client import');
 
-program
-  .description('Import OAuth2 applications.')
-  .addOption(
-    new Option(
-      '-i, --app-id <id>',
-      'Application id. If specified, only one application is imported and the options -a and -A are ignored.'
+  program
+    .description('Import OAuth2 clients.')
+    .addOption(
+      new Option(
+        '-i, --app-id <id>',
+        'Client id. If specified, only one client is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all applications from single file. Ignored with -i.'
+    .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all clients from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all applications from separate files (*.app.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all clients from separate files (*.app.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option('--no-deps', 'Do not include any dependencies (scripts).')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import by id
-      if (options.file && options.appId && (await getTokens())) {
-        verboseMessage(`Importing OAuth2 application "${options.appId}"...`);
-        const outcome = await importOAuth2ClientFromFile(
-          options.appId,
-          options.file,
-          {
+    .addOption(
+      new Option('--no-deps', 'Do not include any dependencies (scripts).')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        // import by id
+        if (options.file && options.appId && (await getTokens())) {
+          verboseMessage(`Importing OAuth2 client "${options.appId}"...`);
+          const outcome = await importOAuth2ClientFromFile(
+            options.appId,
+            options.file,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing all OAuth2 clients from a single file (${options.file})...`
+          );
+          const outcome = await importOAuth2ClientsFromFile(options.file, {
             deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          verboseMessage(
+            'Importing all OAuth2 clients from separate files in current directory...'
+          );
+          const outcome = await importOAuth2ClientsFromFiles({
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first provider from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first OAuth2 client from file "${options.file}"...`
+          );
+          const outcome = await importFirstOAuth2ClientFromFile(options.file, {
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing all OAuth2 applications from a single file (${options.file})...`
-        );
-        const outcome = await importOAuth2ClientsFromFile(options.file, {
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        verboseMessage(
-          'Importing all OAuth2 applications from separate files in current directory...'
-        );
-        const outcome = await importOAuth2ClientsFromFiles({
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first provider from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first OAuth2 application from file "${options.file}"...`
-        );
-        const outcome = await importFirstOAuth2ClientFromFile(options.file, {
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/oauth/oauth-client-list.ts
+++ b/src/cli/oauth/oauth-client-list.ts
@@ -5,33 +5,35 @@ import { listOAuth2Clients } from '../../ops/OAuth2ClientOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo oauth client list');
+export default function setup() {
+  const program = new FrodoCommand('frodo oauth client list');
 
-program
-  .description('List OAuth2 applications.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Listing OAuth2 applications...`);
-        const outcome = await listOAuth2Clients(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List OAuth2 clients.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Listing OAuth2 clients...`);
+          const outcome = await listOAuth2Clients(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/oauth/oauth-client.ts
+++ b/src/cli/oauth/oauth-client.ts
@@ -1,17 +1,24 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+// import DescribeCmd from './oauth-client-describe.js';
+import ExportCmd from './oauth-client-export.js';
+import ImportCmd from './oauth-client-import.js';
+import ListCmd from './oauth-client-list.js';
+// import DeleteCmd from './oauth-client-delete.js';
 
-const program = new FrodoStubCommand('frodo oauth client');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo oauth client');
 
-program.description('Manage OAuth2 clients.');
+  program.description('Manage OAuth2 clients.');
 
-program.command('list', 'List OAuth2 clients.');
+  program.addCommand(ListCmd().name('list'));
 
-// program.command('describe', 'Describe OAuth2 clients.');
+  // program.addCommand(DescribeCmd().name('describe'));
 
-program.command('export', 'Export OAuth2 clients.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import OAuth2 clients.');
+  program.addCommand(ImportCmd().name('import'));
 
-// program.command('delete', 'Delete OAuth2 clients.');
+  // program.addCommand(DeleteCmd().name('delete'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/oauth/oauth.ts
+++ b/src/cli/oauth/oauth.ts
@@ -1,18 +1,14 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import ClientCmd from './oauth-client.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('oauth')
-    .description('Manage OAuth2 clients and providers.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('oauth').description(
+    'Manage OAuth2 clients and providers.'
+  );
 
-  program.command('client', 'Manage OAuth2 clients.');
+  program.addCommand(ClientCmd().name('client'));
 
-  // program.command('provider', 'Manage OAuth2 providers.');
+  // program.addCommand(ProviderCmd().name('provider'));
 
   return program;
 }

--- a/src/cli/realm/realm-add-custom-domain.ts
+++ b/src/cli/realm/realm-add-custom-domain.ts
@@ -6,39 +6,41 @@ import { addCustomDomain } from '../../ops/RealmOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo realm add-custom-domain');
+export default function setup() {
+  const program = new FrodoCommand('frodo realm add-custom-domain');
 
-program
-  .description('Add custom domain (realm DNS alias).')
-  .addOption(
-    new Option(
-      '-d, --domain <name>',
-      'Custom DNS domain name.'
-    ).makeOptionMandatory()
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(
-          `Adding custom DNS domain ${
-            options.domain
-          } to realm ${state.getRealm()}...`
+  program
+    .description('Add custom domain (realm DNS alias).')
+    .addOption(
+      new Option(
+        '-d, --domain <name>',
+        'Custom DNS domain name.'
+      ).makeOptionMandatory()
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        await addCustomDomain(state.getRealm(), options.domain);
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage(
+            `Adding custom DNS domain ${
+              options.domain
+            } to realm ${state.getRealm()}...`
+          );
+          await addCustomDomain(state.getRealm(), options.domain);
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/realm/realm-describe.ts
+++ b/src/cli/realm/realm-describe.ts
@@ -5,27 +5,29 @@ import { describeRealm } from '../../ops/RealmOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo realm describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo realm describe');
 
-program.description('Describe realms.').action(
-  // implement command logic inside action handler
-  async (host, realm, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(
-      host,
-      realm,
-      user,
-      password,
-      options,
-      command
-    );
-    if (await getTokens()) {
-      verboseMessage(`Retrieving details of realm ${state.getRealm()}...`);
-      describeRealm(frodo.utils.getRealmName(state.getRealm()));
-    } else {
-      process.exitCode = 1;
+  program.description('Describe realms.').action(
+    // implement command logic inside action handler
+    async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
+      );
+      if (await getTokens()) {
+        verboseMessage(`Retrieving details of realm ${state.getRealm()}...`);
+        describeRealm(frodo.utils.getRealmName(state.getRealm()));
+      } else {
+        process.exitCode = 1;
+      }
     }
-  }
-  // end command logic inside action handler
-);
+    // end command logic inside action handler
+  );
 
-program.parse();
+  return program;
+}

--- a/src/cli/realm/realm-list.ts
+++ b/src/cli/realm/realm-list.ts
@@ -5,32 +5,34 @@ import { listRealms } from '../../ops/RealmOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo realm list');
+export default function setup() {
+  const program = new FrodoCommand('frodo realm list');
 
-program
-  .description('List realms.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage('Listing all realms...');
-        await listRealms(options.long);
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List realms.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage('Listing all realms...');
+          await listRealms(options.long);
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/realm/realm-remove-custom-domain.ts
+++ b/src/cli/realm/realm-remove-custom-domain.ts
@@ -7,39 +7,41 @@ import { FrodoCommand } from '../FrodoCommand';
 
 const { removeCustomDomain } = frodo.realm;
 
-const program = new FrodoCommand('frodo realm remove-custom-domain');
+export default function setup() {
+  const program = new FrodoCommand('frodo realm remove-custom-domain');
 
-program
-  .description('Remove custom domain (realm DNS alias).')
-  .addOption(
-    new Option(
-      '-d, --domain <name>',
-      'Custom DNS domain name.'
-    ).makeOptionMandatory()
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(
-          `Removing custom DNS domain ${
-            options.domain
-          } from realm ${state.getRealm()}...`
+  program
+    .description('Remove custom domain (realm DNS alias).')
+    .addOption(
+      new Option(
+        '-d, --domain <name>',
+        'Custom DNS domain name.'
+      ).makeOptionMandatory()
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        await removeCustomDomain(state.getRealm(), options.domain);
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage(
+            `Removing custom DNS domain ${
+              options.domain
+            } from realm ${state.getRealm()}...`
+          );
+          await removeCustomDomain(state.getRealm(), options.domain);
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/realm/realm.ts
+++ b/src/cli/realm/realm.ts
@@ -1,30 +1,27 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import AddCustomDomainCmd from './realm-add-custom-domain.js';
+import DescribeCmd from './realm-describe.js';
+import ListCmd from './realm-list.js';
+import RemoveCustomDomainCmd from './realm-remove-custom-domain.js';
+// import DeleteCmd from './realm-delete.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('realm')
-    .description('Manage realms.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('realm').description('Manage realms.');
 
-  program.command('list', 'List realms.');
+  program.addCommand(ListCmd().name('list'));
 
-  program
-    .command('describe', 'Describe realms.')
-    // for backwards compatibility
-    .alias('details');
-
-  program.command('add-custom-domain', 'Add custom domain (realm DNS alias).');
-
-  program.command(
-    'remove-custom-domain',
-    'Remove custom domain (realm DNS alias).'
+  program.addCommand(
+    DescribeCmd()
+      .name('describe')
+      // for backwards compatibility
+      .alias('details')
   );
 
-  // program.command('delete', 'Delete realms.');
+  program.addCommand(AddCustomDomainCmd().name('add-custom-domain'));
+
+  program.addCommand(RemoveCustomDomainCmd().name('remove-custom-domain'));
+
+  // program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/saml/saml-cot-export.ts
+++ b/src/cli/saml/saml-cot-export.ts
@@ -10,91 +10,93 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml cot export');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml cot export');
 
-program
-  .description('Export SAML circles of trust.')
-  .addOption(
-    new Option(
-      '-i, --cot-id <cot-id>',
-      'Circle of trust id/name. If specified, -a and -A are ignored.'
+  program
+    .description('Export SAML circles of trust.')
+    .addOption(
+      new Option(
+        '-i, --cot-id <cot-id>',
+        'Circle of trust id/name. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the export file. Ignored with -A. Defaults to <cot-id>.cot.saml.json.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the export file. Ignored with -A. Defaults to <cot-id>.cot.saml.json.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all the circles of trust in a realm to a single file. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all the circles of trust in a realm to a single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all the circles of trust in a realm as separate files <cot-id>.cot.saml.json. Ignored with -i, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all the circles of trust in a realm as separate files <cot-id>.cot.saml.json. Ignored with -i, and -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by id/name
-      if (options.cotId && (await getTokens())) {
-        verboseMessage(
-          `Exporting circle of trust "${
-            options.cotId
-          }" from realm "${state.getRealm()}"...`
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await exportCircleOfTrustToFile(
-          options.cotId,
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
+        // export by id/name
+        if (options.cotId && (await getTokens())) {
+          verboseMessage(
+            `Exporting circle of trust "${
+              options.cotId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportCircleOfTrustToFile(
+            options.cotId,
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all circles of trust to a single file...');
+          const outcome = await exportCirclesOfTrustToFile(
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all circles of trust to separate files...');
+          const outcome = await exportCirclesOfTrustToFiles(options.metadata);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all circles of trust to a single file...');
-        const outcome = await exportCirclesOfTrustToFile(
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all circles of trust to separate files...');
-        const outcome = await exportCirclesOfTrustToFiles(options.metadata);
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-cot-import.ts
+++ b/src/cli/saml/saml-cot-import.ts
@@ -11,95 +11,97 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml cot import');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml cot import');
 
-program
-  .description('Import SAML circles of trust.')
-  .addOption(
-    new Option(
-      '-i, --cot-id <cot-id>',
-      'Circle of trust id. If specified, only one circle of trust is imported and the options -a and -A are ignored.'
+  program
+    .description('Import SAML circles of trust.')
+    .addOption(
+      new Option(
+        '-i, --cot-id <cot-id>',
+        'Circle of trust id. If specified, only one circle of trust is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import the circle(s) of trust from.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import the circle(s) of trust from.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all circles of trust from single file. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all circles of trust from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all circles of trust from separate files (*.cot.saml.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all circles of trust from separate files (*.cot.saml.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement program logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import by id
-      if (options.file && options.cotId && (await getTokens())) {
-        verboseMessage(
-          `Importing circle of trust "${
-            options.cotId
-          }" into realm "${state.getRealm()}"...`
+    .action(
+      // implement program logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await importCircleOfTrustFromFile(
-          options.cotId,
-          options.file
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing all circles of trust from a single file (${options.file})...`
-        );
-        const outcome = await importCirclesOfTrustFromFile(options.file);
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        verboseMessage(
-          'Importing all circles of trust from separate files (*.saml.json) in current directory...'
-        );
-        const outcome = await importCirclesOfTrustFromFiles();
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first circle of trust from file "${
+        // import by id
+        if (options.file && options.cotId && (await getTokens())) {
+          verboseMessage(
+            `Importing circle of trust "${
+              options.cotId
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importCircleOfTrustFromFile(
+            options.cotId,
             options.file
-          }" into realm "${state.getRealm()}"...`
-        );
-        const outcome = await importFirstCircleOfTrustFromFile(options.file);
-        if (!outcome) process.exitCode = 1;
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing all circles of trust from a single file (${options.file})...`
+          );
+          const outcome = await importCirclesOfTrustFromFile(options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          verboseMessage(
+            'Importing all circles of trust from separate files (*.saml.json) in current directory...'
+          );
+          const outcome = await importCirclesOfTrustFromFiles();
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first circle of trust from file "${
+              options.file
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importFirstCircleOfTrustFromFile(options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end program logic inside action handler
-  );
+      // end program logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-cot-list.ts
+++ b/src/cli/saml/saml-cot-list.ts
@@ -6,35 +6,37 @@ import { listCirclesOfTrust } from '../../ops/CirclesOfTrustOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml cot list');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml cot list');
 
-program
-  .description('List SAML circles of trust.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(
-          `Listing SAML circles of trust in realm "${state.getRealm()}"...`
+  program
+    .description('List SAML circles of trust.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await listCirclesOfTrust(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage(
+            `Listing SAML circles of trust in realm "${state.getRealm()}"...`
+          );
+          const outcome = await listCirclesOfTrust(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-cot.ts
+++ b/src/cli/saml/saml-cot.ts
@@ -1,13 +1,18 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import ExportCmd from './saml-cot-export.js';
+import ImportCmd from './saml-cot-import.js';
+import ListCmd from './saml-cot-list.js';
 
-const program = new FrodoStubCommand('frodo saml cot');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo saml cot');
 
-program.description('Manage circles of trust.');
+  program.description('Manage circles of trust.');
 
-program.command('list', 'List circles of trust.');
+  program.addCommand(ListCmd().name('list'));
 
-program.command('export', 'Export circles of trust.');
+  program.addCommand(ExportCmd().name('export'));
 
-program.command('import', 'Import circles of trust.');
+  program.addCommand(ImportCmd().name('import'));
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-delete.ts
+++ b/src/cli/saml/saml-delete.ts
@@ -8,51 +8,53 @@ import { FrodoCommand } from '../FrodoCommand';
 const { deleteSaml2Provider, deleteSaml2Providers } =
   frodo.saml2.entityProvider;
 
-const program = new FrodoCommand('frodo saml delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml delete');
 
-program
-  .description('Delete SAML entity providers.')
-  .addOption(
-    new Option(
-      '-i, --entity-id <entity-id>',
-      'Entity id. If specified, -a is ignored.'
+  program
+    .description('Delete SAML entity providers.')
+    .addOption(
+      new Option(
+        '-i, --entity-id <entity-id>',
+        'Entity id. If specified, -a is ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option('-a, --all', 'Delete all entity providers. Ignored with -i.')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // -i / --entity-id
-      if (options.entityId && (await getTokens())) {
-        verboseMessage(`Deleting entity provider '${options.entityId}'...`);
-        await deleteSaml2Provider(options.entityId);
-      }
-      // -a / --all
-      else if (options.all && (await getTokens())) {
-        verboseMessage(`Deleting all entity providers...`);
-        await deleteSaml2Providers();
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
+    .addOption(
+      new Option('-a, --all', 'Delete all entity providers. Ignored with -i.')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        program.help();
-        process.exitCode = 1;
+        // -i / --entity-id
+        if (options.entityId && (await getTokens())) {
+          verboseMessage(`Deleting entity provider '${options.entityId}'...`);
+          await deleteSaml2Provider(options.entityId);
+        }
+        // -a / --all
+        else if (options.all && (await getTokens())) {
+          verboseMessage(`Deleting all entity providers...`);
+          await deleteSaml2Providers();
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-describe.ts
+++ b/src/cli/saml/saml-describe.ts
@@ -6,35 +6,37 @@ import { describeSaml2Provider } from '../../ops/Saml2Ops';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml describe');
 
-program
-  .description('Describe the configuration of an entity provider.')
-  .addOption(new Option('-i, --entity-id <entity-id>', 'Entity id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(
-          `Describing SAML entity provider ${
-            options.entityId
-          } in realm "${state.getRealm()}"...`
+  program
+    .description('Describe the configuration of an entity provider.')
+    .addOption(new Option('-i, --entity-id <entity-id>', 'Entity id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await describeSaml2Provider(options.entityId);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage(
+            `Describing SAML entity provider ${
+              options.entityId
+            } in realm "${state.getRealm()}"...`
+          );
+          const outcome = await describeSaml2Provider(options.entityId);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-export.ts
+++ b/src/cli/saml/saml-export.ts
@@ -10,102 +10,104 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml export');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml export');
 
-program
-  .description('Export SAML entity providers.')
-  .addOption(
-    new Option(
-      '-i, --entity-id <entity-id>',
-      'Entity id. If specified, -a and -A are ignored.'
+  program
+    .description('Export SAML entity providers.')
+    .addOption(
+      new Option(
+        '-i, --entity-id <entity-id>',
+        'Entity id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the file to write the exported provider(s) to. Ignored with -A. If not specified, the export file is named <id>.saml.json.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the file to write the exported provider(s) to. Ignored with -A. If not specified, the export file is named <id>.saml.json.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all the providers in a realm to a single file. Ignored with -t and -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all the providers in a realm to a single file. Ignored with -t and -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all the providers in a realm as separate files <provider name>.saml.json. Ignored with -t, -i, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all the providers in a realm as separate files <provider name>.saml.json. Ignored with -t, -i, and -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .addOption(
-    new Option('--no-deps', 'Do not include any dependencies (scripts).')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by id/name
-      if (options.entityId && (await getTokens())) {
-        verboseMessage(
-          `Exporting provider "${
-            options.entityId
-          }" from realm "${state.getRealm()}"...`
+    .addOption(
+      new Option('--no-deps', 'Do not include any dependencies (scripts).')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await exportSaml2ProviderToFile(
-          options.entityId,
-          options.file,
-          options.metadata,
-          {
+        // export by id/name
+        if (options.entityId && (await getTokens())) {
+          verboseMessage(
+            `Exporting provider "${
+              options.entityId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportSaml2ProviderToFile(
+            options.entityId,
+            options.file,
+            options.metadata,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all providers to a single file...');
+          const outcome = await exportSaml2ProvidersToFile(
+            options.file,
+            options.metadata,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all providers to separate files...');
+          const outcome = await exportSaml2ProvidersToFiles(options.metadata, {
             deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all providers to a single file...');
-        const outcome = await exportSaml2ProvidersToFile(
-          options.file,
-          options.metadata,
-          {
-            deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all providers to separate files...');
-        const outcome = await exportSaml2ProvidersToFiles(options.metadata, {
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-import.ts
+++ b/src/cli/saml/saml-import.ts
@@ -11,104 +11,106 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml import');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml import');
 
-program
-  .description('Import SAML entity providers.')
-  .addOption(
-    new Option(
-      '-i, --entity-id <entity-id>',
-      'Entity id. If specified, only one provider is imported and the options -a and -A are ignored.'
+  program
+    .description('Import SAML entity providers.')
+    .addOption(
+      new Option(
+        '-i, --entity-id <entity-id>',
+        'Entity id. If specified, only one provider is imported and the options -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import the entity provider(s) from.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import the entity provider(s) from.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all entity providers from single file. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all entity providers from single file. Ignored with -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all entity providers from separate files (*.saml.json) in the current directory. Ignored with -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all entity providers from separate files (*.saml.json) in the current directory. Ignored with -i or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option('--no-deps', 'Do not include any dependencies (scripts).')
-  )
-  .action(
-    // implement program logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import by id
-      if (options.file && options.entityId && (await getTokens())) {
-        verboseMessage(
-          `Importing provider "${
-            options.entityId
-          }" into realm "${state.getRealm()}"...`
+    .addOption(
+      new Option('--no-deps', 'Do not include any dependencies (scripts).')
+    )
+    .action(
+      // implement program logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await importSaml2ProviderFromFile(
-          options.entityId,
-          options.file,
-          {
+        // import by id
+        if (options.file && options.entityId && (await getTokens())) {
+          verboseMessage(
+            `Importing provider "${
+              options.entityId
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importSaml2ProviderFromFile(
+            options.entityId,
+            options.file,
+            {
+              deps: options.deps,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing all providers from a single file (${options.file})...`
+          );
+          const outcome = await importSaml2ProvidersFromFile(options.file, {
             deps: options.deps,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          verboseMessage(
+            'Importing all providers from separate files (*.saml.json) in current directory...'
+          );
+          const outcome = await importSaml2ProvidersFromFiles({
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import first provider from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first provider from file "${
+              options.file
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importFirstSaml2ProviderFromFile(options.file, {
+            deps: options.deps,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage('Unrecognized combination of options or no options...');
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing all providers from a single file (${options.file})...`
-        );
-        const outcome = await importSaml2ProvidersFromFile(options.file, {
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        verboseMessage(
-          'Importing all providers from separate files (*.saml.json) in current directory...'
-        );
-        const outcome = await importSaml2ProvidersFromFiles({
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import first provider from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first provider from file "${
-            options.file
-          }" into realm "${state.getRealm()}"...`
-        );
-        const outcome = await importFirstSaml2ProviderFromFile(options.file, {
-          deps: options.deps,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage('Unrecognized combination of options or no options...');
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end program logic inside action handler
-  );
+      // end program logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-list.ts
+++ b/src/cli/saml/saml-list.ts
@@ -6,35 +6,37 @@ import { listSaml2Providers } from '../../ops/Saml2Ops';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml list');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml list');
 
-program
-  .description('List SAML entity providers.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(
-          `Listing SAML entity providers in realm "${state.getRealm()}"...`
+  program
+    .description('List SAML entity providers.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await listSaml2Providers(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage(
+            `Listing SAML entity providers in realm "${state.getRealm()}"...`
+          );
+          const outcome = await listSaml2Providers(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-metadata-export.ts
+++ b/src/cli/saml/saml-metadata-export.ts
@@ -6,68 +6,70 @@ import { exportSaml2MetadataToFile } from '../../ops/Saml2Ops';
 import { printMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo saml metadata export');
+export default function setup() {
+  const program = new FrodoCommand('frodo saml metadata export');
 
-program
-  .description('Export SAML metadata.')
-  .addOption(
-    new Option(
-      '-i, --entity-id <entity-id>',
-      'Entity id. If specified, -a and -A are ignored.'
+  program
+    .description('Export SAML metadata.')
+    .addOption(
+      new Option(
+        '-i, --entity-id <entity-id>',
+        'Entity id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the file to write the exported metadata to. Ignored with -A. If not specified, the export file is named <entity-id>.metadata.xml.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the file to write the exported metadata to. Ignored with -A. If not specified, the export file is named <entity-id>.metadata.xml.'
+      )
     )
-  )
-  // .addOption(
-  //   new Option(
-  //     '-A, --all-separate',
-  //     'Export all the providers in a realm as separate files <provider name>.saml.json. Ignored with -t, -i, and -a.'
-  //   )
-  // )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by id/name
-      if (options.entityId && (await getTokens())) {
-        printMessage(
-          `Exporting metadata for provider "${
-            options.entityId
-          }" from realm "${state.getRealm()}"...`
+    // .addOption(
+    //   new Option(
+    //     '-A, --all-separate',
+    //     'Export all the providers in a realm as separate files <provider name>.saml.json. Ignored with -t, -i, and -a.'
+    //   )
+    // )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await exportSaml2MetadataToFile(
-          options.entityId,
-          options.file
-        );
-        if (!outcome) process.exitCode = 1;
+        // export by id/name
+        if (options.entityId && (await getTokens())) {
+          printMessage(
+            `Exporting metadata for provider "${
+              options.entityId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportSaml2MetadataToFile(
+            options.entityId,
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // // --all-separate -A
+        // else if (options.allSeparate && (await getTokens())) {
+        //   printMessage('Exporting all providers to separate files...');
+        //   exportProvidersToFiles();
+        // }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // // --all-separate -A
-      // else if (options.allSeparate && (await getTokens())) {
-      //   printMessage('Exporting all providers to separate files...');
-      //   exportProvidersToFiles();
-      // }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml-metadata.ts
+++ b/src/cli/saml/saml-metadata.ts
@@ -1,9 +1,14 @@
 import { FrodoStubCommand } from '../FrodoCommand';
+import ExportCmd from './saml-metadata-export.js';
 
-const program = new FrodoStubCommand('frodo saml metadata');
+export default function setup() {
+  const program = new FrodoStubCommand('frodo saml metadata');
 
-program.description('SAML metadata operations.');
+  program.description('SAML metadata operations.');
 
-program.command('export', 'Export metadata.');
+  program.addCommand(
+    ExportCmd().name('export').description('Export metadata.')
+  );
 
-program.parse();
+  return program;
+}

--- a/src/cli/saml/saml.ts
+++ b/src/cli/saml/saml.ts
@@ -1,28 +1,30 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import CotCmd from './saml-cot.js';
+import DeleteCmd from './saml-delete.js';
+import DescribeCmd from './saml-describe.js';
+import ExportCmd from './saml-export.js';
+import ImportCmd from './saml-import.js';
+import ListCmd from './saml-list.js';
+import MetadataCmd from './saml-metadata.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('saml')
-    .description('Manage SAML entity providers and circles of trust.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('saml').description(
+    'Manage SAML entity providers and circles of trust.'
+  );
 
-  program.command('list', 'List entity providers.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('describe', 'Describe entity providers.');
+  program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('export', 'Export entity providers.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import entity providers.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('cot', 'Manage circles of trust.');
+  program.addCommand(CotCmd().name('cot'));
 
-  program.command('metadata', 'Metadata operations.');
+  program.addCommand(MetadataCmd().name('metadata'));
 
-  program.command('delete', 'Delete an SAML Entity');
+  program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/script/script-delete.ts
+++ b/src/cli/script/script-delete.ts
@@ -10,72 +10,73 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo script delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo script delete');
 
-program
-  .description('Delete scripts.')
-  .addOption(
-    new Option(
-      '-i, --script-id <script>',
-      'id of a script. If specified, -a and -A are ignored.'
+  program
+    .description('Delete scripts.')
+    .addOption(
+      new Option(
+        '-i, --script-id <script>',
+        'id of a script. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-n, --script-name <script>',
-      'name of a script. If specified, -a and -A are ignored.'
+    .addOption(
+      new Option(
+        '-n, --script-name <script>',
+        'name of a script. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Delete all non-default scripts in a realm. Ignored with -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all non-default scripts in a realm. Ignored with -i.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (options.scriptId && (await getTokens())) {
-        verboseMessage(
-          `Deleting script ${
-            options.scriptId
-          } in realm "${state.getRealm()}"...`
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await deleteScriptId(options.scriptId);
-        if (!outcome) process.exitCode = 1;
-      } else if (options.scriptName && (await getTokens())) {
-        verboseMessage(
-          `Deleting script ${
-            options.scriptName
-          } in realm "${state.getRealm()}"...`
-        );
-        const outcome = await deleteScriptName(options.scriptName);
-        if (!outcome) process.exitCode = 1;
-      } else if (options.all && (await getTokens())) {
-        verboseMessage('Deleting all non-default scripts...');
-        const outcome = await deleteAllScripts();
-        if (!outcome) process.exitCode = 1;
+        if (options.scriptId && (await getTokens())) {
+          verboseMessage(
+            `Deleting script ${
+              options.scriptId
+            } in realm "${state.getRealm()}"...`
+          );
+          const outcome = await deleteScriptId(options.scriptId);
+          if (!outcome) process.exitCode = 1;
+        } else if (options.scriptName && (await getTokens())) {
+          verboseMessage(
+            `Deleting script ${
+              options.scriptName
+            } in realm "${state.getRealm()}"...`
+          );
+          const outcome = await deleteScriptName(options.scriptName);
+          if (!outcome) process.exitCode = 1;
+        } else if (options.all && (await getTokens())) {
+          verboseMessage('Deleting all non-default scripts...');
+          const outcome = await deleteAllScripts();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
+      // end command logic inside action handler
+    );
 
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
-
-program.parse();
+  return program;
+}

--- a/src/cli/script/script-describe.ts
+++ b/src/cli/script/script-describe.ts
@@ -3,29 +3,31 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo script describe');
+export default function setup() {
+  const program = new FrodoCommand('frodo script describe');
 
-program
-  .description('Describe script.')
-  .addOption(new Option('-i, --script-id <script-id>', 'Script id.'))
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        // code goes here
-      } else {
-        process.exitCode = 1;
+  program
+    .description('Describe script.')
+    .addOption(new Option('-i, --script-id <script-id>', 'Script id.'))
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          // code goes here
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/script/script-export.ts
+++ b/src/cli/script/script-export.ts
@@ -9,115 +9,117 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo script export');
+export default function setup() {
+  const program = new FrodoCommand('frodo script export');
 
-program
-  .description('Export scripts.')
-  .addOption(
-    new Option(
-      '-n, --script-name <name>',
-      'Name of the script. If specified, -a and -A are ignored.'
+  program
+    .description('Export scripts.')
+    .addOption(
+      new Option(
+        '-n, --script-name <name>',
+        'Name of the script. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  // .addOption(
-  //   new Option(
-  //     '-i, --script-id <uuid>',
-  //     'Uuid of the script. If specified, -a and -A are ignored.'
-  //   )
-  // )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all scripts to a single file. Ignored with -n.'
+    // .addOption(
+    //   new Option(
+    //     '-i, --script-id <uuid>',
+    //     'Uuid of the script. If specified, -a and -A are ignored.'
+    //   )
+    // )
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all scripts to a single file. Ignored with -n.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all scripts to separate files (*.script.json) in the current directory. Ignored with -n or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all scripts to separate files (*.script.json) in the current directory. Ignored with -n or -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  // deprecated option
-  .addOption(
-    new Option(
-      '-s, --script <script>',
-      'DEPRECATED! Use -n/--script-name instead. Name of the script.'
+    // deprecated option
+    .addOption(
+      new Option(
+        '-s, --script <script>',
+        'DEPRECATED! Use -n/--script-name instead. Name of the script.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-x, --extract',
-      'Extract the script from the exported file, and save it to a separate file. Ignored with -a.'
+    .addOption(
+      new Option(
+        '-x, --extract',
+        'Extract the script from the exported file, and save it to a separate file. Ignored with -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-d, --default',
-      'Export all scripts including the default scripts. Ignored with -n.'
+    .addOption(
+      new Option(
+        '-d, --default',
+        'Export all scripts including the default scripts. Ignored with -n.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by name
-      if ((options.scriptName || options.script) && (await getTokens())) {
-        verboseMessage('Exporting script...');
-        const outcome = await exportScriptByNameToFile(
-          options.scriptName || options.script,
-          options.file,
-          options.metadata,
-          options.extract
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -a / --all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all scripts to a single file...');
-        const outcome = await exportScriptsToFile(
-          options.file,
-          options.metadata,
-          options.default
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A / --all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all scripts to separate files...');
-        // -x / --extract
-        const outcome = await exportScriptsToFiles(
-          options.extract,
-          options.metadata,
-          options.default
-        );
-        if (!outcome) process.exitCode = 1;
-      }
+        // export by name
+        if ((options.scriptName || options.script) && (await getTokens())) {
+          verboseMessage('Exporting script...');
+          const outcome = await exportScriptByNameToFile(
+            options.scriptName || options.script,
+            options.file,
+            options.metadata,
+            options.extract
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a / --all
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all scripts to a single file...');
+          const outcome = await exportScriptsToFile(
+            options.file,
+            options.metadata,
+            options.default
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A / --all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all scripts to separate files...');
+          // -x / --extract
+          const outcome = await exportScriptsToFiles(
+            options.extract,
+            options.metadata,
+            options.default
+          );
+          if (!outcome) process.exitCode = 1;
+        }
 
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/script/script-list.ts
+++ b/src/cli/script/script-list.ts
@@ -6,52 +6,54 @@ import { listScripts } from '../../ops/ScriptOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo script list');
+export default function setup() {
+  const program = new FrodoCommand('frodo script list');
 
-program
-  .description('List scripts.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields besides usage.').default(
-      false,
-      'false'
+  program
+    .description('List scripts.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields besides usage.').default(
+        false,
+        'false'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-u, --usage',
-      'Display usage field. If a file is provided with -f or --file, it will search for usage in the file. If a directory is provided with -D or --directory, it will search for usage in all .json files in the directory and sub-directories. If no file or directory is provided, it will perform a full export automatically to determine usage.'
-    ).default(false, 'false')
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Optional export file to use to determine usage. Overrides -D, --directory. Only used if -u or --usage is provided as well.'
+    .addOption(
+      new Option(
+        '-u, --usage',
+        'Display usage field. If a file is provided with -f or --file, it will search for usage in the file. If a directory is provided with -D or --directory, it will search for usage in all .json files in the directory and sub-directories. If no file or directory is provided, it will perform a full export automatically to determine usage.'
+      ).default(false, 'false')
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Listing scripts in realm "${state.getRealm()}"...`);
-        const outcome = await listScripts(
-          options.long,
-          options.usage,
-          options.file
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Optional export file to use to determine usage. Overrides -D, --directory. Only used if -u or --usage is provided as well.'
+      )
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+        if (await getTokens()) {
+          verboseMessage(`Listing scripts in realm "${state.getRealm()}"...`);
+          const outcome = await listScripts(
+            options.long,
+            options.usage,
+            options.file
+          );
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/script/script.ts
+++ b/src/cli/script/script.ts
@@ -1,24 +1,22 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './script-delete.js';
+// import DescribeCmd from './script-describe.js';
+import ExportCmd from './script-export.js';
+import ImportCmd from './script-import.js';
+import ListCmd from './script-list.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('script')
-    .description('Manage scripts.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('script').description('Manage scripts.');
 
-  program.command('list', 'List scripts.');
+  program.addCommand(ListCmd().name('list'));
 
-  // program.command('describe', 'Describe scripts.');
+  // program.addCommand(DescribeCmd().name('describe'));
 
-  program.command('export', 'Export scripts.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import scripts.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('delete', 'Delete scripts.');
+  program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/service/service-delete.ts
+++ b/src/cli/service/service-delete.ts
@@ -4,55 +4,57 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { deleteService, deleteServices } from '../../ops/ServiceOps.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo service delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo service delete');
 
-interface ServiceDeleteOptions {
-  id?: string;
-  type?: string;
-  insecure?: boolean;
-  verbose?: boolean;
-  debug?: boolean;
-  curlirize?: boolean;
-  all?: boolean;
-  global?: boolean;
-}
+  interface ServiceDeleteOptions {
+    id?: string;
+    type?: string;
+    insecure?: boolean;
+    verbose?: boolean;
+    debug?: boolean;
+    curlirize?: boolean;
+    all?: boolean;
+    global?: boolean;
+  }
 
-program
-  .description('Delete AM services.')
-  .addOption(new Option('-i, --id <id>', 'Id of Service to be deleted.'))
-  .addOption(new Option('-a, --all', 'Delete all services. Ignored with -i.'))
-  .addOption(new Option('-g, --global', 'Delete global services.'))
-  .action(
-    async (
-      host: string,
-      realm: string,
-      user: string,
-      password: string,
-      options: ServiceDeleteOptions,
-      command
-    ) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
+  program
+    .description('Delete AM services.')
+    .addOption(new Option('-i, --id <id>', 'Id of Service to be deleted.'))
+    .addOption(new Option('-a, --all', 'Delete all services. Ignored with -i.'))
+    .addOption(new Option('-g, --global', 'Delete global services.'))
+    .action(
+      async (
+        host: string,
+        realm: string,
+        user: string,
+        password: string,
+        options: ServiceDeleteOptions,
         command
-      );
+      ) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
 
-      const globalConfig = options.global ?? false;
+        const globalConfig = options.global ?? false;
 
-      if (options.id && (await getTokens())) {
-        const outcome = await deleteService(options.id, globalConfig);
-        if (!outcome) process.exitCode = 1;
-      } else if (options.all && (await getTokens())) {
-        const outcome = await deleteServices(globalConfig);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        program.help();
-        process.exitCode = 1;
+        if (options.id && (await getTokens())) {
+          const outcome = await deleteService(options.id, globalConfig);
+          if (!outcome) process.exitCode = 1;
+        } else if (options.all && (await getTokens())) {
+          const outcome = await deleteServices(globalConfig);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          program.help();
+          process.exitCode = 1;
+        }
       }
-    }
-  );
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/service/service-export.ts
+++ b/src/cli/service/service-export.ts
@@ -9,106 +9,108 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo service export');
+export default function setup() {
+  const program = new FrodoCommand('frodo service export');
 
-interface ServiceExportOptions {
-  file?: string;
-  all?: boolean;
-  serviceId?: string;
-  allSeparate?: boolean;
-  type?: string;
-  insecure?: boolean;
-  verbose?: boolean;
-  debug?: boolean;
-  curlirize?: boolean;
-  global?: boolean;
-  metadata?: boolean;
-}
+  interface ServiceExportOptions {
+    file?: string;
+    all?: boolean;
+    serviceId?: string;
+    allSeparate?: boolean;
+    type?: string;
+    insecure?: boolean;
+    verbose?: boolean;
+    debug?: boolean;
+    curlirize?: boolean;
+    global?: boolean;
+    metadata?: boolean;
+  }
 
-program
-  .description('Export AM services.')
-  .addOption(
-    new Option(
-      '-i, --service-id <service-id>',
-      'Service id. If specified, -a and -A are ignored.'
+  program
+    .description('Export AM services.')
+    .addOption(
+      new Option(
+        '-i, --service-id <service-id>',
+        'Service id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
-  .addOption(new Option('-a, --all', 'Export all services to a single file.'))
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all services to separate files (*.service.json) in the current directory. Ignored with -a.'
+    .addOption(new Option('-f, --file <file>', 'Name of the export file.'))
+    .addOption(new Option('-a, --all', 'Export all services to a single file.'))
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all services to separate files (*.service.json) in the current directory. Ignored with -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .addOption(new Option('-g, --global', 'Export global services.'))
-  .action(
-    async (
-      host: string,
-      realm: string,
-      user: string,
-      password: string,
-      options: ServiceExportOptions,
-      command
-    ) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
+    .addOption(new Option('-g, --global', 'Export global services.'))
+    .action(
+      async (
+        host: string,
+        realm: string,
+        user: string,
+        password: string,
+        options: ServiceExportOptions,
         command
-      );
+      ) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
 
-      const globalConfig = options.global ?? false;
+        const globalConfig = options.global ?? false;
 
-      // export by name
-      if (options.serviceId && (await getTokens())) {
-        verboseMessage('Exporting service...');
-        const outcome = await exportServiceToFile(
-          options.serviceId,
-          options.file,
-          globalConfig,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
+        // export by name
+        if (options.serviceId && (await getTokens())) {
+          verboseMessage('Exporting service...');
+          const outcome = await exportServiceToFile(
+            options.serviceId,
+            options.file,
+            globalConfig,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a / --all
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all services to a single file...');
+          const outcome = await exportServicesToFile(
+            options.file,
+            globalConfig,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A / --all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all services to separate files...');
+          const outcome = await exportServicesToFiles(
+            globalConfig,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a / --all
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all services to a single file...');
-        const outcome = await exportServicesToFile(
-          options.file,
-          globalConfig,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A / --all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all services to separate files...');
-        const outcome = await exportServicesToFiles(
-          globalConfig,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/service/service-import.ts
+++ b/src/cli/service/service-import.ts
@@ -10,137 +10,143 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo service import');
+export default function setup() {
+  const program = new FrodoCommand('frodo service import');
 
-interface ServiceImportOptions {
-  file?: string;
-  all?: boolean;
-  serviceId?: string;
-  allSeparate?: boolean;
-  type?: string;
-  insecure?: boolean;
-  clean?: boolean;
-  directory?: string;
-  verbose?: boolean;
-  debug?: boolean;
-  curlirize?: boolean;
-  global?: boolean;
-  currentRealm?: boolean;
-}
+  interface ServiceImportOptions {
+    file?: string;
+    all?: boolean;
+    serviceId?: string;
+    allSeparate?: boolean;
+    type?: string;
+    insecure?: boolean;
+    clean?: boolean;
+    directory?: string;
+    verbose?: boolean;
+    debug?: boolean;
+    curlirize?: boolean;
+    global?: boolean;
+    currentRealm?: boolean;
+  }
 
-program
-  .description('Import AM services.')
-  .addOption(
-    new Option(
-      '-i, --service-id <service-id>',
-      'Service id. If specified, -a and -A are ignored.'
+  program
+    .description('Import AM services.')
+    .addOption(
+      new Option(
+        '-i, --service-id <service-id>',
+        'Service id. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import SAML Entity(s) from. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import SAML Entity(s) from. Ignored with -A.'
+      )
     )
-  )
-  .addOption(new Option('-a, --all', 'Import all services from a single file.'))
-  .addOption(
-    new Option('-C, --clean', 'Remove existing service(s) before importing.')
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all services from separate files <id>.service.json.'
+    .addOption(
+      new Option('-a, --all', 'Import all services from a single file.')
     )
-  )
-  .addOption(
-    new Option(
-      '-g, --global',
-      'Import service(s) as global service(s).'
-    ).default(false)
-  )
-  .addOption(
-    new Option(
-      '-r, --current-realm',
-      'Import service(s) into the current realm. Use this flag if you exported a service from one realm and are importing into another realm.'
-    ).default(false)
-  )
-  .action(
-    async (
-      host: string,
-      realm: string,
-      user: string,
-      password: string,
-      options: ServiceImportOptions,
-      command
-    ) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
+    .addOption(
+      new Option('-C, --clean', 'Remove existing service(s) before importing.')
+    )
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all services from separate files <id>.service.json.'
+      )
+    )
+    .addOption(
+      new Option(
+        '-g, --global',
+        'Import service(s) as global service(s).'
+      ).default(false)
+    )
+    .addOption(
+      new Option(
+        '-r, --current-realm',
+        'Import service(s) into the current realm. Use this flag if you exported a service from one realm and are importing into another realm.'
+      ).default(false)
+    )
+    .action(
+      async (
+        host: string,
+        realm: string,
+        user: string,
+        password: string,
+        options: ServiceImportOptions,
         command
-      );
+      ) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
 
-      const clean = options.clean ?? false;
-      const globalConfig = options.global ?? false;
-      const realmConfig = globalConfig ? false : options.currentRealm ?? false;
+        const clean = options.clean ?? false;
+        const globalConfig = options.global ?? false;
+        const realmConfig = globalConfig
+          ? false
+          : options.currentRealm ?? false;
 
-      // import by id
-      if (options.serviceId && options.file && (await getTokens())) {
-        verboseMessage('Importing service...');
-        const outcome = await importServiceFromFile(
-          options.serviceId,
-          options.file,
-          {
+        // import by id
+        if (options.serviceId && options.file && (await getTokens())) {
+          verboseMessage('Importing service...');
+          const outcome = await importServiceFromFile(
+            options.serviceId,
+            options.file,
+            {
+              clean,
+              global: globalConfig,
+              realm: realmConfig,
+            }
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // -a / --all
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage('Importing all services from a single file...');
+          const outcome = await importServicesFromFile(options.file, {
             clean,
             global: globalConfig,
             realm: realmConfig,
-          }
-        );
-        if (!outcome) process.exitCode = 1;
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // -A / --all-separate
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Importing all services from separate files...');
+          const outcome = await importServicesFromFiles({
+            clean,
+            global: globalConfig,
+            realm: realmConfig,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // import file
+        else if (options.file && (await getTokens())) {
+          verboseMessage('Importing service...');
+          const outcome = await importFirstServiceFromFile(options.file, {
+            clean,
+            global: globalConfig,
+            realm: realmConfig,
+          });
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // -a / --all
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage('Importing all services from a single file...');
-        const outcome = await importServicesFromFile(options.file, {
-          clean,
-          global: globalConfig,
-          realm: realmConfig,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // -A / --all-separate
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Importing all services from separate files...');
-        const outcome = await importServicesFromFiles({
-          clean,
-          global: globalConfig,
-          realm: realmConfig,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // import file
-      else if (options.file && (await getTokens())) {
-        verboseMessage('Importing service...');
-        const outcome = await importFirstServiceFromFile(options.file, {
-          clean,
-          global: globalConfig,
-          realm: realmConfig,
-        });
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/service/service-list.ts
+++ b/src/cli/service/service-list.ts
@@ -5,30 +5,32 @@ import { listServices } from '../../ops/ServiceOps.js';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo service list');
+export default function setup() {
+  const program = new FrodoCommand('frodo service list');
 
-program
-  .description('List AM services.')
-  .addOption(
-    new Option('-l, --long', 'Long with all fields.').default(false, 'false')
-  )
-  .addOption(new Option('-g, --global', 'List global services.'))
-  .action(async (host, realm, user, password, options, command) => {
-    command.handleDefaultArgsAndOpts(
-      host,
-      realm,
-      user,
-      password,
-      options,
-      command
-    );
-    if (await getTokens()) {
-      verboseMessage(`Listing all AM services for realm: ${realm}`);
-      const outcome = await listServices(options.long, options.global);
-      if (!outcome) process.exitCode = 1;
-    } else {
-      process.exitCode = 1;
-    }
-  });
+  program
+    .description('List AM services.')
+    .addOption(
+      new Option('-l, --long', 'Long with all fields.').default(false, 'false')
+    )
+    .addOption(new Option('-g, --global', 'List global services.'))
+    .action(async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
+      );
+      if (await getTokens()) {
+        verboseMessage(`Listing all AM services for realm: ${realm}`);
+        const outcome = await listServices(options.long, options.global);
+        if (!outcome) process.exitCode = 1;
+      } else {
+        process.exitCode = 1;
+      }
+    });
 
-program.parse();
+  return program;
+}

--- a/src/cli/service/service.ts
+++ b/src/cli/service/service.ts
@@ -1,22 +1,21 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './service-delete.js';
+import ExportCmd from './service-export.js';
+import ImportCmd from './service-import.js';
+import ListCmd from './service-list.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('service')
-    .description('Manage AM services.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('service').description(
+    'Manage AM services.'
+  );
 
-  program.command('list', 'List AM services.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('export', 'Export AM services.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import AM services.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('delete', 'Delete AM services.');
+  program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/src/cli/theme/theme-delete.ts
+++ b/src/cli/theme/theme-delete.ts
@@ -10,78 +10,80 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo theme delete');
+export default function setup() {
+  const program = new FrodoCommand('frodo theme delete');
 
-program
-  .description('Delete themes.')
-  .addOption(
-    new Option(
-      '-n, --theme-name <name>',
-      'Name of the theme. If specified, -a and -A are ignored.'
+  program
+    .description('Delete themes.')
+    .addOption(
+      new Option(
+        '-n, --theme-name <name>',
+        'Name of the theme. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-i, --theme-id <uuid>',
-      'Uuid of the theme. If specified, -a and -A are ignored.'
+    .addOption(
+      new Option(
+        '-i, --theme-id <uuid>',
+        'Uuid of the theme. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Delete all the themes in the realm. Ignored with -n and -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Delete all the themes in the realm. Ignored with -n and -i.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // delete by name
-      if (options.themeName && (await getTokens())) {
-        verboseMessage(
-          `Deleting theme with name "${
-            options.themeName
-          }" from realm "${state.getRealm()}"...`
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await deleteThemeByName(options.themeName);
-        if (!outcome) process.exitCode = 1;
+        // delete by name
+        if (options.themeName && (await getTokens())) {
+          verboseMessage(
+            `Deleting theme with name "${
+              options.themeName
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await deleteThemeByName(options.themeName);
+          if (!outcome) process.exitCode = 1;
+        }
+        // delete by id
+        else if (options.themeId && (await getTokens())) {
+          verboseMessage(
+            `Deleting theme with id "${
+              options.themeId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await deleteTheme(options.themeId);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage(
+            `Deleting all themes from realm "${state.getRealm()}"...`
+          );
+          const outcome = await deleteThemes();
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // delete by id
-      else if (options.themeId && (await getTokens())) {
-        verboseMessage(
-          `Deleting theme with id "${
-            options.themeId
-          }" from realm "${state.getRealm()}"...`
-        );
-        const outcome = await deleteTheme(options.themeId);
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage(
-          `Deleting all themes from realm "${state.getRealm()}"...`
-        );
-        const outcome = await deleteThemes();
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/theme/theme-export.ts
+++ b/src/cli/theme/theme-export.ts
@@ -11,111 +11,113 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo theme export');
+export default function setup() {
+  const program = new FrodoCommand('frodo theme export');
 
-program
-  .description('Export themes.')
-  .addOption(
-    new Option(
-      '-n, --theme-name <name>',
-      'Name of the theme. If specified, -a and -A are ignored.'
+  program
+    .description('Export themes.')
+    .addOption(
+      new Option(
+        '-n, --theme-name <name>',
+        'Name of the theme. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-i, --theme-id <uuid>',
-      'Uuid of the theme. If specified, -a and -A are ignored.'
+    .addOption(
+      new Option(
+        '-i, --theme-id <uuid>',
+        'Uuid of the theme. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file [file]',
-      'Name of the file to write the exported theme(s) to. Ignored with -A.'
+    .addOption(
+      new Option(
+        '-f, --file [file]',
+        'Name of the file to write the exported theme(s) to. Ignored with -A.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Export all the themes in a realm to a single file. Ignored with -n and -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Export all the themes in a realm to a single file. Ignored with -n and -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Export all the themes in a realm as separate files <theme name>.theme.json. Ignored with -n, -i, and -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Export all the themes in a realm as separate files <theme name>.theme.json. Ignored with -n, -i, and -a.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-N, --no-metadata',
-      'Does not include metadata in the export file.'
+    .addOption(
+      new Option(
+        '-N, --no-metadata',
+        'Does not include metadata in the export file.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // export by name
-      if (options.themeName && (await getTokens())) {
-        verboseMessage(
-          `Exporting theme "${
-            options.themeName
-          }" from realm "${state.getRealm()}"...`
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await exportThemeByName(
-          options.themeName,
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
+        // export by name
+        if (options.themeName && (await getTokens())) {
+          verboseMessage(
+            `Exporting theme "${
+              options.themeName
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportThemeByName(
+            options.themeName,
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // export by id
+        else if (options.themeId && (await getTokens())) {
+          verboseMessage(
+            `Exporting theme "${
+              options.themeId
+            }" from realm "${state.getRealm()}"...`
+          );
+          const outcome = await exportThemeById(
+            options.themeId,
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && (await getTokens())) {
+          verboseMessage('Exporting all themes to a single file...');
+          const outcome = await exportThemesToFile(
+            options.file,
+            options.metadata
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && (await getTokens())) {
+          verboseMessage('Exporting all themes to separate files...');
+          const outcome = await exportThemesToFiles(options.metadata);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // export by id
-      else if (options.themeId && (await getTokens())) {
-        verboseMessage(
-          `Exporting theme "${
-            options.themeId
-          }" from realm "${state.getRealm()}"...`
-        );
-        const outcome = await exportThemeById(
-          options.themeId,
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all -a
-      else if (options.all && (await getTokens())) {
-        verboseMessage('Exporting all themes to a single file...');
-        const outcome = await exportThemesToFile(
-          options.file,
-          options.metadata
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && (await getTokens())) {
-        verboseMessage('Exporting all themes to separate files...');
-        const outcome = await exportThemesToFiles(options.metadata);
-        if (!outcome) process.exitCode = 1;
-      }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/theme/theme-import.ts
+++ b/src/cli/theme/theme-import.ts
@@ -12,111 +12,113 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo theme import');
+export default function setup() {
+  const program = new FrodoCommand('frodo theme import');
 
-program
-  .description('Import themes.')
-  .addOption(
-    new Option(
-      '-n, --theme-name <name>',
-      'Name of the theme. If specified, -a and -A are ignored.'
+  program
+    .description('Import themes.')
+    .addOption(
+      new Option(
+        '-n, --theme-name <name>',
+        'Name of the theme. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-i, --theme-id <uuid>',
-      'Uuid of the theme. If specified, -a and -A are ignored.'
+    .addOption(
+      new Option(
+        '-i, --theme-id <uuid>',
+        'Uuid of the theme. If specified, -a and -A are ignored.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-f, --file <file>',
-      'Name of the file to import the theme(s) from.'
+    .addOption(
+      new Option(
+        '-f, --file <file>',
+        'Name of the file to import the theme(s) from.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-a, --all',
-      'Import all the themes from single file. Ignored with -n or -i.'
+    .addOption(
+      new Option(
+        '-a, --all',
+        'Import all the themes from single file. Ignored with -n or -i.'
+      )
     )
-  )
-  .addOption(
-    new Option(
-      '-A, --all-separate',
-      'Import all the themes from separate files (*.json) in the current directory. Ignored with -n or -i or -a.'
+    .addOption(
+      new Option(
+        '-A, --all-separate',
+        'Import all the themes from separate files (*.json) in the current directory. Ignored with -n or -i or -a.'
+      )
     )
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      // import by name
-      if (options.file && options.themeName && (await getTokens())) {
-        verboseMessage(
-          `Importing theme with name "${
-            options.themeName
-          }" into realm "${state.getRealm()}"...`
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
         );
-        const outcome = await importThemeByName(
-          options.themeName,
-          options.file
-        );
-        if (!outcome) process.exitCode = 1;
-      }
-      // import by id
-      else if (options.file && options.themeId && (await getTokens())) {
-        verboseMessage(
-          `Importing theme with id "${
-            options.themeId
-          }" into realm "${state.getRealm()}"...`
-        );
-        const outcome = await importThemeById(options.themeId, options.file);
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all -a
-      else if (options.all && options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing all themes from a single file (${options.file})...`
-        );
-        const outcome = await importThemesFromFile(options.file);
-        if (!outcome) process.exitCode = 1;
-      }
-      // --all-separate -A
-      else if (options.allSeparate && !options.file && (await getTokens())) {
-        verboseMessage(
-          'Importing all themes from separate files in current directory...'
-        );
-        const outcome = await importThemesFromFiles();
-        if (!outcome) process.exitCode = 1;
-      }
-      // import single theme from file
-      else if (options.file && (await getTokens())) {
-        verboseMessage(
-          `Importing first theme from file "${
+        // import by name
+        if (options.file && options.themeName && (await getTokens())) {
+          verboseMessage(
+            `Importing theme with name "${
+              options.themeName
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importThemeByName(
+            options.themeName,
             options.file
-          }" into realm "${state.getRealm()}"...`
-        );
-        const outcome = await importFirstThemeFromFile(options.file);
-        if (!outcome) process.exitCode = 1;
+          );
+          if (!outcome) process.exitCode = 1;
+        }
+        // import by id
+        else if (options.file && options.themeId && (await getTokens())) {
+          verboseMessage(
+            `Importing theme with id "${
+              options.themeId
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importThemeById(options.themeId, options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all -a
+        else if (options.all && options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing all themes from a single file (${options.file})...`
+          );
+          const outcome = await importThemesFromFile(options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // --all-separate -A
+        else if (options.allSeparate && !options.file && (await getTokens())) {
+          verboseMessage(
+            'Importing all themes from separate files in current directory...'
+          );
+          const outcome = await importThemesFromFiles();
+          if (!outcome) process.exitCode = 1;
+        }
+        // import single theme from file
+        else if (options.file && (await getTokens())) {
+          verboseMessage(
+            `Importing first theme from file "${
+              options.file
+            }" into realm "${state.getRealm()}"...`
+          );
+          const outcome = await importFirstThemeFromFile(options.file);
+          if (!outcome) process.exitCode = 1;
+        }
+        // unrecognized combination of options or no options
+        else {
+          printMessage(
+            'Unrecognized combination of options or no options...',
+            'error'
+          );
+          program.help();
+          process.exitCode = 1;
+        }
       }
-      // unrecognized combination of options or no options
-      else {
-        printMessage(
-          'Unrecognized combination of options or no options...',
-          'error'
-        );
-        program.help();
-        process.exitCode = 1;
-      }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/theme/theme-list.ts
+++ b/src/cli/theme/theme-list.ts
@@ -6,33 +6,35 @@ import { listThemes } from '../../ops/ThemeOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const program = new FrodoCommand('frodo theme list');
+export default function setup() {
+  const program = new FrodoCommand('frodo theme list');
 
-program
-  .description('List themes.')
-  .addOption(
-    new Option('-l, --long', 'Long with more fields.').default(false, 'false')
-  )
-  .action(
-    // implement command logic inside action handler
-    async (host, realm, user, password, options, command) => {
-      command.handleDefaultArgsAndOpts(
-        host,
-        realm,
-        user,
-        password,
-        options,
-        command
-      );
-      if (await getTokens()) {
-        verboseMessage(`Listing themes in realm "${state.getRealm()}"...`);
-        const outcome = await listThemes(options.long);
-        if (!outcome) process.exitCode = 1;
-      } else {
-        process.exitCode = 1;
+  program
+    .description('List themes.')
+    .addOption(
+      new Option('-l, --long', 'Long with more fields.').default(false, 'false')
+    )
+    .action(
+      // implement command logic inside action handler
+      async (host, realm, user, password, options, command) => {
+        command.handleDefaultArgsAndOpts(
+          host,
+          realm,
+          user,
+          password,
+          options,
+          command
+        );
+        if (await getTokens()) {
+          verboseMessage(`Listing themes in realm "${state.getRealm()}"...`);
+          const outcome = await listThemes(options.long);
+          if (!outcome) process.exitCode = 1;
+        } else {
+          process.exitCode = 1;
+        }
       }
-    }
-    // end command logic inside action handler
-  );
+      // end command logic inside action handler
+    );
 
-program.parse();
+  return program;
+}

--- a/src/cli/theme/theme.ts
+++ b/src/cli/theme/theme.ts
@@ -1,22 +1,19 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-
 import { FrodoStubCommand } from '../FrodoCommand';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import DeleteCmd from './theme-delete.js';
+import ExportCmd from './theme-export.js';
+import ImportCmd from './theme-import.js';
+import ListCmd from './theme-list.js';
 
 export default function setup() {
-  const program = new FrodoStubCommand('theme')
-    .description('Manage themes.')
-    .executableDir(__dirname);
+  const program = new FrodoStubCommand('theme').description('Manage themes.');
 
-  program.command('list', 'List themes.');
+  program.addCommand(ListCmd().name('list'));
 
-  program.command('export', 'Export themes.');
+  program.addCommand(ExportCmd().name('export'));
 
-  program.command('import', 'Import themes.');
+  program.addCommand(ImportCmd().name('import'));
 
-  program.command('delete', 'Delete themes.');
+  program.addCommand(DeleteCmd().name('delete'));
 
   return program;
 }

--- a/test/client_cli/en/__snapshots__/admin.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin.test.js.snap
@@ -12,11 +12,11 @@ Commands:
   add-autoid-static-user-mapping              Add AutoId static user mapping to enable dashboards and other AutoId-based functionality.
   create-oauth2-client-with-admin-privileges  Create an oauth2 client with admin privileges.
   execute-rfc7523-authz-grant-flow            Execute RFC7523 authorization grant flow.
-  federation                                  Manage admin federation configuration.
+  federation                                  Manages admin federation configuration.
   generate-rfc7523-authz-grant-artefacts      Generate RFC7523 authorization grant artefacts.
   get-access-token                            Get an access token using client credentials grant type.
   grant-oauth2-client-admin-privileges        Grant an oauth2 client admin privileges.
-  help [command]                              display help for command
+  help                                        display help for command
   hide-generic-extension-attributes           Hide generic extension attributes.
   list-oauth2-clients-with-admin-privileges   List oauth2 clients with admin privileges.
   list-oauth2-clients-with-custom-privileges  List oauth2 clients with custom privileges.

--- a/test/client_cli/en/__snapshots__/agent-gateway.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-gateway.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'agent gateway' should be expected english 1`] =
 Manage gateway agents.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete gateway agents.
-  describe        Describe gateway agents.
-  export          Export gateway agents.
-  help [command]  display help for command
-  import          Import gateway agents.
-  list            List gateway agents.
+  delete      Delete identity gateway agents.
+  describe    Describe gateway agents.
+  export      Export gateway agents.
+  help        display help for command
+  import      Import gateway agents.
+  list        List gateway agents.
 "
 `;

--- a/test/client_cli/en/__snapshots__/agent-java.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-java.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'agent java' should be expected english 1`] = `
 Manage java agents.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete java agents.
-  describe        Describe java agents.
-  export          Export java agents.
-  help [command]  display help for command
-  import          Import java agents.
-  list            List java agents.
+  delete      Delete java agents.
+  describe    Describe java agents.
+  export      Export java agents.
+  help        display help for command
+  import      Import java agents.
+  list        List java agents.
 "
 `;

--- a/test/client_cli/en/__snapshots__/agent-web.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-web.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'agent web' should be expected english 1`] = `
 Manage web agents.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete web agents.
-  describe        Describe web agents.
-  export          Export web agents.
-  help [command]  display help for command
-  import          Import web agents.
-  list            List web agents.
+  delete      Delete web agents.
+  describe    Describe web agents.
+  export      Export web agents.
+  help        display help for command
+  import      Import web agents.
+  list        List web agents.
 "
 `;

--- a/test/client_cli/en/__snapshots__/agent.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent.test.js.snap
@@ -6,17 +6,17 @@ exports[`CLI help interface for 'agent' should be expected english 1`] = `
 Manage agents.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete agents.
-  describe        Describe agents.
-  export          Export agents.
-  gateway|ig      Manage gateway agents.
-  help [command]  display help for command
-  import          Import agents.
-  java            Manage java agents.
-  list            List agents.
-  web             Manage web agents.
+  delete      Delete agents.
+  describe    Describe agents.
+  export      Export agents.
+  gateway|ig  Manage gateway agents.
+  help        display help for command
+  import      Import agents.
+  java        Manage java agents.
+  list        List agents.
+  web         Manage web agents.
 "
 `;

--- a/test/client_cli/en/__snapshots__/app.test.js.snap
+++ b/test/client_cli/en/__snapshots__/app.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'app' should be expected english 1`] = `
 Manage applications.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete applications.
-  export          Export applications.
-  help [command]  display help for command
-  import          Import applications.
-  list            List applications.
+  delete      Delete applications.
+  export      Export applications.
+  help        display help for command
+  import      Import applications.
+  list        List applications.
 [93m
 Important Note:
 [39m  The [96mfrodo app[39m command to manage OAuth2 clients in v1.x has been renamed to [96mfrodo oauth client[39m in v2.x

--- a/test/client_cli/en/__snapshots__/authn.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authn.test.js.snap
@@ -6,12 +6,12 @@ exports[`CLI help interface for 'authn' should be expected english 1`] = `
 Manage authentication settings.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  describe        Describe authentication settings.
-  export          Export authentication settings.
-  help [command]  display help for command
-  import          Import authentication settings.
+  describe    Describe authentication settings.
+  export      Export authentication settings.
+  help        display help for command
+  import      Import authentication settings.
 "
 `;

--- a/test/client_cli/en/__snapshots__/authz-policy.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-policy.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'authz policy' should be expected english 1`] = 
 Manages authorization policies.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete authorization policies.
-  describe        Describe authorization policies.
-  export          Export authorization policies.
-  help [command]  display help for command
-  import          Import authorization policies.
-  list            List authorization policies.
+  delete      Delete authorization policies.
+  describe    Describe authorization policies.
+  export      Export authorization policies.
+  help        display help for command
+  import      Import authorization policies.
+  list        List authorization policies.
 "
 `;

--- a/test/client_cli/en/__snapshots__/authz-set-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-set-list.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'authz set' should be expected english 1`] = `
 Manage authorization policy sets.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete authorization policy sets.
-  describe        Describe authorization policy sets.
-  export          Export authorization policy sets.
-  help [command]  display help for command
-  import          Import authorization policy sets.
-  list            List authorization policy sets.
+  delete      Delete authorization policy sets.
+  describe    Describe authorization policy sets.
+  export      Export authorization policy sets.
+  help        display help for command
+  import      Import authorization policy sets.
+  list        List authorization policy sets.
 "
 `;

--- a/test/client_cli/en/__snapshots__/authz-set.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-set.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'authz set' should be expected english 1`] = `
 Manage authorization policy sets.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete authorization policy sets.
-  describe        Describe authorization policy sets.
-  export          Export authorization policy sets.
-  help [command]  display help for command
-  import          Import authorization policy sets.
-  list            List authorization policy sets.
+  delete      Delete authorization policy sets.
+  describe    Describe authorization policy sets.
+  export      Export authorization policy sets.
+  help        display help for command
+  import      Import authorization policy sets.
+  list        List authorization policy sets.
 "
 `;

--- a/test/client_cli/en/__snapshots__/authz-type.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-type.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'authz type' should be expected english 1`] = `
 Manage authorization resource types.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete authorization resource types.
-  describe        Describe authorization resource types.
-  export          Export authorization resource types.
-  help [command]  display help for command
-  import          Import authorization resource types.
-  list            List authorization resource types.
+  delete      Delete authorization resource types.
+  describe    Describe authorization resource types.
+  export      Export authorization resource types.
+  help        display help for command
+  import      Import authorization resource types.
+  list        List authorization resource types.
 "
 `;

--- a/test/client_cli/en/__snapshots__/authz.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz.test.js.snap
@@ -6,12 +6,12 @@ exports[`CLI help interface for 'authz' should be expected english 1`] = `
 Manage authotiztion policies, policy sets, and resource types.
 
 Options:
-  -h, --help      Help
+  -h, --help     Help
 
 Commands:
-  help [command]  display help for command
-  policy          Manages policies.
-  set             Manage policy sets.
-  type            Manage resource types.
+  help           display help for command
+  policy         Manages authorization policies.
+  set|policyset  Manage authorization policy sets.
+  type           Manage authorization resource types.
 "
 `;

--- a/test/client_cli/en/__snapshots__/config.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config.test.js.snap
@@ -6,13 +6,12 @@ exports[`CLI help interface for 'config' should be expected english 1`] = `
 Manage full cloud configuration.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  export          Export full cloud configuration for all ops that currently
-                  support export..
-  help [command]  display help for command
-  import          Import full cloud configuration for all ops that currently
-                  support import.
+  export      Export full cloud configuration for all ops that currently
+              support export.
+  help        display help for command
+  import      Import full cloud configuration.
 "
 `;

--- a/test/client_cli/en/__snapshots__/conn.test.js.snap
+++ b/test/client_cli/en/__snapshots__/conn.test.js.snap
@@ -6,13 +6,13 @@ exports[`CLI help interface for 'conn' should be expected english 1`] = `
 Manage connection profiles.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete connection profiles.
-  describe        Describe connection profiles.
-  help [command]  display help for command
-  list            List connection profiles.
-  save|add        Save connection profiles.
+  delete      Delete connection profiles.
+  describe    Describe connection profile.
+  help        display help for command
+  list        List connection profiles.
+  save|add    Save connection profiles.
 "
 `;

--- a/test/client_cli/en/__snapshots__/email-template.test.js.snap
+++ b/test/client_cli/en/__snapshots__/email-template.test.js.snap
@@ -6,12 +6,12 @@ exports[`CLI help interface for 'email template' should be expected english 1`] 
 Manage email templates.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  export          Export email templates.
-  help [command]  display help for command
-  import          Import email templates.
-  list            List email templates.
+  export      Export email templates.
+  help        display help for command
+  import      Import email templates.
+  list        List email templates.
 "
 `;

--- a/test/client_cli/en/__snapshots__/email.test.js.snap
+++ b/test/client_cli/en/__snapshots__/email.test.js.snap
@@ -6,10 +6,10 @@ exports[`CLI help interface for 'email' should be expected english 1`] = `
 Manage email templates and configuration.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  help [command]  display help for command
-  template        Manage email templates.
+  help        display help for command
+  template    Manage email templates.
 "
 `;

--- a/test/client_cli/en/__snapshots__/esv-secret-version.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-version.test.js.snap
@@ -6,14 +6,14 @@ exports[`CLI help interface for 'esv secret version' should be expected english 
 Manage secret versions.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  activate        Activate version.
-  create          Create new version.
-  deactivate      Deactivate version.
-  delete          Delete version.
-  help [command]  display help for command
-  list            List versions.
+  activate    Activate versions of secrets.
+  create      Create new version of secret.
+  deactivate  Deactivate versions of secrets.
+  delete      Delete versions of secrets.
+  help        display help for command
+  list        List versions of secret.
 "
 `;

--- a/test/client_cli/en/__snapshots__/esv-secret.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret.test.js.snap
@@ -6,16 +6,16 @@ exports[`CLI help interface for 'esv secret' should be expected english 1`] = `
 Manages secrets.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  create          Create secrets.
-  delete          Delete secrets.
-  describe        Describe secret.
-  export          Export secrets.
-  help [command]  display help for command
-  list            List secrets.
-  set             Set secret descriptions.
-  version         Manage secret versions.
+  create      Create secrets.
+  delete      Delete secrets.
+  describe    Describe secrets.
+  export      Export secrets.
+  help        display help for command
+  list        List secrets.
+  set         Set secret description.
+  version     Manage secret versions.
 "
 `;

--- a/test/client_cli/en/__snapshots__/esv-variable-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-delete.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CLI help interface for 'esv variable delete' should be expected english 1`] = `
-"Usage: frodo cmd sub2 delete [options] [host] [realm] [username] [password]
+"Usage: frodo esv variable delete [options] [host] [realm] [username] [password]
 
 Delete variables.
 

--- a/test/client_cli/en/__snapshots__/esv-variable.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable.test.js.snap
@@ -6,15 +6,15 @@ exports[`CLI help interface for 'esv variable' should be expected english 1`] = 
 Manage variables.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  create          Create variables.
-  delete          Delete variables.
-  describe        Describe variables.
-  export          Export variables.
-  help [command]  display help for command
-  list            List variables.
-  set             Set variable descriptions.
+  create      Create variables.
+  delete      Delete variables.
+  describe    Describe variables.
+  export      Export variables.
+  help        display help for command
+  list        List variables.
+  set         Set variable description.
 "
 `;

--- a/test/client_cli/en/__snapshots__/idm.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm.test.js.snap
@@ -6,13 +6,13 @@ exports[`CLI help interface for 'idm' should be expected english 1`] = `
 Manage IDM configuration.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  count           Count number of managed objects of a given type.
-  export          Export IDM configuration objects.
-  help [command]  display help for command
-  import          Import IDM configuration objects.
-  list            List all IDM configuration objects.
+  count       Count managed objects.
+  export      Export IDM configuration objects.
+  help        display help for command
+  import      Import IDM configuration objects.
+  list        List IDM configuration objects.
 "
 `;

--- a/test/client_cli/en/__snapshots__/idp.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idp.test.js.snap
@@ -6,12 +6,12 @@ exports[`CLI help interface for 'idp' should be expected english 1`] = `
 Manage (social) identity providers.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  export          Export identity providers.
-  help [command]  display help for command
-  import          Import identity providers.
-  list            List identity providers.
+  export      Export (social) identity providers.
+  help        display help for command
+  import      Import (social) identity providers.
+  list        List (social) identity providers.
 "
 `;

--- a/test/client_cli/en/__snapshots__/journey.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey.test.js.snap
@@ -6,22 +6,21 @@ exports[`CLI help interface for 'journey' should be expected english 1`] = `
 Manage journeys/trees.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete journeys/trees.
-  describe        If host argument is supplied, describe the journey/tree
-                  indicated by -t, or all journeys/trees in the realm if no -t
-                  is supplied, otherwise describe the journey/tree export file
-                  indicated by -f.
-  disable         Disable journeys/trees.
-  enable          Enable journeys/trees.
-  export          Export journeys/trees.
-  help [command]  display help for command
-  import          Import journeys/trees.
-  list            List journeys/trees.
-  prune           Prune orphaned configuration artifacts left behind after
-                  deleting authentication trees. You will be prompted before
-                  any destructive operations are performed.
+  delete      Delete journeys/trees.
+  describe    If -h is supplied, describe the journey/tree indicated by -i, or
+              all journeys/trees in the realm if no -i is supplied, otherwise
+              describe the journey/tree export file indicated by -f.
+  disable     Disable journeys/trees.
+  enable      Enable journeys/trees.
+  export      Export journeys/trees.
+  help        display help for command
+  import      Import journey/tree.
+  list        List journeys/trees.
+  prune       Prune orphaned configuration artifacts left behind after deleting
+              authentication trees. You will be prompted before any destructive
+              operations are performed.
 "
 `;

--- a/test/client_cli/en/__snapshots__/log-fetch.test.js.snap
+++ b/test/client_cli/en/__snapshots__/log-fetch.test.js.snap
@@ -20,9 +20,9 @@ Arguments:
 Options:
   -b, --begin-timestamp <beginTs>  Begin timestamp for period (in ISO8601,
                                    example: "2022-10-13T19:06:28Z", or
-                                   "2022-09.30". Cannot be more than 30 days in
-                                   the past. If not specified, logs from one
-                                   hour ago are fetched (-e is ignored)
+                                   "2022-09.30".   Cannot be more than 30 days
+                                   in the past. If not specified, logs from one
+                                   hour ago are fetched   (-e is ignored)
   -c, --sources <sources>          Comma separated list of log sources
                                    (default: Log everything)
   --curlirize                      Output all network calls in curl format.
@@ -43,7 +43,7 @@ Options:
                                    case the proxy must provide this capability.
                                    (default: Don't allow insecure connections)
   -l, --level <level>              Set log level filter. You can specify the
-                                   level as a number or a string. Following
+                                   level as a number or a string.   Following
                                    values are possible (values on the same line
                                    are equivalent):
                                    0, SEVERE, FATAL, or ERROR
@@ -102,9 +102,9 @@ Arguments:
 Options:
   -b, --begin-timestamp <beginTs>  Begin timestamp for period (in ISO8601,
                                    example: "2022-10-13T19:06:28Z", or
-                                   "2022-09.30". Cannot be more than 30 days in
-                                   the past. If not specified, logs from one
-                                   hour ago are fetched (-e is ignored)
+                                   "2022-09.30".   Cannot be more than 30 days
+                                   in the past. If not specified, logs from one
+                                   hour ago are fetched   (-e is ignored)
   -c, --sources <sources>          Comma separated list of log sources
                                    (default: Log everything)
   --curlirize                      Output all network calls in curl format.
@@ -125,7 +125,7 @@ Options:
                                    case the proxy must provide this capability.
                                    (default: Don't allow insecure connections)
   -l, --level <level>              Set log level filter. You can specify the
-                                   level as a number or a string. Following
+                                   level as a number or a string.   Following
                                    values are possible (values on the same line
                                    are equivalent):
                                    0, SEVERE, FATAL, or ERROR

--- a/test/client_cli/en/__snapshots__/log-tail.test.js.snap
+++ b/test/client_cli/en/__snapshots__/log-tail.test.js.snap
@@ -35,7 +35,7 @@ Options:
                                capability. (default: Don't allow insecure
                                connections)
   -l, --level <level>          Set log level filter. You can specify the level
-                               as a number or a string. Following values are
+                               as a number or a string.   Following values are
                                possible (values on the same line are
                                equivalent):
                                0, SEVERE, FATAL, or ERROR
@@ -107,7 +107,7 @@ Options:
                                capability. (default: Don't allow insecure
                                connections)
   -l, --level <level>          Set log level filter. You can specify the level
-                               as a number or a string. Following values are
+                               as a number or a string.   Following values are
                                possible (values on the same line are
                                equivalent):
                                0, SEVERE, FATAL, or ERROR

--- a/test/client_cli/en/__snapshots__/log.test.js.snap
+++ b/test/client_cli/en/__snapshots__/log.test.js.snap
@@ -7,14 +7,16 @@ View Identity Cloud logs. If valid tenant admin credentials are specified, a
 log API key and secret are automatically created for that admin user.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  fetch           Fetch Identity Cloud logs for a time window.
-  help [command]  display help for command
-  key             Manage Identity Cloud log API keys.
-  list            List available ID Cloud log sources.
-  tail            Tail Identity Cloud logs.
+  fetch       Fetch Identity Cloud logs between a specified begin and end time
+              period.  WARNING: depending on filters and time period specified,
+              this could take substantial time to complete.
+  help        display help for command
+  key         Manage Identity Cloud log API keys.
+  list        List available ID Cloud log sources.
+  tail        Tail Identity Cloud logs.
 "
 `;
 
@@ -25,13 +27,15 @@ View Identity Cloud logs. If valid tenant admin credentials are specified, a
 log API key and secret are automatically created for that admin user.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  fetch           Fetch Identity Cloud logs for a time window.
-  help [command]  display help for command
-  key             Manage Identity Cloud log API keys.
-  list            List available ID Cloud log sources.
-  tail            Tail Identity Cloud logs.
+  fetch       Fetch Identity Cloud logs between a specified begin and end time
+              period.  WARNING: depending on filters and time period specified,
+              this could take substantial time to complete.
+  help        display help for command
+  key         Manage Identity Cloud log API keys.
+  list        List available ID Cloud log sources.
+  tail        Tail Identity Cloud logs.
 "
 `;

--- a/test/client_cli/en/__snapshots__/oauth-client-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client-export.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CLI help interface for 'oauth client export' should be expected english 1`] = `
 "Usage: frodo oauth client export [options] [host] [realm] [username] [password]
 
-Export OAuth2 applications.
+Export OAuth2 clients.
 
 Arguments:
   host                         Access Management base URL, e.g.:

--- a/test/client_cli/en/__snapshots__/oauth-client-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client-import.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CLI help interface for 'oauth client import' should be expected english 1`] = `
 "Usage: frodo oauth client import [options] [host] [realm] [username] [password]
 
-Import OAuth2 applications.
+Import OAuth2 clients.
 
 Arguments:
   host                         Access Management base URL, e.g.:
@@ -20,9 +20,9 @@ Arguments:
   password                     Password.
 
 Options:
-  -a, --all                    Import all applications from single file.
-                               Ignored with -i.
-  -A, --all-separate           Import all applications from separate files
+  -a, --all                    Import all clients from single file. Ignored
+                               with -i.
+  -A, --all-separate           Import all clients from separate files
                                (*.app.json) in the current directory. Ignored
                                with -i or -a.
   --curlirize                  Output all network calls in curl format.
@@ -33,9 +33,8 @@ Options:
   -f, --file <file>            Name of the file to import.
   --flush-cache                Flush token cache.
   -h, --help                   Help
-  -i, --app-id <id>            Application id. If specified, only one
-                               application is imported and the options -a and
-                               -A are ignored.
+  -i, --app-id <id>            Client id. If specified, only one client is
+                               imported and the options -a and -A are ignored.
   -k, --insecure               Allow insecure connections when using SSL/TLS.
                                Has no effect when using a network proxy for
                                https (HTTPS_PROXY=http://<host>:<port>), in

--- a/test/client_cli/en/__snapshots__/oauth-client-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client-list.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CLI help interface for 'oauth client list' should be expected english 1`] = `
 "Usage: frodo oauth client list [options] [host] [realm] [username] [password]
 
-List OAuth2 applications.
+List OAuth2 clients.
 
 Arguments:
   host                         Access Management base URL, e.g.:

--- a/test/client_cli/en/__snapshots__/oauth-client.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client.test.js.snap
@@ -6,12 +6,12 @@ exports[`CLI help interface for 'oauth client' should be expected english 1`] = 
 Manage OAuth2 clients.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  export          Export OAuth2 clients.
-  help [command]  display help for command
-  import          Import OAuth2 clients.
-  list            List OAuth2 clients.
+  export      Export OAuth2 clients.
+  help        display help for command
+  import      Import OAuth2 clients.
+  list        List OAuth2 clients.
 "
 `;

--- a/test/client_cli/en/__snapshots__/oauth.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth.test.js.snap
@@ -6,10 +6,10 @@ exports[`CLI help interface for 'oauth' should be expected english 1`] = `
 Manage OAuth2 clients and providers.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  client          Manage OAuth2 clients.
-  help [command]  display help for command
+  client      Manage OAuth2 clients.
+  help        display help for command
 "
 `;

--- a/test/client_cli/en/__snapshots__/realm-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm-describe.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CLI help interface for 'realm describe' should be expected english 1`] = `
-"Usage: frodo realm describe [options] [host] [realm] [username] [password]
+"Usage: frodo realm describe|details [options] [host] [realm] [username] [password]
 
 Describe realms.
 

--- a/test/client_cli/en/__snapshots__/realm.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm.test.js.snap
@@ -11,7 +11,7 @@ Options:
 Commands:
   add-custom-domain     Add custom domain (realm DNS alias).
   describe|details      Describe realms.
-  help [command]        display help for command
+  help                  display help for command
   list                  List realms.
   remove-custom-domain  Remove custom domain (realm DNS alias).
 "

--- a/test/client_cli/en/__snapshots__/saml-cot.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-cot.test.js.snap
@@ -6,12 +6,12 @@ exports[`CLI help interface for 'saml cot' should be expected english 1`] = `
 Manage circles of trust.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  export          Export circles of trust.
-  help [command]  display help for command
-  import          Import circles of trust.
-  list            List circles of trust.
+  export      Export SAML circles of trust.
+  help        display help for command
+  import      Import SAML circles of trust.
+  list        List SAML circles of trust.
 "
 `;

--- a/test/client_cli/en/__snapshots__/saml-metadata-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-metadata-export.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CLI help interface for 'saml metadata export' should be expected english 1`] = `
 "Usage: frodo saml metadata export [options] [host] [realm] [username] [password]
 
-Export SAML metadata.
+Export metadata.
 
 Arguments:
   host                         Access Management base URL, e.g.:

--- a/test/client_cli/en/__snapshots__/saml-metadata.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-metadata.test.js.snap
@@ -6,10 +6,10 @@ exports[`CLI help interface for 'saml metadata' should be expected english 1`] =
 SAML metadata operations.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  export          Export metadata.
-  help [command]  display help for command
+  export      Export metadata.
+  help        display help for command
 "
 `;

--- a/test/client_cli/en/__snapshots__/saml.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml.test.js.snap
@@ -6,16 +6,16 @@ exports[`CLI help interface for 'saml' should be expected english 1`] = `
 Manage SAML entity providers and circles of trust.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  cot             Manage circles of trust.
-  delete          Delete an SAML Entity
-  describe        Describe entity providers.
-  export          Export entity providers.
-  help [command]  display help for command
-  import          Import entity providers.
-  list            List entity providers.
-  metadata        Metadata operations.
+  cot         Manage circles of trust.
+  delete      Delete SAML entity providers.
+  describe    Describe the configuration of an entity provider.
+  export      Export SAML entity providers.
+  help        display help for command
+  import      Import SAML entity providers.
+  list        List SAML entity providers.
+  metadata    SAML metadata operations.
 "
 `;

--- a/test/client_cli/en/__snapshots__/script.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script.test.js.snap
@@ -6,13 +6,13 @@ exports[`CLI help interface for 'script' should be expected english 1`] = `
 Manage scripts.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete scripts.
-  export          Export scripts.
-  help [command]  display help for command
-  import          Import scripts.
-  list            List scripts.
+  delete      Delete scripts.
+  export      Export scripts.
+  help        display help for command
+  import      Import scripts.
+  list        List scripts.
 "
 `;

--- a/test/client_cli/en/__snapshots__/service.test.js.snap
+++ b/test/client_cli/en/__snapshots__/service.test.js.snap
@@ -6,13 +6,13 @@ exports[`CLI help interface for 'service' should be expected english 1`] = `
 Manage AM services.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete AM services.
-  export          Export AM services.
-  help [command]  display help for command
-  import          Import AM services.
-  list            List AM services.
+  delete      Delete AM services.
+  export      Export AM services.
+  help        display help for command
+  import      Import AM services.
+  list        List AM services.
 "
 `;

--- a/test/client_cli/en/__snapshots__/theme.test.js.snap
+++ b/test/client_cli/en/__snapshots__/theme.test.js.snap
@@ -6,13 +6,13 @@ exports[`CLI help interface for 'theme' should be expected english 1`] = `
 Manage themes.
 
 Options:
-  -h, --help      Help
+  -h, --help  Help
 
 Commands:
-  delete          Delete themes.
-  export          Export themes.
-  help [command]  display help for command
-  import          Import themes.
-  list            List themes.
+  delete      Delete themes.
+  export      Export themes.
+  help        display help for command
+  import      Import themes.
+  list        List themes.
 "
 `;


### PR DESCRIPTION
This PR updates the help command by adding a custom Help object for FrodoStubCommands. Additionally, it refactors all sub-commands to run in the same process instead of running the sub-commands as executables in separate processes. Thus, everything should be functionally the same besides this change to how the commands are run. 

Due to the changes to how the commands are created, there can no longer be two descriptions for each sub-command, but just one description. This isn't a huge deal since a lot of the descriptions were the same or very similar anyways, but it did mean that we had to update the client_cli snapshots where the descriptions differed. Similarly, due to the changes in the help command, the client_cli snapshots had to be updated. 

No changes needed to be made to e2e tests or snapshots however. They were originally failing after the changes due to the mock naming scheme no longer working as it was before, likely due to the fact that it is now using only one process to run all sub-commands, resulting in the mocks generating differently now. We made a temporary fix in frodo-lib to how mocks are named to make it so the tests work with the current mocks, which fix is in another PR on the frodo-lib project, although the mock naming is something we will want to improve eventually.