### PR TITLE
Fix and Improve Script Exports and Imports

### DIFF
--- a/src/cli/script/script-delete.ts
+++ b/src/cli/script/script-delete.ts
@@ -17,14 +17,14 @@ export default function setup() {
     .description('Delete scripts.')
     .addOption(
       new Option(
-        '-i, --script-id <script>',
-        'id of a script. If specified, -a and -A are ignored.'
+        '-i, --script-id <uuid>',
+        'Uuid of the script. If specified, -a and -A are ignored.'
       )
     )
     .addOption(
       new Option(
-        '-n, --script-name <script>',
-        'name of a script. If specified, -a and -A are ignored.'
+        '-n, --script-name <name>',
+        'Name of the script. If specified, -a and -A are ignored.'
       )
     )
     .addOption(

--- a/src/cli/script/script-describe.ts
+++ b/src/cli/script/script-describe.ts
@@ -8,7 +8,12 @@ export default function setup() {
 
   program
     .description('Describe script.')
-    .addOption(new Option('-i, --script-id <script-id>', 'Script id.'))
+    .addOption(
+      new Option(
+        '-i, --script-id <uuid>',
+        'Uuid of the script. If specified, -a and -A are ignored.'
+      )
+    )
     .action(
       // implement command logic inside action handler
       async (host, realm, user, password, options, command) => {

--- a/src/cli/script/script-import.ts
+++ b/src/cli/script/script-import.ts
@@ -17,6 +17,12 @@ export default function setup() {
     .addOption(new Option('-f, --file <file>', 'Name of the file to import.'))
     .addOption(
       new Option(
+        '-i, --script-id <uuid>',
+        'Uuid of the script. If specified, -a and -A are ignored.'
+      )
+    )
+    .addOption(
+      new Option(
         '-n, --script-name <name>',
         'Name of the script. If specified, -a and -A are ignored.'
       )
@@ -49,7 +55,13 @@ export default function setup() {
     .addOption(
       new Option(
         '-d, --default',
-        'Import all scripts including the default scripts. Ignored with -n.'
+        'Import all scripts including the default scripts.'
+      )
+    )
+    .addOption(
+      new Option(
+        '--no-deps',
+        'Do not include script dependencies (i.e. library scripts). Can only be used with -n or -i.'
       )
     )
     .action(
@@ -69,9 +81,11 @@ export default function setup() {
             `Importing script(s) into realm "${state.getRealm()}"...`
           );
           const outcome = await importScriptsFromFile(
+            options.scriptId,
             options.scriptName || options.script,
             options.file,
             {
+              deps: options.deps,
               reUuid: options.reUuid,
               includeDefault: options.default,
             }
@@ -85,6 +99,7 @@ export default function setup() {
             await importScriptsFromFiles(
               options.watch,
               {
+                deps: options.deps,
                 reUuid: options.reUuid,
                 includeDefault: options.default,
               },

--- a/src/ops/ConfigOps.ts
+++ b/src/ops/ConfigOps.ts
@@ -14,7 +14,7 @@ import {
 } from '../utils/Config';
 import { cleanupProgressIndicators, printError } from '../utils/Console';
 import { writeSyncJsonToDirectory } from './MappingOps';
-import { extractScriptToFile } from './ScriptOps';
+import { extractScriptsToFiles } from './ScriptOps';
 
 const { getTypedFilename, saveJsonToFile, getFilePath, getWorkingDirectory } =
   frodo.utils;
@@ -295,7 +295,7 @@ function exportItem(
         }
         const filename = getTypedFilename(name ? name : id, fileType);
         if (extract && type === 'script') {
-          extractScriptToFile(
+          extractScriptsToFiles(
             exportData as ScriptExportInterface,
             id,
             `${baseDirectory.substring(getWorkingDirectory(false).length + 1)}/${fileType}`

--- a/test/client_cli/en/__snapshots__/script-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-delete.test.js.snap
@@ -29,7 +29,7 @@ Options:
                                output helpful for troubleshooting.
   --flush-cache                Flush token cache.
   -h, --help                   Help
-  -i, --script-id <script>     id of a script. If specified, -a and -A are
+  -i, --script-id <uuid>       Uuid of the script. If specified, -a and -A are
                                ignored.
   -k, --insecure               Allow insecure connections when using SSL/TLS.
                                Has no effect when using a network proxy for
@@ -52,7 +52,7 @@ Options:
                                templates or how to walk through the tenant
                                admin login flow of Identity Cloud and handle
                                MFA (choices: "classic", "cloud", "forgeops")
-  -n, --script-name <script>   name of a script. If specified, -a and -A are
+  -n, --script-name <name>     Name of the script. If specified, -a and -A are
                                ignored.
   --no-cache                   Disable token cache for this operation.
   --sa-id <sa-id>              Service account id.

--- a/test/client_cli/en/__snapshots__/script-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-export.test.js.snap
@@ -35,6 +35,8 @@ Options:
   -f, --file <file>            Name of the export file.
   --flush-cache                Flush token cache.
   -h, --help                   Help
+  -i, --script-id <uuid>       Uuid of the script. If specified, -a and -A are
+                               ignored.
   -k, --insecure               Allow insecure connections when using SSL/TLS.
                                Has no effect when using a network proxy for
                                https (HTTPS_PROXY=http://<host>:<port>), in
@@ -60,6 +62,8 @@ Options:
                                ignored.
   -N, --no-metadata            Does not include metadata in the export file.
   --no-cache                   Disable token cache for this operation.
+  --no-deps                    Do not include script dependencies (i.e. library
+                               scripts). Ignored with -a and -A.
   -s, --script <script>        DEPRECATED! Use -n/--script-name instead. Name
                                of the script.
   --sa-id <sa-id>              Service account id.

--- a/test/client_cli/en/__snapshots__/script-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-import.test.js.snap
@@ -25,7 +25,7 @@ Options:
                                Ignored with -n.
   --curlirize                  Output all network calls in curl format.
   -d, --default                Import all scripts including the default
-                               scripts. Ignored with -n.
+                               scripts.
   -D, --directory <directory>  Set the working directory.
   --debug                      Debug output during command execution. If
                                specified, may or may not produce additional
@@ -33,6 +33,8 @@ Options:
   -f, --file <file>            Name of the file to import.
   --flush-cache                Flush token cache.
   -h, --help                   Help
+  -i, --script-id <uuid>       Uuid of the script. If specified, -a and -A are
+                               ignored.
   -k, --insecure               Allow insecure connections when using SSL/TLS.
                                Has no effect when using a network proxy for
                                https (HTTPS_PROXY=http://<host>:<port>), in
@@ -57,6 +59,8 @@ Options:
   -n, --script-name <name>     Name of the script. If specified, -a and -A are
                                ignored.
   --no-cache                   Disable token cache for this operation.
+  --no-deps                    Do not include script dependencies (i.e. library
+                               scripts). Can only be used with -n or -i.
   --re-uuid                    Re-UUID. Create a new UUID for the script upon
                                import. Use this to duplicate a script or create
                                a new version of the same script. Note that you

--- a/test/e2e/__snapshots__/config-import.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/config-import.e2e.test.js.snap
@@ -13,6 +13,7 @@ Errors occurred during full config import
     Reason: Unauthorized
     Message: Unauthorized
   Error importing email templates
+  Error updating email template baselineDemoEmailVerification
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401
@@ -50,6 +51,7 @@ Errors occurred during full config import
     Reason: Unauthorized
     Message: Unauthorized
   Error importing email templates
+  Error updating email template baselineDemoEmailVerification
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401
@@ -92,11 +94,13 @@ Errors occurred during full config import
     Reason: Unauthorized
     Message: Unauthorized
   Error importing email templates
+  Error updating email template baselineDemoEmailVerification
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401
     Reason: Unauthorized
     Message: Unauthorized
+  Error updating email template baselineDemoMagicLink
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401
@@ -644,21 +648,24 @@ Errors occurred during full config import
     Reason: Unauthorized
     Message: Unauthorized
   Error importing email templates
+  Error updating email template baselineDemoEmailVerification
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 403
     Reason: Forbidden
     Message: Access denied
+  Error updating email template baselineDemoMagicLink
   HTTP client error
     Code: ERR_BAD_REQUEST
-    Status: 403
-    Reason: Forbidden
-    Message: Access denied
+    Status: 401
+    Reason: Unauthorized
+    Message: Unauthorized
+  Error updating email template forgottenUsername
   HTTP client error
     Code: ERR_BAD_REQUEST
-    Status: 403
-    Reason: Forbidden
-    Message: Access denied
+    Status: 401
+    Reason: Unauthorized
+    Message: Unauthorized
   Error importing services
   Error putting global full service configs
   Error putting global full service config CorsService
@@ -697,11 +704,13 @@ Errors occurred during full config import
     Reason: Unauthorized
     Message: Unauthorized
   Error importing email templates
+  Error updating email template baselineDemoEmailVerification
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401
     Reason: Unauthorized
     Message: Unauthorized
+  Error updating email template baselineDemoMagicLink
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401
@@ -1254,11 +1263,13 @@ Errors occurred during full config import
     Reason: Unauthorized
     Message: Unauthorized
   Error importing email templates
+  Error updating email template baselineDemoEmailVerification
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401
     Reason: Unauthorized
     Message: Unauthorized
+  Error updating email template baselineDemoMagicLink
   HTTP client error
     Code: ERR_BAD_REQUEST
     Status: 401

--- a/test/e2e/__snapshots__/journey-describe.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/journey-describe.e2e.test.js.snap
@@ -68,10 +68,10 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (4)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| debug | JavaSscript | Authentication Tree Decision Node | \`3cb43516-ae69-433a-8787-501d45db14e9\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| debug | JavaScript | Authentication Tree Decision Node | \`3cb43516-ae69-433a-8787-501d45db14e9\` |
 # j01 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j01.png)]()
@@ -97,9 +97,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
 # j02 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j02.png)]()
@@ -126,9 +126,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
 # j03 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j03.png)]()
@@ -156,9 +156,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
 # j04 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j04.png)]()
@@ -187,9 +187,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
 # j05 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j05.png)]()
@@ -219,9 +219,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
 # j06 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j06.png)]()
@@ -252,9 +252,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
 # j07 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j07.png)]()
@@ -286,9 +286,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
 # j08 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j08.png)]()
@@ -321,9 +321,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
 # j09 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j09.png)]()
@@ -357,9 +357,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
 # j10 - :white_check_mark: \`enabled\`, :green_circle: \`standard\`
 
 [![](./j10.png)]()
@@ -394,9 +394,9 @@ exports[`frodo journey describe "frodo journey describe --markdown": should desc
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
 "
 `;
 
@@ -1402,9 +1402,9 @@ exports[`frodo journey describe "frodo journey describe -F test3.json --markdown
 ## Scripts (3)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
 "
 `;
 
@@ -1751,10 +1751,10 @@ exports[`frodo journey describe "frodo journey describe -f test/e2e/exports/all/
 ## Scripts (4)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| debug | JavaSscript | Authentication Tree Decision Node | \`3cb43516-ae69-433a-8787-501d45db14e9\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| debug | JavaScript | Authentication Tree Decision Node | \`3cb43516-ae69-433a-8787-501d45db14e9\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
 "
 `;
 
@@ -1826,10 +1826,10 @@ exports[`frodo journey describe "frodo journey describe -i j00 --markdown": shou
 ## Scripts (4)
 | Name | Language | Type | Id |
 | ---- | -------- | ---- | ---|
-| shared | JavaSscript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
-| mode | JavaSscript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
-| level | JavaSscript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
-| debug | JavaSscript | Authentication Tree Decision Node | \`3cb43516-ae69-433a-8787-501d45db14e9\` |
+| shared | JavaScript | Authentication Tree Decision Node | \`1b52a7e0-4019-40fa-958a-15a49870e901\` |
+| mode | JavaScript | Authentication Tree Decision Node | \`5bbdaeff-ddee-44b9-b608-8d413d7d65a6\` |
+| level | JavaScript | Authentication Tree Decision Node | \`41c24257-d7fc-4654-8b46-c2666dc5b56d\` |
+| debug | JavaScript | Authentication Tree Decision Node | \`3cb43516-ae69-433a-8787-501d45db14e9\` |
 "
 `;
 

--- a/test/e2e/__snapshots__/script-export.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/script-export.e2e.test.js.snap
@@ -9484,6 +9484,188 @@ exports[`frodo script export "frodo script export --all-separate --no-metadata -
 }
 `;
 
+exports[`frodo script export "frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" along with libraries 1`] = `""`;
+
+exports[`frodo script export "frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" along with libraries: scriptExportTestDir5/2c38c998-aec0-4e56-8d46-bff6e24a704e.script.js 1`] = `
+"var myOtherlib = require('My Other Example Library Script');
+
+var i = 0;
+
+function add(j) {i += j};
+function logTotal(log) { log.info("Total: " + i) };
+
+// export constant
+exports.MSG = 'Final sum';
+
+// export function
+exports.add = add;
+exports.logTotal = logTotal;
+
+//direct export using a inline declaration
+exports.logTotalWithMessage = (log, message) => log.info(message + ": " + i);
+"
+`;
+
+exports[`frodo script export "frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" along with libraries: scriptExportTestDir5/4e053815-adde-46ac-9fe2-d3ae93517c14.script.js 1`] = `
+"console.log("hi");
+"
+`;
+
+exports[`frodo script export "frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" along with libraries: scriptExportTestDir5/6c49bebe-3a62-11ed-a261-0242ac120002.script.js 1`] = `
+"/*
+ * Copyright 2022-2023 ForgeRock AS. All Rights Reserved
+ *
+ * Use of this code requires a commercial software license with ForgeRock AS.
+ * or with one of its affiliates. All use shall be exclusively subject
+ * to such license between the licensee and ForgeRock AS.
+ */
+
+/*
+ * This is an example library script with methods that can be used in other scripts.
+ * To reference it, use the following:
+ *
+ * var library = require("Library Script");
+ *
+ * library.logError(logger, "Error message");
+ * library.logDebug(logger, "Debug message");
+ */
+
+function logError(log, errorMessage) {
+  log.error(errorMessage);
+}
+
+function logWarning(log, warningMessage) {
+  log.warn(warningMessage);
+}
+
+exports.logError = logError;
+exports.logWarning = logWarning;
+
+// Alternatively, exports can be declared using an inline arrow function
+
+exports.logInfo = (log, infoMessage) => log.info(infoMessage);
+exports.logDebug = (log, debugMessage) => log.debug(debugMessage);
+"
+`;
+
+exports[`frodo script export "frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" along with libraries: scriptExportTestDir5/bb393d07-a121-47e2-9d24-1a1066f39ec0.script.js 1`] = `
+"/**
+ * Testing library scripts
+ */
+var mylib = require('My Example Library');
+var loggers = require('Library Script');
+
+mylib.add(1);
+mylib.logTotal(logger);
+mylib.add(3);
+mylib.logTotalWithMessage(logger, mylib.MSG);
+
+outcome = 'true';
+"
+`;
+
+exports[`frodo script export "frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" along with libraries: scriptExportTestDir5/bb393d07-a121-47e2-9d24-1a1066f39ec0.script.json 1`] = `
+{
+  "meta": Any<Object>,
+  "script": {
+    "2c38c998-aec0-4e56-8d46-bff6e24a704e": {
+      "_id": "2c38c998-aec0-4e56-8d46-bff6e24a704e",
+      "context": "LIBRARY",
+      "createdBy": "null",
+      "creationDate": 0,
+      "default": false,
+      "description": "My Example Library",
+      "evaluatorVersion": "2.0",
+      "language": "JAVASCRIPT",
+      "lastModifiedBy": "null",
+      "lastModifiedDate": 0,
+      "name": "My Example Library",
+      "script": "file://2c38c998-aec0-4e56-8d46-bff6e24a704e.script.js",
+    },
+    "4e053815-adde-46ac-9fe2-d3ae93517c14": {
+      "_id": "4e053815-adde-46ac-9fe2-d3ae93517c14",
+      "context": "LIBRARY",
+      "createdBy": "null",
+      "creationDate": 0,
+      "default": false,
+      "description": null,
+      "evaluatorVersion": "2.0",
+      "language": "JAVASCRIPT",
+      "lastModifiedBy": "null",
+      "lastModifiedDate": 0,
+      "name": "My Other Example Library Script",
+      "script": "file://4e053815-adde-46ac-9fe2-d3ae93517c14.script.js",
+    },
+    "6c49bebe-3a62-11ed-a261-0242ac120002": {
+      "_id": "6c49bebe-3a62-11ed-a261-0242ac120002",
+      "context": "LIBRARY",
+      "createdBy": "null",
+      "creationDate": 0,
+      "default": true,
+      "description": "Default global library script to be referenced from other scripts",
+      "evaluatorVersion": "2.0",
+      "language": "JAVASCRIPT",
+      "lastModifiedBy": "null",
+      "lastModifiedDate": 0,
+      "name": "Library Script",
+      "script": "file://6c49bebe-3a62-11ed-a261-0242ac120002.script.js",
+    },
+    "bb393d07-a121-47e2-9d24-1a1066f39ec0": {
+      "_id": "bb393d07-a121-47e2-9d24-1a1066f39ec0",
+      "context": "AUTHENTICATION_TREE_DECISION_NODE",
+      "createdBy": "null",
+      "creationDate": 0,
+      "default": false,
+      "description": "My Example Script Using Libraries",
+      "evaluatorVersion": "2.0",
+      "language": "JAVASCRIPT",
+      "lastModifiedBy": "null",
+      "lastModifiedDate": 0,
+      "name": "My Example Script Using Libraries",
+      "script": "file://bb393d07-a121-47e2-9d24-1a1066f39ec0.script.js",
+    },
+  },
+}
+`;
+
+exports[`frodo script export "frodo script export --no-deps -i 'bb393d07-a121-47e2-9d24-1a1066f39ec0'": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" 1`] = `""`;
+
+exports[`frodo script export "frodo script export --no-deps -i 'bb393d07-a121-47e2-9d24-1a1066f39ec0'": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0": bb393d07-a121-47e2-9d24-1a1066f39ec0.script.json 1`] = `
+{
+  "meta": Any<Object>,
+  "script": {
+    "bb393d07-a121-47e2-9d24-1a1066f39ec0": {
+      "_id": "bb393d07-a121-47e2-9d24-1a1066f39ec0",
+      "context": "AUTHENTICATION_TREE_DECISION_NODE",
+      "createdBy": "null",
+      "creationDate": 0,
+      "default": false,
+      "description": "My Example Script Using Libraries",
+      "evaluatorVersion": "2.0",
+      "language": "JAVASCRIPT",
+      "lastModifiedBy": "null",
+      "lastModifiedDate": 0,
+      "name": "My Example Script Using Libraries",
+      "script": [
+        "/**",
+        " * Testing library scripts",
+        " */",
+        "var mylib = require('My Example Library');",
+        "var loggers = require('Library Script');",
+        "",
+        "mylib.add(1);",
+        "mylib.logTotal(logger);",
+        "mylib.add(3);",
+        "mylib.logTotalWithMessage(logger, mylib.MSG);",
+        "",
+        "outcome = 'true';",
+        "",
+      ],
+    },
+  },
+}
+`;
+
 exports[`frodo script export "frodo script export --script-name 'GitHub Profile Normalization'": should export the script named "GitHub Profile Normalization" 1`] = `""`;
 
 exports[`frodo script export "frodo script export --script-name 'GitHub Profile Normalization'": should export the script named "GitHub Profile Normalization": GitHub-Profile-Normalization.script.json 1`] = `

--- a/test/e2e/mocks/script_540962730/export_4211608755/0_extract_script-id_directory_3126738353/am_1076162899/recording.har
+++ b/test/e2e/mocks/script_540962730/export_4211608755/0_extract_script-id_directory_3126738353/am_1076162899/recording.har
@@ -1,0 +1,915 @@
+{
+  "log": {
+    "_recordingName": "script/export/0_extract_script-id_directory/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 385,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"allowedWithoutReferer\":true,\"refererWhitelist\":[]},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:20.926Z",
+        "time": 330,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 330
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1892,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 273,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 273,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1157267696\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 3044e8afddd78acfb775451f6053575b124e7cb3 (2024-June-25 16:54)\",\"revision\":\"3044e8afddd78acfb775451f6053575b124e7cb3\",\"date\":\"2024-June-25 16:54\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1157267696\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "273"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.389Z",
+        "time": 72,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 72
+        }
+      },
+      {
+        "_id": "0ac4a5ec30bd9a108e714d2a1992da80",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1956,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/bb393d07-a121-47e2-9d24-1a1066f39ec0"
+        },
+        "response": {
+          "bodySize": 659,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 659,
+            "text": "{\"_id\":\"bb393d07-a121-47e2-9d24-1a1066f39ec0\",\"name\":\"My Example Script Using Libraries\",\"description\":\"My Example Script Using Libraries\",\"script\":\"LyoqCiAqIFRlc3RpbmcgbGlicmFyeSBzY3JpcHRzCiAqLwp2YXIgbXlsaWIgPSByZXF1aXJlKCdNeSBFeGFtcGxlIExpYnJhcnknKTsKdmFyIGxvZ2dlcnMgPSByZXF1aXJlKCdMaWJyYXJ5IFNjcmlwdCcpOwoKbXlsaWIuYWRkKDEpOwpteWxpYi5sb2dUb3RhbChsb2dnZXIpOwpteWxpYi5hZGQoMyk7Cm15bGliLmxvZ1RvdGFsV2l0aE1lc3NhZ2UobG9nZ2VyLCBteWxpYi5NU0cpOwoKb3V0Y29tZSA9ICd0cnVlJzsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"evaluatorVersion\":\"2.0\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "659"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.549Z",
+        "time": 63,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 63
+        }
+      },
+      {
+        "_id": "9f5fae53bb48b1f59117d2164779fd6b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1973,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "name eq \"My Example Library\""
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts?_queryFilter=name%20eq%20%22My%20Example%20Library%22"
+        },
+        "response": {
+          "bodySize": 944,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 944,
+            "text": "{\"result\":[{\"_id\":\"2c38c998-aec0-4e56-8d46-bff6e24a704e\",\"name\":\"My Example Library\",\"description\":\"My Example Library\",\"script\":\"dmFyIG15T3RoZXJsaWIgPSByZXF1aXJlKCdNeSBPdGhlciBFeGFtcGxlIExpYnJhcnkgU2NyaXB0Jyk7Cgp2YXIgaSA9IDA7CgpmdW5jdGlvbiBhZGQoaikge2kgKz0gan07CmZ1bmN0aW9uIGxvZ1RvdGFsKGxvZykgeyBsb2cuaW5mbygiVG90YWw6ICIgKyBpKSB9OwoKLy8gZXhwb3J0IGNvbnN0YW50CmV4cG9ydHMuTVNHID0gJ0ZpbmFsIHN1bSc7CgovLyBleHBvcnQgZnVuY3Rpb24KZXhwb3J0cy5hZGQgPSBhZGQ7CmV4cG9ydHMubG9nVG90YWwgPSBsb2dUb3RhbDsKCi8vZGlyZWN0IGV4cG9ydCB1c2luZyBhIGlubGluZSBkZWNsYXJhdGlvbgpleHBvcnRzLmxvZ1RvdGFsV2l0aE1lc3NhZ2UgPSAobG9nLCBtZXNzYWdlKSA9PiBsb2cuaW5mbyhtZXNzYWdlICsgIjogIiArIGkpOwo=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"LIBRARY\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"evaluatorVersion\":\"2.0\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.1, resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "944"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.632Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      },
+      {
+        "_id": "2c8325ae78c1183838d010882c0b48b2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1967,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "name eq \"Library Script\""
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts?_queryFilter=name%20eq%20%22Library%20Script%22"
+        },
+        "response": {
+          "bodySize": 1746,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1746,
+            "text": "{\"result\":[{\"_id\":\"6c49bebe-3a62-11ed-a261-0242ac120002\",\"name\":\"Library Script\",\"description\":\"Default global library script to be referenced from other scripts\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjItMjAyMyBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWQKICoKICogVXNlIG9mIHRoaXMgY29kZSByZXF1aXJlcyBhIGNvbW1lcmNpYWwgc29mdHdhcmUgbGljZW5zZSB3aXRoIEZvcmdlUm9jayBBUy4KICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIGlzIGFuIGV4YW1wbGUgbGlicmFyeSBzY3JpcHQgd2l0aCBtZXRob2RzIHRoYXQgY2FuIGJlIHVzZWQgaW4gb3RoZXIgc2NyaXB0cy4KICogVG8gcmVmZXJlbmNlIGl0LCB1c2UgdGhlIGZvbGxvd2luZzoKICoKICogdmFyIGxpYnJhcnkgPSByZXF1aXJlKCJMaWJyYXJ5IFNjcmlwdCIpOwogKgogKiBsaWJyYXJ5LmxvZ0Vycm9yKGxvZ2dlciwgIkVycm9yIG1lc3NhZ2UiKTsKICogbGlicmFyeS5sb2dEZWJ1Zyhsb2dnZXIsICJEZWJ1ZyBtZXNzYWdlIik7CiAqLwoKZnVuY3Rpb24gbG9nRXJyb3IobG9nLCBlcnJvck1lc3NhZ2UpIHsKICBsb2cuZXJyb3IoZXJyb3JNZXNzYWdlKTsKfQoKZnVuY3Rpb24gbG9nV2FybmluZyhsb2csIHdhcm5pbmdNZXNzYWdlKSB7CiAgbG9nLndhcm4od2FybmluZ01lc3NhZ2UpOwp9CgpleHBvcnRzLmxvZ0Vycm9yID0gbG9nRXJyb3I7CmV4cG9ydHMubG9nV2FybmluZyA9IGxvZ1dhcm5pbmc7CgovLyBBbHRlcm5hdGl2ZWx5LCBleHBvcnRzIGNhbiBiZSBkZWNsYXJlZCB1c2luZyBhbiBpbmxpbmUgYXJyb3cgZnVuY3Rpb24KCmV4cG9ydHMubG9nSW5mbyA9IChsb2csIGluZm9NZXNzYWdlKSA9PiBsb2cuaW5mbyhpbmZvTWVzc2FnZSk7CmV4cG9ydHMubG9nRGVidWcgPSAobG9nLCBkZWJ1Z01lc3NhZ2UpID0+IGxvZy5kZWJ1ZyhkZWJ1Z01lc3NhZ2UpOwo=\",\"default\":true,\"language\":\"JAVASCRIPT\",\"context\":\"LIBRARY\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"evaluatorVersion\":\"2.0\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.1, resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1746"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 794,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.635Z",
+        "time": 64,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 64
+        }
+      },
+      {
+        "_id": "a48c9bafd8bf132b1f22c943f8f32cb6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1990,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "name eq \"My Other Example Library Script\""
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts?_queryFilter=name%20eq%20%22My%20Other%20Example%20Library%20Script%22"
+        },
+        "response": {
+          "bodySize": 445,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 445,
+            "text": "{\"result\":[{\"_id\":\"4e053815-adde-46ac-9fe2-d3ae93517c14\",\"name\":\"My Other Example Library Script\",\"description\":null,\"script\":\"Y29uc29sZS5sb2coImhpIik7\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"LIBRARY\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"evaluatorVersion\":\"2.0\"}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":0}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.1, resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "445"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:21 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.706Z",
+        "time": 60,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 60
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/export_4211608755/0_extract_script-id_directory_3126738353/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/script_540962730/export_4211608755/0_extract_script-id_directory_3126738353/oauth2_393036114/recording.har
@@ -1,0 +1,146 @@
+{
+  "log": {
+    "_recordingName": "script/export/0_extract_script-id_directory/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1339,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "1339"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 440,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:autoaccess:* fr:idc:esv:* fr:iga:* fr:idc:analytics:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:certificate:read fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:promotion:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1776,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1776,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:autoaccess:* fr:idc:esv:* fr:iga:* fr:idc:analytics:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:certificate:read fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:promotion:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1776"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:20 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 561,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.280Z",
+        "time": 101,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 101
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/export_4211608755/0_extract_script-id_directory_3126738353/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/script_540962730/export_4211608755/0_extract_script-id_directory_3126738353/openidm_3290118515/recording.har
@@ -1,0 +1,302 @@
+{
+  "log": {
+    "_recordingName": "script/export/0_extract_script-id_directory/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1904,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/7a031a92-f70d-4b30-9d70-da7cfb1d9c93?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1383,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1383,
+            "text": "{\"_id\":\"7a031a92-f70d-4b30-9d70-da7cfb1d9c93\",\"_rev\":\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1720799681233\",\"description\":\"phales@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:autoaccess:*\",\"fr:idc:certificate:*\",\"fr:idc:certificate:read\",\"fr:idc:content-security-policy:*\",\"fr:idc:custom-domain:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:iga:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"0XdDQoML6maEILSCc8AWtpjBlKNOzf_NTG_jT0M0wzk\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"mvVVosknqaMRfUPxzZKLpNIIEZCTHcVT3QGRsA2CpUaK0jNO5WOljqLe3XjJmE27b2vcO_GT29M9QIwUVYAx8cv9BnwTEuioTu_Tugp3O4X3VO9VmNTQkaM1gASCTkZ2u_VuZefusBmydrheMP_XlT7GvB_sSpLgpyiN88LEO1RVVZEiG9YAanSQZejtKYLpxV5-Sxu3kh3c1M2HGiw9LeGu0h1p6okCDWwaJUDIG7jXgcHYgFCcNLkklzMX82ozWXEyjQPaxg95sk3d1ZLl-hoAJAI2-bF_ANvqK60i3WCBBPpulUU_RGeVhgxcnMTbDJUm1KgFhlK9TcvgQmZtm1u9NF0hkNlfrYhDUiy3BVWnHCTi50JUZYTevfo6LS2waTE-ZWMAZ0CCeShPR92HkcyfFIYf_PFvrwk55pmvDbx4Fc4l2y_JXKckSuKf2ErmWN_8F7ou5zNsrYcmApCuNj7m0Is3BhnvafhIsI8nocyeJPiaH5oHm5aCSWbjVFvFyOmsuZQ3AAkHjBcET3iqBneHKqSe4-Zw9-u4W6iSw8L8fF7_RPFGYAnxidqEl2Y4WOB3GsaYXEOn5uT6yKJTDbtRABdvEswFfxdVcWwvnGItgmVbUnU_QFjkOgNC2U051jUE3crGZSpeTN8028NGikzvB4PhcvIFT0biHIXFr98\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:21 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1383"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 668,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.454Z",
+        "time": 102,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 102
+        }
+      },
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1904,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/7a031a92-f70d-4b30-9d70-da7cfb1d9c93?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1383,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1383,
+            "text": "{\"_id\":\"7a031a92-f70d-4b30-9d70-da7cfb1d9c93\",\"_rev\":\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1720799681233\",\"description\":\"phales@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:autoaccess:*\",\"fr:idc:certificate:*\",\"fr:idc:certificate:read\",\"fr:idc:content-security-policy:*\",\"fr:idc:custom-domain:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:iga:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"0XdDQoML6maEILSCc8AWtpjBlKNOzf_NTG_jT0M0wzk\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"mvVVosknqaMRfUPxzZKLpNIIEZCTHcVT3QGRsA2CpUaK0jNO5WOljqLe3XjJmE27b2vcO_GT29M9QIwUVYAx8cv9BnwTEuioTu_Tugp3O4X3VO9VmNTQkaM1gASCTkZ2u_VuZefusBmydrheMP_XlT7GvB_sSpLgpyiN88LEO1RVVZEiG9YAanSQZejtKYLpxV5-Sxu3kh3c1M2HGiw9LeGu0h1p6okCDWwaJUDIG7jXgcHYgFCcNLkklzMX82ozWXEyjQPaxg95sk3d1ZLl-hoAJAI2-bF_ANvqK60i3WCBBPpulUU_RGeVhgxcnMTbDJUm1KgFhlK9TcvgQmZtm1u9NF0hkNlfrYhDUiy3BVWnHCTi50JUZYTevfo6LS2waTE-ZWMAZ0CCeShPR92HkcyfFIYf_PFvrwk55pmvDbx4Fc4l2y_JXKckSuKf2ErmWN_8F7ou5zNsrYcmApCuNj7m0Is3BhnvafhIsI8nocyeJPiaH5oHm5aCSWbjVFvFyOmsuZQ3AAkHjBcET3iqBneHKqSe4-Zw9-u4W6iSw8L8fF7_RPFGYAnxidqEl2Y4WOB3GsaYXEOn5uT6yKJTDbtRABdvEswFfxdVcWwvnGItgmVbUnU_QFjkOgNC2U051jUE3crGZSpeTN8028NGikzvB4PhcvIFT0biHIXFr98\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:47:21 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1383"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-89746b71-88e6-4c2e-938e-e87c2caf071c"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 668,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:47:21.468Z",
+        "time": 72,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 72
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/export_4211608755/0_no-deps_i_3429592532/am_1076162899/recording.har
+++ b/test/e2e/mocks/script_540962730/export_4211608755/0_no-deps_i_3429592532/am_1076162899/recording.har
@@ -1,0 +1,459 @@
+{
+  "log": {
+    "_recordingName": "script/export/0_no-deps_i/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 385,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 553,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"allowedWithoutReferer\":true,\"refererWhitelist\":[]},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1874515102\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "553"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:37:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:37:03.384Z",
+        "time": 119,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 119
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1892,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 273,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 273,
+            "text": "{\"_id\":\"version\",\"_rev\":\"1157267696\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 3044e8afddd78acfb775451f6053575b124e7cb3 (2024-June-25 16:54)\",\"revision\":\"3044e8afddd78acfb775451f6053575b124e7cb3\",\"date\":\"2024-June-25 16:54\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1157267696\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "273"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:37:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:37:03.613Z",
+        "time": 65,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 65
+        }
+      },
+      {
+        "_id": "0ac4a5ec30bd9a108e714d2a1992da80",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1956,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/bb393d07-a121-47e2-9d24-1a1066f39ec0"
+        },
+        "response": {
+          "bodySize": 659,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 659,
+            "text": "{\"_id\":\"bb393d07-a121-47e2-9d24-1a1066f39ec0\",\"name\":\"My Example Script Using Libraries\",\"description\":\"My Example Script Using Libraries\",\"script\":\"LyoqCiAqIFRlc3RpbmcgbGlicmFyeSBzY3JpcHRzCiAqLwp2YXIgbXlsaWIgPSByZXF1aXJlKCdNeSBFeGFtcGxlIExpYnJhcnknKTsKdmFyIGxvZ2dlcnMgPSByZXF1aXJlKCdMaWJyYXJ5IFNjcmlwdCcpOwoKbXlsaWIuYWRkKDEpOwpteWxpYi5sb2dUb3RhbChsb2dnZXIpOwpteWxpYi5hZGQoMyk7Cm15bGliLmxvZ1RvdGFsV2l0aE1lc3NhZ2UobG9nZ2VyLCBteWxpYi5NU0cpOwoKb3V0Y29tZSA9ICd0cnVlJzsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"evaluatorVersion\":\"2.0\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "659"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:37:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:37:03.756Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/export_4211608755/0_no-deps_i_3429592532/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/script_540962730/export_4211608755/0_no-deps_i_3429592532/oauth2_393036114/recording.har
@@ -1,0 +1,146 @@
+{
+  "log": {
+    "_recordingName": "script/export/0_no-deps_i/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1339,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "1339"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 440,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:autoaccess:* fr:idc:esv:* fr:iga:* fr:idc:analytics:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:certificate:read fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:promotion:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1776,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1776,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:autoaccess:* fr:idc:esv:* fr:iga:* fr:idc:analytics:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:certificate:read fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:promotion:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1776"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:37:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 561,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:37:03.524Z",
+        "time": 83,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 83
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/script_540962730/export_4211608755/0_no-deps_i_3429592532/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/script_540962730/export_4211608755/0_no-deps_i_3429592532/openidm_3290118515/recording.har
@@ -1,0 +1,302 @@
+{
+  "log": {
+    "_recordingName": "script/export/0_no-deps_i/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1904,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/7a031a92-f70d-4b30-9d70-da7cfb1d9c93?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1383,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1383,
+            "text": "{\"_id\":\"7a031a92-f70d-4b30-9d70-da7cfb1d9c93\",\"_rev\":\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1720799681233\",\"description\":\"phales@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:autoaccess:*\",\"fr:idc:certificate:*\",\"fr:idc:certificate:read\",\"fr:idc:content-security-policy:*\",\"fr:idc:custom-domain:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:iga:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"0XdDQoML6maEILSCc8AWtpjBlKNOzf_NTG_jT0M0wzk\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"mvVVosknqaMRfUPxzZKLpNIIEZCTHcVT3QGRsA2CpUaK0jNO5WOljqLe3XjJmE27b2vcO_GT29M9QIwUVYAx8cv9BnwTEuioTu_Tugp3O4X3VO9VmNTQkaM1gASCTkZ2u_VuZefusBmydrheMP_XlT7GvB_sSpLgpyiN88LEO1RVVZEiG9YAanSQZejtKYLpxV5-Sxu3kh3c1M2HGiw9LeGu0h1p6okCDWwaJUDIG7jXgcHYgFCcNLkklzMX82ozWXEyjQPaxg95sk3d1ZLl-hoAJAI2-bF_ANvqK60i3WCBBPpulUU_RGeVhgxcnMTbDJUm1KgFhlK9TcvgQmZtm1u9NF0hkNlfrYhDUiy3BVWnHCTi50JUZYTevfo6LS2waTE-ZWMAZ0CCeShPR92HkcyfFIYf_PFvrwk55pmvDbx4Fc4l2y_JXKckSuKf2ErmWN_8F7ou5zNsrYcmApCuNj7m0Is3BhnvafhIsI8nocyeJPiaH5oHm5aCSWbjVFvFyOmsuZQ3AAkHjBcET3iqBneHKqSe4-Zw9-u4W6iSw8L8fF7_RPFGYAnxidqEl2Y4WOB3GsaYXEOn5uT6yKJTDbtRABdvEswFfxdVcWwvnGItgmVbUnU_QFjkOgNC2U051jUE3crGZSpeTN8028NGikzvB4PhcvIFT0biHIXFr98\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:37:03 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1383"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 668,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:37:03.673Z",
+        "time": 106,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 106
+        }
+      },
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/2.0.3"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1904,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/7a031a92-f70d-4b30-9d70-da7cfb1d9c93?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1383,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1383,
+            "text": "{\"_id\":\"7a031a92-f70d-4b30-9d70-da7cfb1d9c93\",\"_rev\":\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1720799681233\",\"description\":\"phales@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:autoaccess:*\",\"fr:idc:certificate:*\",\"fr:idc:certificate:read\",\"fr:idc:content-security-policy:*\",\"fr:idc:custom-domain:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:iga:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"0XdDQoML6maEILSCc8AWtpjBlKNOzf_NTG_jT0M0wzk\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"mvVVosknqaMRfUPxzZKLpNIIEZCTHcVT3QGRsA2CpUaK0jNO5WOljqLe3XjJmE27b2vcO_GT29M9QIwUVYAx8cv9BnwTEuioTu_Tugp3O4X3VO9VmNTQkaM1gASCTkZ2u_VuZefusBmydrheMP_XlT7GvB_sSpLgpyiN88LEO1RVVZEiG9YAanSQZejtKYLpxV5-Sxu3kh3c1M2HGiw9LeGu0h1p6okCDWwaJUDIG7jXgcHYgFCcNLkklzMX82ozWXEyjQPaxg95sk3d1ZLl-hoAJAI2-bF_ANvqK60i3WCBBPpulUU_RGeVhgxcnMTbDJUm1KgFhlK9TcvgQmZtm1u9NF0hkNlfrYhDUiy3BVWnHCTi50JUZYTevfo6LS2waTE-ZWMAZ0CCeShPR92HkcyfFIYf_PFvrwk55pmvDbx4Fc4l2y_JXKckSuKf2ErmWN_8F7ou5zNsrYcmApCuNj7m0Is3BhnvafhIsI8nocyeJPiaH5oHm5aCSWbjVFvFyOmsuZQ3AAkHjBcET3iqBneHKqSe4-Zw9-u4W6iSw8L8fF7_RPFGYAnxidqEl2Y4WOB3GsaYXEOn5uT6yKJTDbtRABdvEswFfxdVcWwvnGItgmVbUnU_QFjkOgNC2U051jUE3crGZSpeTN8028NGikzvB4PhcvIFT0biHIXFr98\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 15 Aug 2024 14:37:03 GMT"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"fc6b5463-d755-4128-a47f-0d7700ebbb98-4940\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1383"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-84d1eedc-571c-409d-9e12-6a90493a4df8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 668,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-08-15T14:37:03.686Z",
+        "time": 61,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 61
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/script-export.e2e.test.js
+++ b/test/e2e/script-export.e2e.test.js
@@ -47,6 +47,8 @@
  */
 
 /*
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script export --no-deps -i 'bb393d07-a121-47e2-9d24-1a1066f39ec0'
 FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script export --script-name 'GitHub Profile Normalization'
 FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script export -n 'GitHub Profile Normalization' -f my-GitHub-Profile-Normalization.script.json
 FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo script export -Nxn 'GitHub Profile Normalization' -D scriptExportTestDir1
@@ -66,6 +68,19 @@ const env = getEnv(c);
 const type = 'script';
 
 describe('frodo script export', () => {
+  // The first two tests use the 'My Example Script Using Libraries' (with id 'bb393d07-a121-47e2-9d24-1a1066f39ec0') script to test that libraries are exported correctly, including recursively.
+  test('"frodo script export --extract --script-id \'bb393d07-a121-47e2-9d24-1a1066f39ec0\' --directory scriptExportTestDir5": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0" along with libraries', async () => {
+    const exportDirectory = 'scriptExportTestDir5';
+    const CMD = `frodo script export --extract --script-id 'bb393d07-a121-47e2-9d24-1a1066f39ec0' --directory scriptExportTestDir5`;
+    await testExport(CMD, env, type, undefined, exportDirectory, false);
+  });
+
+  test('"frodo script export --no-deps -i \'bb393d07-a121-47e2-9d24-1a1066f39ec0\'": should export the script with id "bb393d07-a121-47e2-9d24-1a1066f39ec0"', async () => {
+    const exportFile = 'bb393d07-a121-47e2-9d24-1a1066f39ec0.script.json';
+    const CMD = `frodo script export --no-deps -i 'bb393d07-a121-47e2-9d24-1a1066f39ec0'`;
+    await testExport(CMD, env, type, exportFile);
+  });
+
   test('"frodo script export --script-name \'GitHub Profile Normalization\'": should export the script named "GitHub Profile Normalization"', async () => {
     const exportFile = 'GitHub-Profile-Normalization.script.json';
     const CMD = `frodo script export --script-name 'GitHub Profile Normalization'`;


### PR DESCRIPTION
This PR makes a few updates to help fix and improve script exports and imports. The main changes include:

1. Adding the option to import and export scripts by id.
2. Adding the option to not include library scripts in exports of single scripts using the --no-deps flag. Similarly adds the option on single script imports using the same flag to not import library dependencies if so desired.
3. Fixing many bugs related to script extraction. For example, there were certain cases where importing wouldn't function correctly due to being unable to find the extracted script(s). For exports, library scripts weren't being extracted correctly either. Therefore, an overhaul was done to try and help simplify the extraction process to that it can work for multiple scripts if dealing with library scripts both on export and import.
4. Fixing the watch option for script imports since I discovered many errors with it. One big one was if there were several scripts for a single json file (e.g. when exporting scripts with library scripts) that only one of the scripts would correctly be watched. This was fixed by creating mappings before watching begins to map extracted script files with their corresponding json files so it functions correctly.
5. Fixing a small bug with config imports where, if the working directory started with . or ./ it would usually fail due to being unable to locate the expected files it was looking for.
6. Various other refactoring changes to help improve the code related to scripts, including reducing redundancy and some typo fixes.

There is a PR in frodo-lib (with the same name as this one) that this PR relies on due to a few changes made there.