### PR TITLE
Update journey import mock recordings to pass tests

### DIFF
--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_af_3559436575/am_1076162899/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_af_3559436575/am_1076162899/recording.har
@@ -25,15 +25,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.1"
             },
             {
               "name": "accept-encoding",
@@ -51,11 +51,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
         },
         "response": {
-          "bodySize": 538,
+          "bodySize": 553,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 538,
-            "text": "{\"_id\":\"*\",\"_rev\":\"36966512\",\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
           },
           "cookies": [],
           "headers": [
@@ -77,7 +77,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.1"
             },
             {
               "name": "content-security-policy",
@@ -93,7 +93,7 @@
             },
             {
               "name": "etag",
-              "value": "\"36966512\""
+              "value": "\"1874515102\""
             },
             {
               "name": "expires",
@@ -109,15 +109,15 @@
             },
             {
               "name": "content-length",
-              "value": "538"
+              "value": "553"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:58 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -136,14 +136,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 785,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:07.513Z",
-        "time": 87,
+        "startedDateTime": "2024-12-04T16:31:58.700Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -151,7 +151,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 90
         }
       },
       {
@@ -172,11 +172,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -206,7 +206,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 282,
-            "text": "{\"_id\":\"version\",\"_rev\":\"355151460\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 493165657bbb9390016bd43ca767a46f23d8d24a (2024-September-23 14:30)\",\"revision\":\"493165657bbb9390016bd43ca767a46f23d8d24a\",\"date\":\"2024-September-23 14:30\"}"
+            "text": "{\"_id\":\"version\",\"_rev\":\"-1964495080\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 7cab9c08465b06ed66fff4b458eef61d6b6825da (2024-November-15 10:51)\",\"revision\":\"7cab9c08465b06ed66fff4b458eef61d6b6825da\",\"date\":\"2024-November-15 10:51\"}"
           },
           "cookies": [],
           "headers": [
@@ -244,7 +244,7 @@
             },
             {
               "name": "etag",
-              "value": "\"355151460\""
+              "value": "\"-1964495080\""
             },
             {
               "name": "expires",
@@ -264,11 +264,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:58 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -287,14 +287,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 786,
+          "headersSize": 788,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:07.711Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:31:58.904Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -302,7 +302,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 69
         }
       },
       {
@@ -323,15 +323,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -362,7 +362,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 31869,
-            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-501795106\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"description\":\"Reset Password Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"OrphanedTest\",\"_rev\":\"-764260244\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"343e745f-923a-43c4-8675-649a490fd0a3\",\"innerTreeOnly\":false,\"nodes\":{\"343e745f-923a-43c4-8675-649a490fd0a3\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":407.046875,\"y\":190.015625}},\"description\":\"Test orphaned nodes\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":704,\"y\":129},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":707,\"y\":381},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"test\",\"_rev\":\"279923916\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{},\"entryNodeId\":\"d26176be-ea6f-4f2a-81cd-3d41dd6cee4d\",\"innerTreeOnly\":false,\"nodes\":{},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":50,\"y\":117},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":152,\"y\":25},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ForgottenUsername\",\"_rev\":\"1703131230\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":0,\"y\":0},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":0,\"y\":0},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":0,\"y\":0}},\"description\":\"Forgotten Username Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j10\",\"_rev\":\"751431822\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"c91d626e-1156-41bd-b1fb-d292f640fba6\",\"innerTreeOnly\":false,\"nodes\":{\"300feda0-3248-49a9-b60f-01df802b2229\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"40afb384-e9b6-4dcb-acde-04de109474c8\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"8d7d64ee-da20-461f-a2ca-206b7479dd67\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\":{\"connections\":{\"true\":\"8d7d64ee-da20-461f-a2ca-206b7479dd67\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"c91d626e-1156-41bd-b1fb-d292f640fba6\":{\"connections\":{\"level only\":\"300feda0-3248-49a9-b60f-01df802b2229\",\"none\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\",\"shared and level\":\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\",\"shared only\":\"40afb384-e9b6-4dcb-acde-04de109474c8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j01\",\"_rev\":\"-523887030\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"f129f0df-b49e-453b-97fb-db508e3893ce\",\"innerTreeOnly\":false,\"nodes\":{\"6674b4ac-dd89-4e13-9440-6f81194e3a22\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\":{\"connections\":{\"true\":\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"f129f0df-b49e-453b-97fb-db508e3893ce\":{\"connections\":{\"level only\":\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\",\"none\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\",\"shared and level\":\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\",\"shared only\":\"6674b4ac-dd89-4e13-9440-6f81194e3a22\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"UpdatePassword\",\"_rev\":\"-1067190791\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"description\":\"Update password using active session\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j00\",\"_rev\":\"214130857\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\",\"innerTreeOnly\":false,\"nodes\":{\"01d3785f-7fb4-44a7-9458-72c380a9818f\":{\"connections\":{\"true\":\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":348,\"y\":61},\"39b48197-f4be-42b9-800a-866587b4b9b5\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":365,\"y\":252},\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":567,\"y\":64},\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\":{\"connections\":{\"level only\":\"39b48197-f4be-42b9-800a-866587b4b9b5\",\"none\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\",\"shared and level\":\"01d3785f-7fb4-44a7-9458-72c380a9818f\",\"shared only\":\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":117,\"y\":117},\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\":{\"connections\":{\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":760,\"y\":137},\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":338,\"y\":156}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":132,\"y\":364},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":137},\"startNode\":{\"x\":0,\"y\":0}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Login\",\"_rev\":\"-453684268\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"nodes\":{\"2119f332-0f69-4088-a7a1-6582bf0f2001\":{\"connections\":{\"Reject\":\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\",\"Retry\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\"},\"displayName\":\"Retry Limit Decision\",\"nodeType\":\"RetryLimitDecisionNode\",\"x\":612,\"y\":105.015625},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":827,\"y\":13},\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Account Lockout\",\"nodeType\":\"AccountLockoutNode\",\"x\":836,\"y\":184.015625},\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\":{\"connections\":{\"CANCELLED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EXPIRED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"FALSE\":\"2119f332-0f69-4088-a7a1-6582bf0f2001\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":352,\"y\":40.015625},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":579,\"y\":34}},\"description\":\"Platform Login Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1073,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":761,\"y\":401},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j03\",\"_rev\":\"-1352811052\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\",\"innerTreeOnly\":false,\"nodes\":{\"35a4f94b-c895-46b9-bc0a-93cf59233759\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"3a92300d-6d64-451d-8156-30cb51781026\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"6f9de973-9ed4-41f5-b43d-4036041e2b96\":{\"connections\":{\"true\":\"3a92300d-6d64-451d-8156-30cb51781026\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\":{\"connections\":{\"level only\":\"35a4f94b-c895-46b9-bc0a-93cf59233759\",\"none\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\",\"shared and level\":\"6f9de973-9ed4-41f5-b43d-4036041e2b96\",\"shared only\":\"fae7424e-13c9-45bd-b3a2-045773671a3f\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"fae7424e-13c9-45bd-b3a2-045773671a3f\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j02\",\"_rev\":\"2029292005\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"59b06306-a886-443d-92df-7a27a60c394e\",\"innerTreeOnly\":false,\"nodes\":{\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"56899fef-92a1-4f2a-ade3-973c81eb3af1\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"59b06306-a886-443d-92df-7a27a60c394e\":{\"connections\":{\"level only\":\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\",\"none\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\",\"shared and level\":\"e0983ead-4918-48f6-858d-9aff0f03759c\",\"shared only\":\"cbb3d506-b267-4b99-9edd-363e90aac997\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"cbb3d506-b267-4b99-9edd-363e90aac997\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e0983ead-4918-48f6-858d-9aff0f03759c\":{\"connections\":{\"true\":\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j05\",\"_rev\":\"1652057497\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"622179cb-98f1-484a-820d-9a0df6e45e95\",\"innerTreeOnly\":false,\"nodes\":{\"11f1c31c-50a9-4717-8213-420f6932481f\":{\"connections\":{\"true\":\"e90ae257-c279-46e0-9b43-5ecd89784d77\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"3c106772-ace7-4808-8f3a-9840de8f67f0\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"622179cb-98f1-484a-820d-9a0df6e45e95\":{\"connections\":{\"level only\":\"3c106772-ace7-4808-8f3a-9840de8f67f0\",\"none\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\",\"shared and level\":\"11f1c31c-50a9-4717-8213-420f6932481f\",\"shared only\":\"a0782616-84b7-4bf5-87ed-a01fb3018563\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"a0782616-84b7-4bf5-87ed-a01fb3018563\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e90ae257-c279-46e0-9b43-5ecd89784d77\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j04\",\"_rev\":\"-1089876293\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"040b6c89-313b-4664-92e0-6732017384b8\",\"innerTreeOnly\":false,\"nodes\":{\"00e75aa0-2f9b-4895-9257-d515286fd64b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"040b6c89-313b-4664-92e0-6732017384b8\":{\"connections\":{\"level only\":\"d10104e9-1f8d-4da6-a110-28d879d13959\",\"none\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\",\"shared and level\":\"f5c317ce-fabd-4a10-9907-c71cea037844\",\"shared only\":\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"69ae8ec1-de43-44ac-98e5-733db80ac176\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d10104e9-1f8d-4da6-a110-28d879d13959\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"f5c317ce-fabd-4a10-9907-c71cea037844\":{\"connections\":{\"true\":\"69ae8ec1-de43-44ac-98e5-733db80ac176\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j07\",\"_rev\":\"-937100459\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\",\"innerTreeOnly\":false,\"nodes\":{\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\":{\"connections\":{\"level only\":\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\",\"none\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\",\"shared and level\":\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\",\"shared only\":\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\":{\"connections\":{\"true\":\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j06\",\"_rev\":\"605160891\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\",\"innerTreeOnly\":false,\"nodes\":{\"1d59caff-243c-45bd-b7d0-6dcc563989c5\":{\"connections\":{\"true\":\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"409c251f-c23b-411d-9009-d3b3d26d1b90\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\":{\"connections\":{\"level only\":\"fe8f27df-8a27-4d88-9196-834ce398b2b7\",\"none\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\",\"shared and level\":\"1d59caff-243c-45bd-b7d0-6dcc563989c5\",\"shared only\":\"da878771-421c-463f-aad7-4d5f2ad5e59a\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"da878771-421c-463f-aad7-4d5f2ad5e59a\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"fe8f27df-8a27-4d88-9196-834ce398b2b7\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j09\",\"_rev\":\"-1358707527\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"251f35c3-1a32-4520-be10-1f4af9600935\",\"innerTreeOnly\":false,\"nodes\":{\"251f35c3-1a32-4520-be10-1f4af9600935\":{\"connections\":{\"level only\":\"56b82371-0c61-4dc3-8d06-c1158415b8f9\",\"none\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\",\"shared and level\":\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\",\"shared only\":\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"56b82371-0c61-4dc3-8d06-c1158415b8f9\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"6df24fdd-0b6c-4def-bf42-77af998f28b8\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\":{\"connections\":{\"true\":\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j08\",\"_rev\":\"-1997695217\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"d429b2b5-b215-46a5-b239-4994df65cb8b\",\"innerTreeOnly\":false,\"nodes\":{\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\":{\"connections\":{\"true\":\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"8096649e-973e-4209-88ce-e1d87ae2bb96\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"948e21f4-c512-450a-9d42-e0d629217834\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d429b2b5-b215-46a5-b239-4994df65cb8b\":{\"connections\":{\"level only\":\"8096649e-973e-4209-88ce-e1d87ae2bb96\",\"none\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\",\"shared and level\":\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\",\"shared only\":\"948e21f4-c512-450a-9d42-e0d629217834\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Registration\",\"_rev\":\"-340494482\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"466f8b54-07fb-4e31-a11d-a6842618cc37\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"466f8b54-07fb-4e31-a11d-a6842618cc37\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":484,\"y\":267.015625},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":861,\"y\":221},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":717,\"y\":283}},\"description\":\"Platform Registration Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1085,\"y\":248},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":921,\"y\":370},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"512701181\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"description\":\"Prompt for missing preferences on 3rd login\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"FrodoTest\",\"_rev\":\"1975823900\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"e2c39477-847a-4df2-9c5d-b449a752638b\",\"innerTreeOnly\":false,\"nodes\":{\"278bf084-9eea-46fe-8ce9-2600dde3b046\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":444,\"y\":273.015625},\"64157fca-bd5b-4405-a4c8-64ffd98a5461\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"SAML2 Authentication\",\"nodeType\":\"product-Saml2Node\",\"x\":1196,\"y\":188.015625},\"731c5810-020b-45c8-a7fc-3c21903ae2b3\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":443,\"y\":26.015625},\"bf153f37-83dd-4f39-aa0c-74135430242e\":{\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"64157fca-bd5b-4405-a4c8-64ffd98a5461\"},\"displayName\":\"Email Template Node\",\"nodeType\":\"EmailTemplateNode\",\"x\":967,\"y\":222.015625},\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"bf153f37-83dd-4f39-aa0c-74135430242e\"},\"displayName\":\"Social Login\",\"nodeType\":\"SocialProviderHandlerNode\",\"x\":702,\"y\":116.015625},\"e2c39477-847a-4df2-9c5d-b449a752638b\":{\"connections\":{\"known\":\"731c5810-020b-45c8-a7fc-3c21903ae2b3\",\"unknown\":\"278bf084-9eea-46fe-8ce9-2600dde3b046\"},\"displayName\":\"Check Username\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":200,\"y\":235.015625},\"fc7e47cd-c679-4211-8e05-a36654f23c67\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Validate Creds\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":702,\"y\":292.015625}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1434,\"y\":60},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1433,\"y\":459},\"startNode\":{\"x\":63,\"y\":252}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"RadioChoice\",\"_rev\":\"947126104\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"5d6cd20e-5074-43de-8832-fddd95fb078e\",\"innerTreeOnly\":false,\"nodes\":{\"5d6cd20e-5074-43de-8832-fddd95fb078e\":{\"connections\":{\"one\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"three\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"two\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":260,\"y\":409.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":50},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":744,\"y\":327},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true}],\"resultCount\":21,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-501795106\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"description\":\"Reset Password Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"OrphanedTest\",\"_rev\":\"-764260244\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"343e745f-923a-43c4-8675-649a490fd0a3\",\"innerTreeOnly\":false,\"nodes\":{\"343e745f-923a-43c4-8675-649a490fd0a3\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":407.046875,\"y\":190.015625}},\"description\":\"Test orphaned nodes\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":704,\"y\":129},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":707,\"y\":381},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"test\",\"_rev\":\"279923916\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{},\"entryNodeId\":\"d26176be-ea6f-4f2a-81cd-3d41dd6cee4d\",\"innerTreeOnly\":false,\"nodes\":{},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":50,\"y\":117},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":152,\"y\":25},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ForgottenUsername\",\"_rev\":\"1703131230\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":0,\"y\":0},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":0,\"y\":0},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":0,\"y\":0}},\"description\":\"Forgotten Username Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j10\",\"_rev\":\"751431822\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"c91d626e-1156-41bd-b1fb-d292f640fba6\",\"innerTreeOnly\":false,\"nodes\":{\"300feda0-3248-49a9-b60f-01df802b2229\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"40afb384-e9b6-4dcb-acde-04de109474c8\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"8d7d64ee-da20-461f-a2ca-206b7479dd67\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\":{\"connections\":{\"true\":\"8d7d64ee-da20-461f-a2ca-206b7479dd67\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"c91d626e-1156-41bd-b1fb-d292f640fba6\":{\"connections\":{\"level only\":\"300feda0-3248-49a9-b60f-01df802b2229\",\"none\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\",\"shared and level\":\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\",\"shared only\":\"40afb384-e9b6-4dcb-acde-04de109474c8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j01\",\"_rev\":\"-523887030\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"f129f0df-b49e-453b-97fb-db508e3893ce\",\"innerTreeOnly\":false,\"nodes\":{\"6674b4ac-dd89-4e13-9440-6f81194e3a22\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\":{\"connections\":{\"true\":\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"f129f0df-b49e-453b-97fb-db508e3893ce\":{\"connections\":{\"level only\":\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\",\"none\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\",\"shared and level\":\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\",\"shared only\":\"6674b4ac-dd89-4e13-9440-6f81194e3a22\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"UpdatePassword\",\"_rev\":\"-1067190791\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"description\":\"Update password using active session\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Login\",\"_rev\":\"-453684268\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"nodes\":{\"2119f332-0f69-4088-a7a1-6582bf0f2001\":{\"connections\":{\"Reject\":\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\",\"Retry\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\"},\"displayName\":\"Retry Limit Decision\",\"nodeType\":\"RetryLimitDecisionNode\",\"x\":612,\"y\":105.015625},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":827,\"y\":13},\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Account Lockout\",\"nodeType\":\"AccountLockoutNode\",\"x\":836,\"y\":184.015625},\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\":{\"connections\":{\"CANCELLED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EXPIRED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"FALSE\":\"2119f332-0f69-4088-a7a1-6582bf0f2001\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":352,\"y\":40.015625},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":579,\"y\":34}},\"description\":\"Platform Login Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1073,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":761,\"y\":401},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j00\",\"_rev\":\"214130857\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\",\"innerTreeOnly\":false,\"nodes\":{\"01d3785f-7fb4-44a7-9458-72c380a9818f\":{\"connections\":{\"true\":\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":348,\"y\":61},\"39b48197-f4be-42b9-800a-866587b4b9b5\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":365,\"y\":252},\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":567,\"y\":64},\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\":{\"connections\":{\"level only\":\"39b48197-f4be-42b9-800a-866587b4b9b5\",\"none\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\",\"shared and level\":\"01d3785f-7fb4-44a7-9458-72c380a9818f\",\"shared only\":\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":117,\"y\":117},\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\":{\"connections\":{\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":760,\"y\":137},\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":338,\"y\":156}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":132,\"y\":364},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":137},\"startNode\":{\"x\":0,\"y\":0}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j03\",\"_rev\":\"-1352811052\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\",\"innerTreeOnly\":false,\"nodes\":{\"35a4f94b-c895-46b9-bc0a-93cf59233759\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"3a92300d-6d64-451d-8156-30cb51781026\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"6f9de973-9ed4-41f5-b43d-4036041e2b96\":{\"connections\":{\"true\":\"3a92300d-6d64-451d-8156-30cb51781026\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\":{\"connections\":{\"level only\":\"35a4f94b-c895-46b9-bc0a-93cf59233759\",\"none\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\",\"shared and level\":\"6f9de973-9ed4-41f5-b43d-4036041e2b96\",\"shared only\":\"fae7424e-13c9-45bd-b3a2-045773671a3f\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"fae7424e-13c9-45bd-b3a2-045773671a3f\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j02\",\"_rev\":\"2029292005\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"59b06306-a886-443d-92df-7a27a60c394e\",\"innerTreeOnly\":false,\"nodes\":{\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"56899fef-92a1-4f2a-ade3-973c81eb3af1\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"59b06306-a886-443d-92df-7a27a60c394e\":{\"connections\":{\"level only\":\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\",\"none\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\",\"shared and level\":\"e0983ead-4918-48f6-858d-9aff0f03759c\",\"shared only\":\"cbb3d506-b267-4b99-9edd-363e90aac997\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"cbb3d506-b267-4b99-9edd-363e90aac997\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e0983ead-4918-48f6-858d-9aff0f03759c\":{\"connections\":{\"true\":\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j05\",\"_rev\":\"1652057497\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"622179cb-98f1-484a-820d-9a0df6e45e95\",\"innerTreeOnly\":false,\"nodes\":{\"11f1c31c-50a9-4717-8213-420f6932481f\":{\"connections\":{\"true\":\"e90ae257-c279-46e0-9b43-5ecd89784d77\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"3c106772-ace7-4808-8f3a-9840de8f67f0\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"622179cb-98f1-484a-820d-9a0df6e45e95\":{\"connections\":{\"level only\":\"3c106772-ace7-4808-8f3a-9840de8f67f0\",\"none\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\",\"shared and level\":\"11f1c31c-50a9-4717-8213-420f6932481f\",\"shared only\":\"a0782616-84b7-4bf5-87ed-a01fb3018563\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"a0782616-84b7-4bf5-87ed-a01fb3018563\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e90ae257-c279-46e0-9b43-5ecd89784d77\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j04\",\"_rev\":\"-1089876293\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"040b6c89-313b-4664-92e0-6732017384b8\",\"innerTreeOnly\":false,\"nodes\":{\"00e75aa0-2f9b-4895-9257-d515286fd64b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"040b6c89-313b-4664-92e0-6732017384b8\":{\"connections\":{\"level only\":\"d10104e9-1f8d-4da6-a110-28d879d13959\",\"none\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\",\"shared and level\":\"f5c317ce-fabd-4a10-9907-c71cea037844\",\"shared only\":\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"69ae8ec1-de43-44ac-98e5-733db80ac176\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d10104e9-1f8d-4da6-a110-28d879d13959\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"f5c317ce-fabd-4a10-9907-c71cea037844\":{\"connections\":{\"true\":\"69ae8ec1-de43-44ac-98e5-733db80ac176\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j07\",\"_rev\":\"-937100459\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\",\"innerTreeOnly\":false,\"nodes\":{\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\":{\"connections\":{\"level only\":\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\",\"none\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\",\"shared and level\":\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\",\"shared only\":\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\":{\"connections\":{\"true\":\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j06\",\"_rev\":\"605160891\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\",\"innerTreeOnly\":false,\"nodes\":{\"1d59caff-243c-45bd-b7d0-6dcc563989c5\":{\"connections\":{\"true\":\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"409c251f-c23b-411d-9009-d3b3d26d1b90\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\":{\"connections\":{\"level only\":\"fe8f27df-8a27-4d88-9196-834ce398b2b7\",\"none\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\",\"shared and level\":\"1d59caff-243c-45bd-b7d0-6dcc563989c5\",\"shared only\":\"da878771-421c-463f-aad7-4d5f2ad5e59a\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"da878771-421c-463f-aad7-4d5f2ad5e59a\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"fe8f27df-8a27-4d88-9196-834ce398b2b7\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j09\",\"_rev\":\"-1358707527\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"251f35c3-1a32-4520-be10-1f4af9600935\",\"innerTreeOnly\":false,\"nodes\":{\"251f35c3-1a32-4520-be10-1f4af9600935\":{\"connections\":{\"level only\":\"56b82371-0c61-4dc3-8d06-c1158415b8f9\",\"none\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\",\"shared and level\":\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\",\"shared only\":\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"56b82371-0c61-4dc3-8d06-c1158415b8f9\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"6df24fdd-0b6c-4def-bf42-77af998f28b8\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\":{\"connections\":{\"true\":\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j08\",\"_rev\":\"-1997695217\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"d429b2b5-b215-46a5-b239-4994df65cb8b\",\"innerTreeOnly\":false,\"nodes\":{\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\":{\"connections\":{\"true\":\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"8096649e-973e-4209-88ce-e1d87ae2bb96\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"948e21f4-c512-450a-9d42-e0d629217834\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d429b2b5-b215-46a5-b239-4994df65cb8b\":{\"connections\":{\"level only\":\"8096649e-973e-4209-88ce-e1d87ae2bb96\",\"none\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\",\"shared and level\":\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\",\"shared only\":\"948e21f4-c512-450a-9d42-e0d629217834\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Registration\",\"_rev\":\"-340494482\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"466f8b54-07fb-4e31-a11d-a6842618cc37\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"466f8b54-07fb-4e31-a11d-a6842618cc37\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":484,\"y\":267.015625},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":861,\"y\":221},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":717,\"y\":283}},\"description\":\"Platform Registration Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1085,\"y\":248},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":921,\"y\":370},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"512701181\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"description\":\"Prompt for missing preferences on 3rd login\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"FrodoTest\",\"_rev\":\"1975823900\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"e2c39477-847a-4df2-9c5d-b449a752638b\",\"innerTreeOnly\":false,\"nodes\":{\"278bf084-9eea-46fe-8ce9-2600dde3b046\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":444,\"y\":273.015625},\"64157fca-bd5b-4405-a4c8-64ffd98a5461\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"SAML2 Authentication\",\"nodeType\":\"product-Saml2Node\",\"x\":1196,\"y\":188.015625},\"731c5810-020b-45c8-a7fc-3c21903ae2b3\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":443,\"y\":26.015625},\"bf153f37-83dd-4f39-aa0c-74135430242e\":{\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"64157fca-bd5b-4405-a4c8-64ffd98a5461\"},\"displayName\":\"Email Template Node\",\"nodeType\":\"EmailTemplateNode\",\"x\":967,\"y\":222.015625},\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"bf153f37-83dd-4f39-aa0c-74135430242e\"},\"displayName\":\"Social Login\",\"nodeType\":\"SocialProviderHandlerNode\",\"x\":702,\"y\":116.015625},\"e2c39477-847a-4df2-9c5d-b449a752638b\":{\"connections\":{\"known\":\"731c5810-020b-45c8-a7fc-3c21903ae2b3\",\"unknown\":\"278bf084-9eea-46fe-8ce9-2600dde3b046\"},\"displayName\":\"Check Username\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":200,\"y\":235.015625},\"fc7e47cd-c679-4211-8e05-a36654f23c67\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Validate Creds\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":702,\"y\":292.015625}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1434,\"y\":60},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1433,\"y\":459},\"startNode\":{\"x\":63,\"y\":252}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"RadioChoice\",\"_rev\":\"947126104\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"5d6cd20e-5074-43de-8832-fddd95fb078e\",\"innerTreeOnly\":false,\"nodes\":{\"5d6cd20e-5074-43de-8832-fddd95fb078e\":{\"connections\":{\"one\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"three\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"two\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":260,\"y\":409.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":50},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":744,\"y\":327},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true}],\"resultCount\":21,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
           },
           "cookies": [],
           "headers": [
@@ -384,7 +384,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "protocol=2.1,resource=2.0, resource=2.0"
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -412,11 +412,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -445,8 +445,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:07.870Z",
-        "time": 79,
+        "startedDateTime": "2024-12-04T16:31:59.062Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -454,7 +454,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 79
+          "wait": 84
         }
       },
       {
@@ -475,15 +475,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -540,7 +540,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -576,11 +576,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -605,8 +605,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:08.026Z",
-        "time": 224,
+        "startedDateTime": "2024-12-04T16:31:59.235Z",
+        "time": 108,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -614,7 +614,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 224
+          "wait": 108
         }
       },
       {
@@ -635,15 +635,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -700,7 +700,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -736,11 +736,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -765,8 +765,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:08.254Z",
-        "time": 197,
+        "startedDateTime": "2024-12-04T16:31:59.349Z",
+        "time": 123,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -774,7 +774,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 197
+          "wait": 123
         }
       },
       {
@@ -795,15 +795,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -860,7 +860,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -896,11 +896,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -925,8 +925,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:08.456Z",
-        "time": 209,
+        "startedDateTime": "2024-12-04T16:31:59.477Z",
+        "time": 127,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -934,7 +934,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 209
+          "wait": 127
         }
       },
       {
@@ -955,15 +955,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1020,7 +1020,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1056,11 +1056,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1085,8 +1085,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:08.671Z",
-        "time": 115,
+        "startedDateTime": "2024-12-04T16:31:59.610Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1094,7 +1094,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 115
+          "wait": 90
         }
       },
       {
@@ -1115,15 +1115,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1180,7 +1180,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1216,11 +1216,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1245,8 +1245,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:08.791Z",
-        "time": 154,
+        "startedDateTime": "2024-12-04T16:31:59.705Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1254,7 +1254,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 154
+          "wait": 90
         }
       },
       {
@@ -1275,15 +1275,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1340,7 +1340,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1376,11 +1376,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1405,8 +1405,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:08.950Z",
-        "time": 80,
+        "startedDateTime": "2024-12-04T16:31:59.800Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1414,15 +1414,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 80
+          "wait": 72
         }
       },
       {
-        "_id": "683a2255bd43586b9d44750ce010ca82",
+        "_id": "9dc8bcea13a507715e6733c8ac72ea6f",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1489,
+          "bodySize": 1437,
           "cookies": [],
           "headers": [
             {
@@ -1435,11 +1435,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -1451,7 +1451,7 @@
             },
             {
               "name": "content-length",
-              "value": "1489"
+              "value": "1437"
             },
             {
               "name": "accept-encoding",
@@ -1468,17 +1468,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"GitHub Profile Normalization (VS)\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSlcbiI=\"}"
+            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"GitHub Profile Normalization (VS)\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJHaXRIdWIgcmF3UHJvZmlsZTogIityYXdQcm9maWxlKQoKcmV0dXJuIGpzb24ob2JqZWN0KAogICAgICAgIGZpZWxkKCJpZCIsIHJhd1Byb2ZpbGUuaWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIHJhd1Byb2ZpbGUubmFtZSksCiAgICAgICAgZmllbGQoImdpdmVuTmFtZSIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksCiAgICAgICAgZmllbGQoImZhbWlseU5hbWUiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksCiAgICAgICAgZmllbGQoInBob3RvVXJsIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSwKICAgICAgICBmaWVsZCgiZW1haWwiLCByYXdQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCByYXdQcm9maWxlLmVtYWlsKSkpCg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/23143919-6b78-40c3-b25e-beca19b229e0"
         },
         "response": {
-          "bodySize": 1557,
+          "bodySize": 1505,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1557,
-            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSlcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329088,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1505,
+            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJHaXRIdWIgcmF3UHJvZmlsZTogIityYXdQcm9maWxlKQoKcmV0dXJuIGpzb24ob2JqZWN0KAogICAgICAgIGZpZWxkKCJpZCIsIHJhd1Byb2ZpbGUuaWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIHJhd1Byb2ZpbGUubmFtZSksCiAgICAgICAgZmllbGQoImdpdmVuTmFtZSIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksCiAgICAgICAgZmllbGQoImZhbWlseU5hbWUiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksCiAgICAgICAgZmllbGQoInBob3RvVXJsIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSwKICAgICAgICBmaWVsZCgiZW1haWwiLCByYXdQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCByYXdQcm9maWxlLmVtYWlsKSkpCg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329919928,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1528,15 +1528,15 @@
             },
             {
               "name": "content-length",
-              "value": "1557"
+              "value": "1505"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1561,7 +1561,163 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.035Z",
+        "startedDateTime": "2024-12-04T16:31:59.877Z",
+        "time": 69,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 69
+        }
+      },
+      {
+        "_id": "27fecf30018919bfaf247e6bc83f9f50",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2921,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "2921"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2022,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Apple\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Apple Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxuICpcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcbiAqIHVzZXJuYW1lLCBnaXZlbk5hbWUsIGZhbWlseU5hbWUsIGVtYWlsLlxuICpcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcbiAqIGFyYml0cmFyeSBjaGFyYWN0ZXJzIGZyb20gdGhlIFVuaXZlcnNhbCBDaGFyYWN0ZXIgU2V0IChVQ1MpLlxuICogQSB6ZXJvLWxlbmd0aCBjaGFyYWN0ZXIgc3RyaW5nIGlzIG5vdCBwZXJtaXR0ZWQuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5TdHJpbmcgZW1haWwgPSBcImNoYW5nZUBtZS5jb21cIlxuU3RyaW5nIHN1YmplY3RJZCA9IHJhd1Byb2ZpbGUuc3ViXG5TdHJpbmcgZmlyc3ROYW1lID0gXCIgXCJcblN0cmluZyBsYXN0TmFtZSA9IFwiIFwiXG5TdHJpbmcgdXNlcm5hbWUgPSBzdWJqZWN0SWRcblN0cmluZyBuYW1lXG5cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcImVtYWlsXCIpICYmIHJhd1Byb2ZpbGUuZW1haWwuaXNOb3ROdWxsKCkpeyAvLyBVc2VyIGNhbiBlbGVjdCB0byBub3Qgc2hhcmUgdGhlaXIgZW1haWxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxuICAgIHVzZXJuYW1lID0gZW1haWxcbn1cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcIm5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmlzTm90TnVsbCgpKSB7XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJmaXJzdE5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xuICAgICAgICBmaXJzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUuZmlyc3ROYW1lLmFzU3RyaW5nKClcbiAgICB9XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJsYXN0TmFtZVwiKSAmJiByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuaXNOb3ROdWxsKCkpIHtcbiAgICAgICAgbGFzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuYXNTdHJpbmcoKVxuICAgIH1cbn1cblxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFwiXCIpICsgKGxhc3ROYW1lPy50cmltKCkgPyAoKGZpcnN0TmFtZT8udHJpbSgpID8gXCIgXCIgOiBcIlwiKSArIGxhc3ROYW1lKSA6IFwiXCIpXG5uYW1lID0gICghbmFtZT8udHJpbSgpKSA/IFwiIFwiIDogbmFtZVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgc3ViamVjdElkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCBuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCBlbWFpbCksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIGZpcnN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCBsYXN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwidXNlcm5hbWVcIiwgdXNlcm5hbWUpKSkiCg==\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/484e6246-dbc6-4288-97e6-54e55431402e"
+        },
+        "response": {
+          "bodySize": 2990,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 2990,
+            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"name\":\"Apple Profile Normalization\",\"description\":\"Normalizes raw profile data from Apple\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxuICpcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcbiAqIHVzZXJuYW1lLCBnaXZlbk5hbWUsIGZhbWlseU5hbWUsIGVtYWlsLlxuICpcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcbiAqIGFyYml0cmFyeSBjaGFyYWN0ZXJzIGZyb20gdGhlIFVuaXZlcnNhbCBDaGFyYWN0ZXIgU2V0IChVQ1MpLlxuICogQSB6ZXJvLWxlbmd0aCBjaGFyYWN0ZXIgc3RyaW5nIGlzIG5vdCBwZXJtaXR0ZWQuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5TdHJpbmcgZW1haWwgPSBcImNoYW5nZUBtZS5jb21cIlxuU3RyaW5nIHN1YmplY3RJZCA9IHJhd1Byb2ZpbGUuc3ViXG5TdHJpbmcgZmlyc3ROYW1lID0gXCIgXCJcblN0cmluZyBsYXN0TmFtZSA9IFwiIFwiXG5TdHJpbmcgdXNlcm5hbWUgPSBzdWJqZWN0SWRcblN0cmluZyBuYW1lXG5cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcImVtYWlsXCIpICYmIHJhd1Byb2ZpbGUuZW1haWwuaXNOb3ROdWxsKCkpeyAvLyBVc2VyIGNhbiBlbGVjdCB0byBub3Qgc2hhcmUgdGhlaXIgZW1haWxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxuICAgIHVzZXJuYW1lID0gZW1haWxcbn1cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcIm5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmlzTm90TnVsbCgpKSB7XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJmaXJzdE5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xuICAgICAgICBmaXJzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUuZmlyc3ROYW1lLmFzU3RyaW5nKClcbiAgICB9XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJsYXN0TmFtZVwiKSAmJiByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuaXNOb3ROdWxsKCkpIHtcbiAgICAgICAgbGFzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuYXNTdHJpbmcoKVxuICAgIH1cbn1cblxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFwiXCIpICsgKGxhc3ROYW1lPy50cmltKCkgPyAoKGZpcnN0TmFtZT8udHJpbSgpID8gXCIgXCIgOiBcIlwiKSArIGxhc3ROYW1lKSA6IFwiXCIpXG5uYW1lID0gICghbmFtZT8udHJpbSgpKSA/IFwiIFwiIDogbmFtZVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgc3ViamVjdElkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCBuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCBlbWFpbCksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIGZpcnN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCBsYXN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwidXNlcm5hbWVcIiwgdXNlcm5hbWUpKSkiCg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329920011,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2990"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-12-04T16:31:59.952Z",
         "time": 79,
         "timings": {
           "blocked": -1,
@@ -1574,11 +1730,11 @@
         }
       },
       {
-        "_id": "0c352d31a9bc8be2496b8ae6c2c92245",
+        "_id": "e440e4911913e767714bc204aa5018cc",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 3085,
+          "bodySize": 3093,
           "cookies": [],
           "headers": [
             {
@@ -1591,11 +1747,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -1607,163 +1763,7 @@
             },
             {
               "name": "content-length",
-              "value": "3085"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "gzip, compress, deflate, br"
-            },
-            {
-              "name": "host",
-              "value": "openam-frodo-dev.forgeblocks.com"
-            }
-          ],
-          "headersSize": 2022,
-          "httpVersion": "HTTP/1.1",
-          "method": "PUT",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Apple\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Apple Profile Normalization\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxcbiAqXFxuICogVXNlIG9mIHRoaXMgY29kZSByZXF1aXJlcyBhIGNvbW1lcmNpYWwgc29mdHdhcmUgbGljZW5zZSB3aXRoIEZvcmdlUm9jayBBUy5cXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXFxuICpcXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcXG4gKiB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cXG4gKlxcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcXG4gKiBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cXG4gKiBBIHplcm8tbGVuZ3RoIGNoYXJhY3RlciBzdHJpbmcgaXMgbm90IHBlcm1pdHRlZC5cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5TdHJpbmcgZW1haWwgPSBcXFwiY2hhbmdlQG1lLmNvbVxcXCJcXG5TdHJpbmcgc3ViamVjdElkID0gcmF3UHJvZmlsZS5zdWJcXG5TdHJpbmcgZmlyc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIGxhc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIHVzZXJuYW1lID0gc3ViamVjdElkXFxuU3RyaW5nIG5hbWVcXG5cXG5pZiAocmF3UHJvZmlsZS5pc0RlZmluZWQoXFxcImVtYWlsXFxcIikgJiYgcmF3UHJvZmlsZS5lbWFpbC5pc05vdE51bGwoKSl7IC8vIFVzZXIgY2FuIGVsZWN0IHRvIG5vdCBzaGFyZSB0aGVpciBlbWFpbFxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxcbiAgICB1c2VybmFtZSA9IGVtYWlsXFxufVxcbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcXFwibmFtZVxcXCIpICYmIHJhd1Byb2ZpbGUubmFtZS5pc05vdE51bGwoKSkge1xcbiAgICBpZiAocmF3UHJvZmlsZS5uYW1lLmlzRGVmaW5lZChcXFwiZmlyc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xcbiAgICAgICAgZmlyc3ROYW1lID0gcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXFxcImxhc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmxhc3ROYW1lLmlzTm90TnVsbCgpKSB7XFxuICAgICAgICBsYXN0TmFtZSA9IHJhd1Byb2ZpbGUubmFtZS5sYXN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG59XFxuXFxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFxcXCJcXFwiKSArIChsYXN0TmFtZT8udHJpbSgpID8gKChmaXJzdE5hbWU/LnRyaW0oKSA/IFxcXCIgXFxcIiA6IFxcXCJcXFwiKSArIGxhc3ROYW1lKSA6IFxcXCJcXFwiKVxcbm5hbWUgPSAgKCFuYW1lPy50cmltKCkpID8gXFxcIiBcXFwiIDogbmFtZVxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHN1YmplY3RJZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCBuYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJlbWFpbFxcXCIsIGVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCBmaXJzdE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImZhbWlseU5hbWVcXFwiLCBsYXN0TmFtZSksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCB1c2VybmFtZSkpKVwiXG4i\"}"
-          },
-          "queryString": [],
-          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/484e6246-dbc6-4288-97e6-54e55431402e"
-        },
-        "response": {
-          "bodySize": 3154,
-          "content": {
-            "mimeType": "application/json;charset=UTF-8",
-            "size": 3154,
-            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"name\":\"Apple Profile Normalization\",\"description\":\"Normalizes raw profile data from Apple\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxcbiAqXFxuICogVXNlIG9mIHRoaXMgY29kZSByZXF1aXJlcyBhIGNvbW1lcmNpYWwgc29mdHdhcmUgbGljZW5zZSB3aXRoIEZvcmdlUm9jayBBUy5cXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXFxuICpcXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcXG4gKiB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cXG4gKlxcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcXG4gKiBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cXG4gKiBBIHplcm8tbGVuZ3RoIGNoYXJhY3RlciBzdHJpbmcgaXMgbm90IHBlcm1pdHRlZC5cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5TdHJpbmcgZW1haWwgPSBcXFwiY2hhbmdlQG1lLmNvbVxcXCJcXG5TdHJpbmcgc3ViamVjdElkID0gcmF3UHJvZmlsZS5zdWJcXG5TdHJpbmcgZmlyc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIGxhc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIHVzZXJuYW1lID0gc3ViamVjdElkXFxuU3RyaW5nIG5hbWVcXG5cXG5pZiAocmF3UHJvZmlsZS5pc0RlZmluZWQoXFxcImVtYWlsXFxcIikgJiYgcmF3UHJvZmlsZS5lbWFpbC5pc05vdE51bGwoKSl7IC8vIFVzZXIgY2FuIGVsZWN0IHRvIG5vdCBzaGFyZSB0aGVpciBlbWFpbFxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxcbiAgICB1c2VybmFtZSA9IGVtYWlsXFxufVxcbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcXFwibmFtZVxcXCIpICYmIHJhd1Byb2ZpbGUubmFtZS5pc05vdE51bGwoKSkge1xcbiAgICBpZiAocmF3UHJvZmlsZS5uYW1lLmlzRGVmaW5lZChcXFwiZmlyc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xcbiAgICAgICAgZmlyc3ROYW1lID0gcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXFxcImxhc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmxhc3ROYW1lLmlzTm90TnVsbCgpKSB7XFxuICAgICAgICBsYXN0TmFtZSA9IHJhd1Byb2ZpbGUubmFtZS5sYXN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG59XFxuXFxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFxcXCJcXFwiKSArIChsYXN0TmFtZT8udHJpbSgpID8gKChmaXJzdE5hbWU/LnRyaW0oKSA/IFxcXCIgXFxcIiA6IFxcXCJcXFwiKSArIGxhc3ROYW1lKSA6IFxcXCJcXFwiKVxcbm5hbWUgPSAgKCFuYW1lPy50cmltKCkpID8gXFxcIiBcXFwiIDogbmFtZVxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHN1YmplY3RJZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCBuYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJlbWFpbFxcXCIsIGVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCBmaXJzdE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImZhbWlseU5hbWVcXFwiLCBsYXN0TmFtZSksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCB1c2VybmFtZSkpKVwiXG4i\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329177,\"evaluatorVersion\":\"1.0\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "x-frame-options",
-              "value": "SAMEORIGIN"
-            },
-            {
-              "name": "content-security-policy-report-only",
-              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "cache-control",
-              "value": "private"
-            },
-            {
-              "name": "content-api-version",
-              "value": "resource=1.1"
-            },
-            {
-              "name": "content-security-policy",
-              "value": "default-src 'none';frame-ancestors 'none';sandbox"
-            },
-            {
-              "name": "cross-origin-opener-policy",
-              "value": "same-origin"
-            },
-            {
-              "name": "cross-origin-resource-policy",
-              "value": "same-origin"
-            },
-            {
-              "name": "expires",
-              "value": "0"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json;charset=UTF-8"
-            },
-            {
-              "name": "content-length",
-              "value": "3154"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
-            },
-            {
-              "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload;"
-            },
-            {
-              "name": "x-robots-tag",
-              "value": "none"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google"
-            },
-            {
-              "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
-            }
-          ],
-          "headersSize": 767,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-10-10T15:32:09.120Z",
-        "time": 80,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 80
-        }
-      },
-      {
-        "_id": "85ade8fc742dd01ea3b1adc2c17bde0c",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 3209,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "accept",
-              "value": "application/json, text/plain, */*"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
-            },
-            {
-              "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
-            },
-            {
-              "name": "accept-api-version",
-              "value": "protocol=2.0,resource=1.0"
-            },
-            {
-              "name": "authorization",
-              "value": "Bearer <bearer token>"
-            },
-            {
-              "name": "content-length",
-              "value": "3209"
+              "value": "3093"
             },
             {
               "name": "accept-encoding",
@@ -1780,17 +1780,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Converts a normalized social profile into a managed user\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Normalized Profile to Managed User\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbmltcG9ydCBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlXFxuXFxuSnNvblZhbHVlIG1hbmFnZWRVc2VyID0ganNvbihvYmplY3QoXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJzblxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmZhbWlseU5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcIm1haWxcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlck5hbWVcXFwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxcblxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXFxcInBvc3RhbEFkZHJlc3NcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwiY2l0eVxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJzdGF0ZVByb3ZpbmNlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbilcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJwb3N0YWxDb2RlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuY291bnRyeS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJjb3VudHJ5XFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuY291bnRyeSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwidGVsZXBob25lTnVtYmVyXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucGhvbmUpXFxuXFxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XFxuLy8gdGhlbiBhZGQgYSBib29sZWFuIGZsYWcgdG8gdGhlIHNoYXJlZCBzdGF0ZSB0byBpbmRpY2F0ZSBuYW1lcyBhcmUgbm90IHByZXNlbnRcXG4vLyB0aGlzIGNvdWxkIGJlIHVzZWQgZWxzZXdoZXJlXFxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcXG4vLyB0aGUgdXNlciBvYmplY3Qgd2l0aCBibGFuayB2YWx1ZXMgd2hlbiBnaXZlbk5hbWUgIGFuZCBmYW1pbHlOYW1lIGlzIG5vdCBwcmVzZW50XFxuYm9vbGVhbiBub0dpdmVuTmFtZSA9IG5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5pc051bGwoKSB8fCAoIW5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuc2hhcmVkU3RhdGUucHV0KFxcXCJuYW1lRW1wdHlPck51bGxcXFwiLCBub0dpdmVuTmFtZSAmJiBub0ZhbWlseU5hbWUpXFxuXFxucmV0dXJuIG1hbmFnZWRVc2VyXFxuXCJcbiI=\"}"
+            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Converts a normalized social profile into a managed user\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Normalized Profile to Managed User\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiIK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/58c824ae-84ed-4724-82cd-db128fc3f6c"
         },
         "response": {
-          "bodySize": 3278,
+          "bodySize": 3162,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3278,
-            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbmltcG9ydCBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlXFxuXFxuSnNvblZhbHVlIG1hbmFnZWRVc2VyID0ganNvbihvYmplY3QoXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJzblxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmZhbWlseU5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcIm1haWxcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlck5hbWVcXFwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxcblxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXFxcInBvc3RhbEFkZHJlc3NcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwiY2l0eVxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJzdGF0ZVByb3ZpbmNlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbilcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJwb3N0YWxDb2RlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuY291bnRyeS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJjb3VudHJ5XFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuY291bnRyeSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwidGVsZXBob25lTnVtYmVyXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucGhvbmUpXFxuXFxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XFxuLy8gdGhlbiBhZGQgYSBib29sZWFuIGZsYWcgdG8gdGhlIHNoYXJlZCBzdGF0ZSB0byBpbmRpY2F0ZSBuYW1lcyBhcmUgbm90IHByZXNlbnRcXG4vLyB0aGlzIGNvdWxkIGJlIHVzZWQgZWxzZXdoZXJlXFxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcXG4vLyB0aGUgdXNlciBvYmplY3Qgd2l0aCBibGFuayB2YWx1ZXMgd2hlbiBnaXZlbk5hbWUgIGFuZCBmYW1pbHlOYW1lIGlzIG5vdCBwcmVzZW50XFxuYm9vbGVhbiBub0dpdmVuTmFtZSA9IG5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5pc051bGwoKSB8fCAoIW5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuc2hhcmVkU3RhdGUucHV0KFxcXCJuYW1lRW1wdHlPck51bGxcXFwiLCBub0dpdmVuTmFtZSAmJiBub0ZhbWlseU5hbWUpXFxuXFxucmV0dXJuIG1hbmFnZWRVc2VyXFxuXCJcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329256,\"evaluatorVersion\":\"1.0\"}"
+            "size": 3162,
+            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiIK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329920087,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1840,15 +1840,15 @@
             },
             {
               "name": "content-length",
-              "value": "3278"
+              "value": "3162"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1873,8 +1873,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.204Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:00.036Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1882,15 +1882,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 81
         }
       },
       {
-        "_id": "3c18b6a5954c46c9eaf069280a91d2d6",
+        "_id": "c7c4491e9f8b5067c7f317f5616f1c01",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1539,
+          "bodySize": 1463,
           "cookies": [],
           "headers": [
             {
@@ -1903,11 +1903,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -1919,7 +1919,7 @@
             },
             {
               "name": "content-length",
-              "value": "1539"
+              "value": "1463"
             },
             {
               "name": "accept-encoding",
@@ -1936,17 +1936,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Google\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Google Profile Normalization\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHJhd1Byb2ZpbGUuc3ViKSxcXG4gICAgICAgIGZpZWxkKFxcXCJkaXNwbGF5TmFtZVxcXCIsIHJhd1Byb2ZpbGUubmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgcmF3UHJvZmlsZS5naXZlbl9uYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJmYW1pbHlOYW1lXFxcIiwgcmF3UHJvZmlsZS5mYW1pbHlfbmFtZSksXFxuICAgICAgICBmaWVsZChcXFwicGhvdG9VcmxcXFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxcbiAgICAgICAgZmllbGQoXFxcImVtYWlsXFxcIiwgcmF3UHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCByYXdQcm9maWxlLmVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJsb2NhbGVcXFwiLCByYXdQcm9maWxlLmxvY2FsZSkpKVwiXG4i\"}"
+            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Google\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Google Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5zdWIpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZ2l2ZW5fbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmZhbWlseV9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcImxvY2FsZVwiLCByYXdQcm9maWxlLmxvY2FsZSkpKSIK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/58d29080-4563-480b-89bb-1e7719776a21"
         },
         "response": {
-          "bodySize": 1608,
+          "bodySize": 1532,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1608,
-            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"name\":\"Google Profile Normalization\",\"description\":\"Normalizes raw profile data from Google\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHJhd1Byb2ZpbGUuc3ViKSxcXG4gICAgICAgIGZpZWxkKFxcXCJkaXNwbGF5TmFtZVxcXCIsIHJhd1Byb2ZpbGUubmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgcmF3UHJvZmlsZS5naXZlbl9uYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJmYW1pbHlOYW1lXFxcIiwgcmF3UHJvZmlsZS5mYW1pbHlfbmFtZSksXFxuICAgICAgICBmaWVsZChcXFwicGhvdG9VcmxcXFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxcbiAgICAgICAgZmllbGQoXFxcImVtYWlsXFxcIiwgcmF3UHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCByYXdQcm9maWxlLmVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJsb2NhbGVcXFwiLCByYXdQcm9maWxlLmxvY2FsZSkpKVwiXG4i\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329328,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1532,
+            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"name\":\"Google Profile Normalization\",\"description\":\"Normalizes raw profile data from Google\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5zdWIpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZ2l2ZW5fbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmZhbWlseV9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcImxvY2FsZVwiLCByYXdQcm9maWxlLmxvY2FsZSkpKSIK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329920180,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1996,15 +1996,15 @@
             },
             {
               "name": "content-length",
-              "value": "1608"
+              "value": "1532"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -2029,8 +2029,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.279Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:00.121Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2038,15 +2038,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 78
         }
       },
       {
-        "_id": "bbb781f13b577c203d3c3c9f093650a0",
+        "_id": "d781078a77df6e3ad9e67899bc667868",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1498,
+          "bodySize": 1442,
           "cookies": [],
           "headers": [
             {
@@ -2059,11 +2059,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -2075,7 +2075,7 @@
             },
             {
               "name": "content-length",
-              "value": "1498"
+              "value": "1442"
             },
             {
               "name": "accept-encoding",
@@ -2092,17 +2092,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Okta Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIk9rdGEgcmF3UHJvZmlsZTogXCIrcmF3UHJvZmlsZSlcblxucmV0dXJuIGpzb24ob2JqZWN0KFxuICAgICAgICBmaWVsZChcImlkXCIsIHJhd1Byb2ZpbGUuaWQpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwicGhvdG9VcmxcIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnByZWZlcnJlZF91c2VybmFtZSkpKVxuIg==\"}"
+            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Okta Profile Normalization\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJPa3RhIHJhd1Byb2ZpbGU6ICIrcmF3UHJvZmlsZSkKCnJldHVybiBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiaWQiLCByYXdQcm9maWxlLmlkKSwKICAgICAgICBmaWVsZCgiZGlzcGxheU5hbWUiLCByYXdQcm9maWxlLm5hbWUpLAogICAgICAgIGZpZWxkKCJnaXZlbk5hbWUiLCByYXdQcm9maWxlLmZpcnN0X25hbWUpLAogICAgICAgIGZpZWxkKCJmYW1pbHlOYW1lIiwgcmF3UHJvZmlsZS5sYXN0X25hbWUpLAogICAgICAgIGZpZWxkKCJwaG90b1VybCIsIHJhd1Byb2ZpbGUucGljdHVyZS5kYXRhLnVybCksCiAgICAgICAgZmllbGQoImVtYWlsIiwgcmF3UHJvZmlsZS5lbWFpbCksCiAgICAgICAgZmllbGQoInVzZXJuYW1lIiwgcmF3UHJvZmlsZS5wcmVmZXJyZWRfdXNlcm5hbWUpKSkK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/6325cf19-a49b-471e-8d26-7e4df76df0e2"
         },
         "response": {
-          "bodySize": 1566,
+          "bodySize": 1510,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1566,
-            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"name\":\"Okta Profile Normalization\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIk9rdGEgcmF3UHJvZmlsZTogXCIrcmF3UHJvZmlsZSlcblxucmV0dXJuIGpzb24ob2JqZWN0KFxuICAgICAgICBmaWVsZChcImlkXCIsIHJhd1Byb2ZpbGUuaWQpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwicGhvdG9VcmxcIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnByZWZlcnJlZF91c2VybmFtZSkpKVxuIg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329404,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1510,
+            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"name\":\"Okta Profile Normalization\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJPa3RhIHJhd1Byb2ZpbGU6ICIrcmF3UHJvZmlsZSkKCnJldHVybiBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiaWQiLCByYXdQcm9maWxlLmlkKSwKICAgICAgICBmaWVsZCgiZGlzcGxheU5hbWUiLCByYXdQcm9maWxlLm5hbWUpLAogICAgICAgIGZpZWxkKCJnaXZlbk5hbWUiLCByYXdQcm9maWxlLmZpcnN0X25hbWUpLAogICAgICAgIGZpZWxkKCJmYW1pbHlOYW1lIiwgcmF3UHJvZmlsZS5sYXN0X25hbWUpLAogICAgICAgIGZpZWxkKCJwaG90b1VybCIsIHJhd1Byb2ZpbGUucGljdHVyZS5kYXRhLnVybCksCiAgICAgICAgZmllbGQoImVtYWlsIiwgcmF3UHJvZmlsZS5lbWFpbCksCiAgICAgICAgZmllbGQoInVzZXJuYW1lIiwgcmF3UHJvZmlsZS5wcmVmZXJyZWRfdXNlcm5hbWUpKSkK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329920259,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2152,15 +2152,15 @@
             },
             {
               "name": "content-length",
-              "value": "1566"
+              "value": "1510"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -2185,8 +2185,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.352Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:00.203Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2194,15 +2194,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 76
         }
       },
       {
-        "_id": "61e02fc399a8567bd8c3bd359f0e7656",
+        "_id": "f6f8b416d52c96b4d98756f6f43be432",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1036,
+          "bodySize": 992,
           "cookies": [],
           "headers": [
             {
@@ -2215,11 +2215,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -2231,7 +2231,7 @@
             },
             {
               "name": "content-length",
-              "value": "1036"
+              "value": "992"
             },
             {
               "name": "accept-encoding",
@@ -2242,23 +2242,23 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2022,
+          "headersSize": 2021,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if username has already been collected.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Check Username\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTtcbiI=\"}"
+            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if username has already been collected.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Check Username\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOwo=\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/739bdc48-fd24-4c52-b353-88706d75558a"
         },
         "response": {
-          "bodySize": 1104,
+          "bodySize": 1060,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1104,
-            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTtcbiI=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329485,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1060,
+            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOwo=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329920340,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2308,15 +2308,15 @@
             },
             {
               "name": "content-length",
-              "value": "1104"
+              "value": "1060"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -2341,7 +2341,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.428Z",
+        "startedDateTime": "2024-12-04T16:32:00.285Z",
         "time": 77,
         "timings": {
           "blocked": -1,
@@ -2354,11 +2354,11 @@
         }
       },
       {
-        "_id": "f589e37b17c99f36912bbedd0f8ca3f9",
+        "_id": "6c7a3ecad7376b499678c33341d8e5d0",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2773,
+          "bodySize": 2553,
           "cookies": [],
           "headers": [
             {
@@ -2371,11 +2371,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -2387,7 +2387,7 @@
             },
             {
               "name": "content-length",
-              "value": "2773"
+              "value": "2553"
             },
             {
               "name": "accept-encoding",
@@ -2404,17 +2404,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Microsoft\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Microsoft Profile Normalization\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbi8qXFxue1xcbiAgICBcXFwiQG9kYXRhLmNvbnRleHRcXFwiOiBcXFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcXFwiLFxcbiAgICBcXFwiQG9kYXRhLmlkXFxcIjogXFxcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcXFwiLFxcbiAgICBcXFwiYnVzaW5lc3NQaG9uZXNcXFwiOiBbXFxuICAgICAgICBcXFwiMTgwMTQ3MzU0NTFcXFwiXFxuICAgIF0sXFxuICAgIFxcXCJkaXNwbGF5TmFtZVxcXCI6IFxcXCJWb2xrZXIgU2NoZXViZXJcXFwiLFxcbiAgICBcXFwiZ2l2ZW5OYW1lXFxcIjogXFxcIlZvbGtlclxcXCIsXFxuICAgIFxcXCJqb2JUaXRsZVxcXCI6IG51bGwsXFxuICAgIFxcXCJtYWlsXFxcIjogXFxcInZzY2hldWJlckB2c2NoZXViZXIub25taWNyb3NvZnQuY29tXFxcIixcXG4gICAgXFxcIm1vYmlsZVBob25lXFxcIjogbnVsbCxcXG4gICAgXFxcIm9mZmljZUxvY2F0aW9uXFxcIjogbnVsbCxcXG4gICAgXFxcInByZWZlcnJlZExhbmd1YWdlXFxcIjogbnVsbCxcXG4gICAgXFxcInN1cm5hbWVcXFwiOiBcXFwiU2NoZXViZXJcXFwiLFxcbiAgICBcXFwidXNlclByaW5jaXBhbE5hbWVcXFwiOiBcXFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cXFwiLFxcbiAgICBcXFwiaWRcXFwiOiBcXFwiN2Q3NzU5ZTItMzZkOC00ZTY0LWIxNzMtM2Y4OTBkN2Q0NmQ2XFxcIlxcbn1cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5sb2dnZXIubWVzc2FnZShcXFwiS2F1YWkgTWljcm9zb2Z0IFByb2ZpbGUgTm9ybWFsaXphdGlvbjogcmF3UHJvZmlsZT17fVxcXCIsIHJhd1Byb2ZpbGUpXFxuXFxucmV0dXJuIGpzb24ob2JqZWN0KFxcbiAgICAgICAgZmllbGQoXFxcImlkXFxcIiwgcmF3UHJvZmlsZS5pZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCByYXdQcm9maWxlLmdpdmVuTmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZmFtaWx5TmFtZVxcXCIsIHJhd1Byb2ZpbGUuc3VybmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZW1haWxcXFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJ1c2VybmFtZVxcXCIsIHJhd1Byb2ZpbGUudXNlclByaW5jaXBhbE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImdyb3Vwc1xcXCIsIHJhd1Byb2ZpbGUuZ3JvdXBzKSkpXCJcbiI=\"}"
+            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Microsoft\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Microsoft Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuLypcbntcbiAgICBcIkBvZGF0YS5jb250ZXh0XCI6IFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcIixcbiAgICBcIkBvZGF0YS5pZFwiOiBcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcIixcbiAgICBcImJ1c2luZXNzUGhvbmVzXCI6IFtcbiAgICAgICAgXCIxODAxNDczNTQ1MVwiXG4gICAgXSxcbiAgICBcImRpc3BsYXlOYW1lXCI6IFwiVm9sa2VyIFNjaGV1YmVyXCIsXG4gICAgXCJnaXZlbk5hbWVcIjogXCJWb2xrZXJcIixcbiAgICBcImpvYlRpdGxlXCI6IG51bGwsXG4gICAgXCJtYWlsXCI6IFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cIixcbiAgICBcIm1vYmlsZVBob25lXCI6IG51bGwsXG4gICAgXCJvZmZpY2VMb2NhdGlvblwiOiBudWxsLFxuICAgIFwicHJlZmVycmVkTGFuZ3VhZ2VcIjogbnVsbCxcbiAgICBcInN1cm5hbWVcIjogXCJTY2hldWJlclwiLFxuICAgIFwidXNlclByaW5jaXBhbE5hbWVcIjogXCJ2c2NoZXViZXJAdnNjaGV1YmVyLm9ubWljcm9zb2Z0LmNvbVwiLFxuICAgIFwiaWRcIjogXCI3ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDZcIlxufVxuICovXG5cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmpzb25cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcblxubG9nZ2VyLm1lc3NhZ2UoXCJLYXVhaSBNaWNyb3NvZnQgUHJvZmlsZSBOb3JtYWxpemF0aW9uOiByYXdQcm9maWxlPXt9XCIsIHJhd1Byb2ZpbGUpXG5cbnJldHVybiBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJpZFwiLCByYXdQcm9maWxlLmlkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5naXZlbk5hbWUpLFxuICAgICAgICBmaWVsZChcImZhbWlseU5hbWVcIiwgcmF3UHJvZmlsZS5zdXJuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJncm91cHNcIiwgcmF3UHJvZmlsZS5ncm91cHMpKSkiCg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/73cecbfc-dad0-4395-be6a-6858ee3a80e5"
         },
         "response": {
-          "bodySize": 2842,
+          "bodySize": 2622,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 2842,
-            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"name\":\"Microsoft Profile Normalization\",\"description\":\"Normalizes raw profile data from Microsoft\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbi8qXFxue1xcbiAgICBcXFwiQG9kYXRhLmNvbnRleHRcXFwiOiBcXFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcXFwiLFxcbiAgICBcXFwiQG9kYXRhLmlkXFxcIjogXFxcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcXFwiLFxcbiAgICBcXFwiYnVzaW5lc3NQaG9uZXNcXFwiOiBbXFxuICAgICAgICBcXFwiMTgwMTQ3MzU0NTFcXFwiXFxuICAgIF0sXFxuICAgIFxcXCJkaXNwbGF5TmFtZVxcXCI6IFxcXCJWb2xrZXIgU2NoZXViZXJcXFwiLFxcbiAgICBcXFwiZ2l2ZW5OYW1lXFxcIjogXFxcIlZvbGtlclxcXCIsXFxuICAgIFxcXCJqb2JUaXRsZVxcXCI6IG51bGwsXFxuICAgIFxcXCJtYWlsXFxcIjogXFxcInZzY2hldWJlckB2c2NoZXViZXIub25taWNyb3NvZnQuY29tXFxcIixcXG4gICAgXFxcIm1vYmlsZVBob25lXFxcIjogbnVsbCxcXG4gICAgXFxcIm9mZmljZUxvY2F0aW9uXFxcIjogbnVsbCxcXG4gICAgXFxcInByZWZlcnJlZExhbmd1YWdlXFxcIjogbnVsbCxcXG4gICAgXFxcInN1cm5hbWVcXFwiOiBcXFwiU2NoZXViZXJcXFwiLFxcbiAgICBcXFwidXNlclByaW5jaXBhbE5hbWVcXFwiOiBcXFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cXFwiLFxcbiAgICBcXFwiaWRcXFwiOiBcXFwiN2Q3NzU5ZTItMzZkOC00ZTY0LWIxNzMtM2Y4OTBkN2Q0NmQ2XFxcIlxcbn1cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5sb2dnZXIubWVzc2FnZShcXFwiS2F1YWkgTWljcm9zb2Z0IFByb2ZpbGUgTm9ybWFsaXphdGlvbjogcmF3UHJvZmlsZT17fVxcXCIsIHJhd1Byb2ZpbGUpXFxuXFxucmV0dXJuIGpzb24ob2JqZWN0KFxcbiAgICAgICAgZmllbGQoXFxcImlkXFxcIiwgcmF3UHJvZmlsZS5pZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCByYXdQcm9maWxlLmdpdmVuTmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZmFtaWx5TmFtZVxcXCIsIHJhd1Byb2ZpbGUuc3VybmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZW1haWxcXFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJ1c2VybmFtZVxcXCIsIHJhd1Byb2ZpbGUudXNlclByaW5jaXBhbE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImdyb3Vwc1xcXCIsIHJhd1Byb2ZpbGUuZ3JvdXBzKSkpXCJcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329557,\"evaluatorVersion\":\"1.0\"}"
+            "size": 2622,
+            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"name\":\"Microsoft Profile Normalization\",\"description\":\"Normalizes raw profile data from Microsoft\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuLypcbntcbiAgICBcIkBvZGF0YS5jb250ZXh0XCI6IFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcIixcbiAgICBcIkBvZGF0YS5pZFwiOiBcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcIixcbiAgICBcImJ1c2luZXNzUGhvbmVzXCI6IFtcbiAgICAgICAgXCIxODAxNDczNTQ1MVwiXG4gICAgXSxcbiAgICBcImRpc3BsYXlOYW1lXCI6IFwiVm9sa2VyIFNjaGV1YmVyXCIsXG4gICAgXCJnaXZlbk5hbWVcIjogXCJWb2xrZXJcIixcbiAgICBcImpvYlRpdGxlXCI6IG51bGwsXG4gICAgXCJtYWlsXCI6IFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cIixcbiAgICBcIm1vYmlsZVBob25lXCI6IG51bGwsXG4gICAgXCJvZmZpY2VMb2NhdGlvblwiOiBudWxsLFxuICAgIFwicHJlZmVycmVkTGFuZ3VhZ2VcIjogbnVsbCxcbiAgICBcInN1cm5hbWVcIjogXCJTY2hldWJlclwiLFxuICAgIFwidXNlclByaW5jaXBhbE5hbWVcIjogXCJ2c2NoZXViZXJAdnNjaGV1YmVyLm9ubWljcm9zb2Z0LmNvbVwiLFxuICAgIFwiaWRcIjogXCI3ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDZcIlxufVxuICovXG5cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmpzb25cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcblxubG9nZ2VyLm1lc3NhZ2UoXCJLYXVhaSBNaWNyb3NvZnQgUHJvZmlsZSBOb3JtYWxpemF0aW9uOiByYXdQcm9maWxlPXt9XCIsIHJhd1Byb2ZpbGUpXG5cbnJldHVybiBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJpZFwiLCByYXdQcm9maWxlLmlkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5naXZlbk5hbWUpLFxuICAgICAgICBmaWVsZChcImZhbWlseU5hbWVcIiwgcmF3UHJvZmlsZS5zdXJuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJncm91cHNcIiwgcmF3UHJvZmlsZS5ncm91cHMpKSkiCg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329920421,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2464,15 +2464,15 @@
             },
             {
               "name": "content-length",
-              "value": "2842"
+              "value": "2622"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -2497,8 +2497,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.510Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:00.367Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2506,15 +2506,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 75
         }
       },
       {
-        "_id": "5c399317a57917ea99761372d2d40e14",
+        "_id": "72a6d1011be243a7380bba9f2bd08145",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 7389,
+          "bodySize": 7225,
           "cookies": [],
           "headers": [
             {
@@ -2527,11 +2527,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -2543,7 +2543,7 @@
             },
             {
               "name": "content-length",
-              "value": "7389"
+              "value": "7225"
             },
             {
               "name": "accept-encoding",
@@ -2560,17 +2560,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from ADFS\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"ADFS Profile Normalization (JS)\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgICAgIC8vbG9nZ2VyLm1lc3NhZ2UoJ1NlZ3VpbiByYXdQcm9maWxlOiAnK3Jhd1Byb2ZpbGUpO1xuXG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnaWQnLCByYXdQcm9maWxlLmdldCgnc3ViJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZGlzcGxheU5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSArICcgJyArIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdnaXZlbk5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZmFtaWx5TmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3JvbGVzJywgcmF3UHJvZmlsZS5nZXQoJ3JvbGVzJykuYXNTdHJpbmcoKSk7XG4gIFxuICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpO1xuXG4gICAgcmV0dXJuIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTtcbn0oKSk7XG4i\"}"
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from ADFS\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"ADFS Profile Normalization (JS)\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7Cg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/dbe0bf9a-72aa-49d5-8483-9db147985a47"
         },
         "response": {
-          "bodySize": 7457,
+          "bodySize": 7293,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 7457,
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgICAgIC8vbG9nZ2VyLm1lc3NhZ2UoJ1NlZ3VpbiByYXdQcm9maWxlOiAnK3Jhd1Byb2ZpbGUpO1xuXG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnaWQnLCByYXdQcm9maWxlLmdldCgnc3ViJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZGlzcGxheU5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSArICcgJyArIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdnaXZlbk5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZmFtaWx5TmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3JvbGVzJywgcmF3UHJvZmlsZS5nZXQoJ3JvbGVzJykuYXNTdHJpbmcoKSk7XG4gIFxuICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpO1xuXG4gICAgcmV0dXJuIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTtcbn0oKSk7XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574329631,\"evaluatorVersion\":\"1.0\"}"
+            "size": 7293,
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329920504,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2620,15 +2620,15 @@
             },
             {
               "name": "content-length",
-              "value": "7457"
+              "value": "7293"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:08 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -2653,8 +2653,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.582Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:00.448Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2662,7 +2662,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 78
         }
       },
       {
@@ -2683,11 +2683,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -2784,11 +2784,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -2813,8 +2813,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.900Z",
-        "time": 101,
+        "startedDateTime": "2024-12-04T16:32:00.794Z",
+        "time": 104,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2822,7 +2822,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 101
+          "wait": 104
         }
       },
       {
@@ -2843,11 +2843,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -2944,11 +2944,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -2973,8 +2973,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.007Z",
-        "time": 91,
+        "startedDateTime": "2024-12-04T16:32:00.903Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2982,7 +2982,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 91
+          "wait": 93
         }
       },
       {
@@ -3003,11 +3003,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -3104,11 +3104,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -3133,8 +3133,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.103Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:32:01.001Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3142,7 +3142,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 80
         }
       },
       {
@@ -3163,11 +3163,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -3264,11 +3264,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -3293,8 +3293,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.181Z",
-        "time": 82,
+        "startedDateTime": "2024-12-04T16:32:01.086Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3302,7 +3302,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 82
+          "wait": 90
         }
       },
       {
@@ -3323,11 +3323,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -3424,11 +3424,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -3453,8 +3453,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.269Z",
-        "time": 85,
+        "startedDateTime": "2024-12-04T16:32:01.181Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3462,7 +3462,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 90
         }
       },
       {
@@ -3483,11 +3483,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -3584,11 +3584,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -3613,8 +3613,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.359Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:32:01.277Z",
+        "time": 103,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3622,7 +3622,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 103
         }
       },
       {
@@ -3643,11 +3643,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -3744,11 +3744,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -3773,8 +3773,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.445Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:32:01.384Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3782,7 +3782,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 83
         }
       },
       {
@@ -3803,11 +3803,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -3900,11 +3900,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -3929,8 +3929,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.525Z",
-        "time": 80,
+        "startedDateTime": "2024-12-04T16:32:01.475Z",
+        "time": 97,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3938,7 +3938,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 80
+          "wait": 97
         }
       },
       {
@@ -3959,11 +3959,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -4060,11 +4060,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -4089,8 +4089,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.611Z",
-        "time": 141,
+        "startedDateTime": "2024-12-04T16:32:01.581Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4098,7 +4098,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 141
+          "wait": 210
         }
       },
       {
@@ -4119,11 +4119,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -4216,11 +4216,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -4245,8 +4245,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.757Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:01.796Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4254,7 +4254,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 65
         }
       },
       {
@@ -4275,11 +4275,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -4314,11 +4314,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/saml2/remote/dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l"
         },
         "response": {
-          "bodySize": 1581,
+          "bodySize": 1604,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1581,
-            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"1007701944\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"accountMapper\":{},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{}}}}"
+            "size": 1604,
+            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"-901720656\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"accountMapper\":{},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{},\"treeConfiguration\":{}}}}"
           },
           "cookies": [],
           "headers": [
@@ -4356,7 +4356,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1007701944\""
+              "value": "\"-901720656\""
             },
             {
               "name": "expires",
@@ -4372,15 +4372,15 @@
             },
             {
               "name": "content-length",
-              "value": "1581"
+              "value": "1604"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:01 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -4405,8 +4405,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:10.833Z",
-        "time": 102,
+        "startedDateTime": "2024-12-04T16:32:01.865Z",
+        "time": 106,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4414,7 +4414,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 102
+          "wait": 106
         }
       },
       {
@@ -4435,15 +4435,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4505,7 +4505,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4537,11 +4537,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -4566,8 +4566,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2024-10-10T15:32:10.939Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:32:01.978Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4575,7 +4575,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 77
         }
       },
       {
@@ -4596,15 +4596,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4661,7 +4661,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4697,11 +4697,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -4726,8 +4726,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.029Z",
-        "time": 175,
+        "startedDateTime": "2024-12-04T16:32:02.060Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4735,7 +4735,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 175
+          "wait": 81
         }
       },
       {
@@ -4756,15 +4756,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4826,7 +4826,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4858,11 +4858,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -4887,8 +4887,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2024-10-10T15:32:11.208Z",
-        "time": 59,
+        "startedDateTime": "2024-12-04T16:32:02.147Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4896,7 +4896,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 59
+          "wait": 78
         }
       },
       {
@@ -4917,15 +4917,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4982,7 +4982,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5018,11 +5018,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -5047,8 +5047,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.272Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:32:02.230Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5056,7 +5056,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 83
         }
       },
       {
@@ -5077,15 +5077,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5142,7 +5142,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5178,11 +5178,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -5207,8 +5207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.351Z",
-        "time": 99,
+        "startedDateTime": "2024-12-04T16:32:02.318Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5216,7 +5216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 99
+          "wait": 83
         }
       },
       {
@@ -5237,15 +5237,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5302,7 +5302,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5338,11 +5338,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -5367,8 +5367,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.454Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:02.406Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5376,7 +5376,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 88
         }
       },
       {
@@ -5397,15 +5397,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5462,7 +5462,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5498,11 +5498,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -5527,8 +5527,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.531Z",
-        "time": 108,
+        "startedDateTime": "2024-12-04T16:32:02.498Z",
+        "time": 100,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5536,7 +5536,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 108
+          "wait": 100
         }
       },
       {
@@ -5557,15 +5557,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5622,7 +5622,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5658,11 +5658,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -5687,8 +5687,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.643Z",
-        "time": 146,
+        "startedDateTime": "2024-12-04T16:32:02.603Z",
+        "time": 101,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5696,7 +5696,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 146
+          "wait": 101
         }
       },
       {
@@ -5717,15 +5717,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5782,7 +5782,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5818,11 +5818,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -5847,8 +5847,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.795Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:02.707Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5856,7 +5856,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 70
         }
       },
       {
@@ -5877,15 +5877,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5942,7 +5942,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5978,11 +5978,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -6007,8 +6007,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.872Z",
-        "time": 82,
+        "startedDateTime": "2024-12-04T16:32:02.782Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6016,7 +6016,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 82
+          "wait": 66
         }
       },
       {
@@ -6037,15 +6037,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6102,7 +6102,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6138,11 +6138,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -6167,8 +6167,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:11.959Z",
-        "time": 104,
+        "startedDateTime": "2024-12-04T16:32:02.852Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6176,7 +6176,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 104
+          "wait": 76
         }
       },
       {
@@ -6197,15 +6197,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6262,7 +6262,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6298,11 +6298,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:02 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -6327,8 +6327,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:12.068Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:02.932Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6336,7 +6336,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 66
         }
       },
       {
@@ -6357,15 +6357,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6422,7 +6422,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6458,11 +6458,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -6487,7 +6487,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:12.145Z",
+        "startedDateTime": "2024-12-04T16:32:03.003Z",
         "time": 92,
         "timings": {
           "blocked": -1,
@@ -6517,15 +6517,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6582,7 +6582,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6618,11 +6618,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -6647,8 +6647,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:12.242Z",
-        "time": 92,
+        "startedDateTime": "2024-12-04T16:32:03.101Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6656,7 +6656,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 92
+          "wait": 76
         }
       },
       {
@@ -6677,15 +6677,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6742,7 +6742,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6778,11 +6778,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -6807,8 +6807,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:12.338Z",
-        "time": 768,
+        "startedDateTime": "2024-12-04T16:32:03.182Z",
+        "time": 313,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6816,7 +6816,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 768
+          "wait": 313
         }
       },
       {
@@ -6837,15 +6837,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6902,7 +6902,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6938,11 +6938,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -6967,8 +6967,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.110Z",
-        "time": 116,
+        "startedDateTime": "2024-12-04T16:32:03.501Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6976,7 +6976,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 116
+          "wait": 83
         }
       },
       {
@@ -6997,15 +6997,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7062,7 +7062,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7098,11 +7098,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -7127,8 +7127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.231Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:03.591Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7136,7 +7136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 78
         }
       },
       {
@@ -7157,15 +7157,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7222,7 +7222,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7258,11 +7258,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -7287,8 +7287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.302Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:03.676Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7296,7 +7296,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 83
         }
       },
       {
@@ -7317,15 +7317,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7382,7 +7382,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7418,11 +7418,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -7447,8 +7447,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.376Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:32:03.763Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7456,7 +7456,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 66
         }
       },
       {
@@ -7477,15 +7477,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7542,7 +7542,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7578,11 +7578,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -7607,8 +7607,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.458Z",
-        "time": 150,
+        "startedDateTime": "2024-12-04T16:32:03.834Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7616,7 +7616,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 150
+          "wait": 84
         }
       },
       {
@@ -7637,15 +7637,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7702,7 +7702,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7738,11 +7738,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:03 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -7767,8 +7767,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.613Z",
-        "time": 79,
+        "startedDateTime": "2024-12-04T16:32:03.923Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7776,7 +7776,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 79
+          "wait": 72
         }
       },
       {
@@ -7797,15 +7797,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7862,7 +7862,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7898,11 +7898,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -7927,8 +7927,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.699Z",
-        "time": 104,
+        "startedDateTime": "2024-12-04T16:32:04.000Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7936,7 +7936,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 104
+          "wait": 81
         }
       },
       {
@@ -7957,15 +7957,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8022,7 +8022,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8058,11 +8058,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -8087,8 +8087,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.807Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:04.085Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8096,7 +8096,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 79
         }
       },
       {
@@ -8117,15 +8117,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8182,7 +8182,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8218,11 +8218,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -8247,8 +8247,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.891Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:04.168Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8256,7 +8256,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 70
         }
       },
       {
@@ -8277,15 +8277,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8342,7 +8342,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8378,11 +8378,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -8407,8 +8407,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:13.974Z",
-        "time": 108,
+        "startedDateTime": "2024-12-04T16:32:04.243Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8416,7 +8416,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 108
+          "wait": 88
         }
       },
       {
@@ -8437,15 +8437,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8502,7 +8502,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8538,11 +8538,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -8567,8 +8567,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.087Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:04.338Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8576,7 +8576,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 77
         }
       },
       {
@@ -8597,15 +8597,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8662,7 +8662,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8698,11 +8698,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -8727,8 +8727,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.171Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:32:04.420Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8736,7 +8736,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 83
         }
       },
       {
@@ -8757,15 +8757,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8822,7 +8822,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8858,11 +8858,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -8887,8 +8887,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.242Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:04.510Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8896,7 +8896,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 65
         }
       },
       {
@@ -8917,15 +8917,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8982,7 +8982,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9018,11 +9018,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -9047,8 +9047,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.313Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:32:04.585Z",
+        "time": 63,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9056,7 +9056,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 63
         }
       },
       {
@@ -9077,15 +9077,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9142,7 +9142,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9178,11 +9178,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -9207,8 +9207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.400Z",
-        "time": 107,
+        "startedDateTime": "2024-12-04T16:32:04.654Z",
+        "time": 91,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9216,7 +9216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 107
+          "wait": 91
         }
       },
       {
@@ -9237,15 +9237,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9302,7 +9302,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9338,11 +9338,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -9367,8 +9367,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.512Z",
-        "time": 113,
+        "startedDateTime": "2024-12-04T16:32:04.750Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9376,7 +9376,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 113
+          "wait": 76
         }
       },
       {
@@ -9397,15 +9397,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9462,7 +9462,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9498,11 +9498,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -9527,8 +9527,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.629Z",
-        "time": 184,
+        "startedDateTime": "2024-12-04T16:32:04.832Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9536,7 +9536,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 184
+          "wait": 75
         }
       },
       {
@@ -9557,15 +9557,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9622,7 +9622,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9658,11 +9658,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:04 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -9687,8 +9687,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.817Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:04.912Z",
+        "time": 62,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9696,7 +9696,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 62
         }
       },
       {
@@ -9717,15 +9717,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9782,7 +9782,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9818,11 +9818,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -9847,8 +9847,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.890Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:04.978Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9856,7 +9856,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 66
         }
       },
       {
@@ -9877,15 +9877,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9942,7 +9942,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9978,11 +9978,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -10007,8 +10007,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:14.963Z",
-        "time": 87,
+        "startedDateTime": "2024-12-04T16:32:05.049Z",
+        "time": 71,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10016,7 +10016,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 71
         }
       },
       {
@@ -10037,15 +10037,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10102,7 +10102,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10138,11 +10138,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -10167,8 +10167,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.054Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:05.125Z",
+        "time": 67,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10176,7 +10176,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 67
         }
       },
       {
@@ -10197,15 +10197,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10262,7 +10262,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10298,11 +10298,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -10327,8 +10327,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.129Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:05.198Z",
+        "time": 62,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10336,7 +10336,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 62
         }
       },
       {
@@ -10357,15 +10357,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10422,7 +10422,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10458,11 +10458,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -10487,8 +10487,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.270Z",
-        "time": 87,
+        "startedDateTime": "2024-12-04T16:32:05.330Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10496,7 +10496,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 76
         }
       },
       {
@@ -10517,15 +10517,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10582,7 +10582,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10618,11 +10618,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -10647,8 +10647,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.362Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:05.411Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10656,7 +10656,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 65
         }
       },
       {
@@ -10677,15 +10677,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10742,7 +10742,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10778,11 +10778,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -10807,8 +10807,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.436Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:05.481Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10816,7 +10816,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 64
         }
       },
       {
@@ -10837,15 +10837,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10902,7 +10902,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10938,11 +10938,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -10967,8 +10967,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.510Z",
-        "time": 86,
+        "startedDateTime": "2024-12-04T16:32:05.551Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10976,7 +10976,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 86
+          "wait": 78
         }
       },
       {
@@ -10997,15 +10997,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11062,7 +11062,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11098,11 +11098,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -11127,8 +11127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.601Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:05.633Z",
+        "time": 92,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11136,7 +11136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 92
         }
       },
       {
@@ -11157,15 +11157,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11222,7 +11222,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11258,11 +11258,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -11287,8 +11287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.677Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:32:05.730Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11296,7 +11296,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 68
         }
       },
       {
@@ -11317,15 +11317,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11382,7 +11382,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11418,11 +11418,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -11447,8 +11447,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.755Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:05.802Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11456,7 +11456,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 65
         }
       },
       {
@@ -11477,15 +11477,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11542,7 +11542,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11578,11 +11578,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -11607,8 +11607,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.831Z",
-        "time": 100,
+        "startedDateTime": "2024-12-04T16:32:05.873Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11616,7 +11616,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 100
+          "wait": 69
         }
       },
       {
@@ -11637,15 +11637,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11702,7 +11702,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11738,11 +11738,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -11767,8 +11767,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.935Z",
-        "time": 93,
+        "startedDateTime": "2024-12-04T16:32:05.947Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11776,7 +11776,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 93
+          "wait": 90
         }
       },
       {
@@ -11797,15 +11797,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11862,7 +11862,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11898,11 +11898,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -11927,8 +11927,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.034Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:06.041Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11936,7 +11936,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 79
         }
       },
       {
@@ -11957,15 +11957,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12022,7 +12022,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12058,11 +12058,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -12087,8 +12087,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.174Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:06.208Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12096,7 +12096,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 65
         }
       },
       {
@@ -12117,15 +12117,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12182,7 +12182,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12218,11 +12218,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -12247,8 +12247,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.250Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:06.277Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12256,7 +12256,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 80
         }
       },
       {
@@ -12277,15 +12277,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12342,7 +12342,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12378,11 +12378,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -12407,8 +12407,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.324Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:06.362Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12416,7 +12416,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 81
         }
       },
       {
@@ -12437,15 +12437,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12502,7 +12502,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12538,11 +12538,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -12567,8 +12567,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.399Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:32:06.448Z",
+        "time": 71,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12576,7 +12576,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 71
         }
       },
       {
@@ -12597,15 +12597,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12662,7 +12662,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12698,11 +12698,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -12727,8 +12727,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.480Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:32:06.524Z",
+        "time": 67,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12736,7 +12736,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 67
         }
       },
       {
@@ -12757,15 +12757,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12822,7 +12822,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12858,11 +12858,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -12887,8 +12887,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.566Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:06.597Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12896,7 +12896,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 72
         }
       },
       {
@@ -12917,15 +12917,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12982,7 +12982,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13018,11 +13018,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -13047,8 +13047,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.642Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:06.673Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13056,7 +13056,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 64
         }
       },
       {
@@ -13077,15 +13077,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13142,7 +13142,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13178,11 +13178,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -13207,8 +13207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.719Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:32:06.741Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13216,7 +13216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 69
         }
       },
       {
@@ -13237,15 +13237,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13302,7 +13302,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13338,11 +13338,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -13367,8 +13367,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.072Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:06.869Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13376,7 +13376,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 73
         }
       },
       {
@@ -13397,15 +13397,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13462,7 +13462,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13498,11 +13498,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -13527,8 +13527,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.147Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:06.947Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13536,7 +13536,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 78
         }
       },
       {
@@ -13557,15 +13557,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13622,7 +13622,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13658,11 +13658,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -13687,8 +13687,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.224Z",
-        "time": 90,
+        "startedDateTime": "2024-12-04T16:32:07.029Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13696,7 +13696,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 90
+          "wait": 85
         }
       },
       {
@@ -13717,15 +13717,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13782,7 +13782,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13818,11 +13818,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -13847,8 +13847,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.319Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:07.120Z",
+        "time": 102,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13856,7 +13856,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 102
         }
       },
       {
@@ -13877,15 +13877,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13942,7 +13942,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13978,11 +13978,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -14007,8 +14007,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.396Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:07.226Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14016,7 +14016,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 68
         }
       },
       {
@@ -14037,15 +14037,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14102,7 +14102,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14138,11 +14138,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -14167,8 +14167,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.471Z",
-        "time": 82,
+        "startedDateTime": "2024-12-04T16:32:07.299Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14176,7 +14176,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 82
+          "wait": 75
         }
       },
       {
@@ -14197,15 +14197,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14262,7 +14262,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14298,11 +14298,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -14327,8 +14327,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.558Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:07.378Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14336,7 +14336,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 65
         }
       },
       {
@@ -14357,15 +14357,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14422,7 +14422,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14458,11 +14458,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -14487,8 +14487,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.636Z",
-        "time": 79,
+        "startedDateTime": "2024-12-04T16:32:07.449Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14496,7 +14496,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 79
+          "wait": 68
         }
       },
       {
@@ -14517,15 +14517,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14582,7 +14582,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14618,11 +14618,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -14647,8 +14647,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.721Z",
-        "time": 95,
+        "startedDateTime": "2024-12-04T16:32:07.522Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14656,7 +14656,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 95
+          "wait": 74
         }
       },
       {
@@ -14677,15 +14677,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14742,7 +14742,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14778,11 +14778,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -14807,8 +14807,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.820Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:07.601Z",
+        "time": 67,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14816,15 +14816,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 67
         }
       },
       {
-        "_id": "9cf0243aa28aad2f8450fabb17eae4a7",
+        "_id": "ecc5b4f2eb12840cf634a5faa3ca5784",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 689,
+          "bodySize": 681,
           "cookies": [],
           "headers": [
             {
@@ -14837,11 +14837,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -14853,7 +14853,7 @@
             },
             {
               "name": "content-length",
-              "value": "689"
+              "value": "681"
             },
             {
               "name": "accept-encoding",
@@ -14870,17 +14870,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set the same shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"shared\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnc2hhcmVkVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2hhcmVkIGFjcm9zcyBhbGwgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIGxhc3Qgc2V0LicpO1xufSgpKTtcbiI=\"}"
+            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set the same shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"shared\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdzaGFyZWRWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzaGFyZWQgYWNyb3NzIGFsbCBuZXN0ZWQgam91cm5leXMuIEl0IGNvbnRhaW5zIGFuIGluZGljYXRvciBpbiB3aGljaCBsZXZlbCBpdCB3YXMgbGFzdCBzZXQuJyk7Cn0oKSk7Cg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/1b52a7e0-4019-40fa-958a-15a49870e901"
         },
         "response": {
-          "bodySize": 757,
+          "bodySize": 749,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 757,
-            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"name\":\"shared\",\"description\":\"set the same shared state variable\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnc2hhcmVkVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2hhcmVkIGFjcm9zcyBhbGwgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIGxhc3Qgc2V0LicpO1xufSgpKTtcbiI=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574337939,\"evaluatorVersion\":\"1.0\"}"
+            "size": 749,
+            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"name\":\"shared\",\"description\":\"set the same shared state variable\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdzaGFyZWRWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzaGFyZWQgYWNyb3NzIGFsbCBuZXN0ZWQgam91cm5leXMuIEl0IGNvbnRhaW5zIGFuIGluZGljYXRvciBpbiB3aGljaCBsZXZlbCBpdCB3YXMgbGFzdCBzZXQuJyk7Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329927731,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -14930,15 +14930,15 @@
             },
             {
               "name": "content-length",
-              "value": "757"
+              "value": "749"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -14963,8 +14963,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.894Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:07.673Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14972,15 +14972,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 81
         }
       },
       {
-        "_id": "589bc3213af463279e35284f3ac342ba",
+        "_id": "124e3260c3d3bd1d675f6cb1e5813068",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 3335,
+          "bodySize": 3171,
           "cookies": [],
           "headers": [
             {
@@ -14993,11 +14993,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -15009,7 +15009,7 @@
             },
             {
               "name": "content-length",
-              "value": "3335"
+              "value": "3171"
             },
             {
               "name": "accept-encoding",
@@ -15026,17 +15026,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Display sharedState, transientState, and headers.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"debug\",\"script\":\"Ii8qIGRlYnVnXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBEaXNwbGF5IHNoYXJlZFN0YXRlLCB0cmFuc2llbnRTdGF0ZSwgYW5kIGhlYWRlcnMuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gdHJ1ZVxuICovXG52YXIgYW5jaG9yID0gXCJhbmNob3ItXCIuY29uY2F0KGdlbmVyYXRlTnVtZXJpY1Rva2VuKCd4eHgnKSk7XG52YXIgaGFsaWduID0gXCJsZWZ0XCI7XG52YXIgbWVzc2FnZSA9IFwiPHA+PGI+U2hhcmVkIFN0YXRlPC9iPjo8YnIvPlwiLmNvbmNhdChcbiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdChcIjwvcD5cIikuY29uY2F0KFxuICAgIFwiPHA+PGI+VHJhbnNpZW50IFN0YXRlPC9iPjo8YnIvPlwiKS5jb25jYXQoXG4gICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoXCI8L3A+XCIpLmNvbmNhdChcbiAgICBcIjxwPjxiPlJlcXVlc3QgSGVhZGVyczwvYj46PGJyLz5cIikuY29uY2F0KFxuICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KFwiPC9wPlwiKVxudmFyIHNjcmlwdCA9IFwiQXJyYXkucHJvdG90eXBlLnNsaWNlLmNhbGwoXFxuXCIuY29uY2F0KFxuICBcImRvY3VtZW50LmdldEVsZW1lbnRzQnlDbGFzc05hbWUoJ2NhbGxiYWNrLWNvbXBvbmVudCcpKS5mb3JFYWNoKFxcblwiKS5jb25jYXQoXG4gIFwiZnVuY3Rpb24gKGUpIHtcXG5cIikuY29uY2F0KFxuICBcIiAgdmFyIG1lc3NhZ2UgPSBlLmZpcnN0RWxlbWVudENoaWxkO1xcblwiKS5jb25jYXQoXG4gIFwiICBpZiAobWVzc2FnZS5maXJzdENoaWxkICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlTmFtZSA9PSAnI3RleHQnICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlVmFsdWUudHJpbSgpID09ICdcIikuY29uY2F0KGFuY2hvcikuY29uY2F0KFwiJykge1xcblwiKS5jb25jYXQoXG4gIFwiICAgIG1lc3NhZ2UuY2xhc3NOYW1lID0gXFxcInRleHQtbGVmdFxcXCI7XFxuXCIpLmNvbmNhdChcbiAgXCIgICAgbWVzc2FnZS5hbGlnbiA9IFxcXCJcIikuY29uY2F0KGhhbGlnbikuY29uY2F0KFwiXFxcIjtcXG5cIikuY29uY2F0KFxuICBcIiAgICBtZXNzYWdlLmlubmVySFRNTCA9ICdcIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdChcIic7XFxuXCIpLmNvbmNhdChcbiAgXCIgIH1cXG5cIikuY29uY2F0KFxuICBcIn0pXCIpXG52YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sXG4gICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5UZXh0T3V0cHV0Q2FsbGJhY2ssXG4gICAgY29tLnN1bi5pZGVudGl0eS5hdXRoZW50aWNhdGlvbi5jYWxsYmFja3MuU2NyaXB0VGV4dE91dHB1dENhbGxiYWNrXG4pXG5pZiAobWVzc2FnZS5sZW5ndGggJiYgY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFxuICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKFxuICAgICAgICAgICAgZnIuVGV4dE91dHB1dENhbGxiYWNrLklORk9STUFUSU9OLFxuICAgICAgICAgICAgYW5jaG9yXG4gICAgICAgICksXG4gICAgICAgIG5ldyBmci5TY3JpcHRUZXh0T3V0cHV0Q2FsbGJhY2soc2NyaXB0KVxuICAgICkuYnVpbGQoKVxufVxuZWxzZSB7XG4gIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKFwidHJ1ZVwiKS5idWlsZCgpO1xufVxuXG4gLypcbiAgKiBHZW5lcmF0ZSBhIHRva2VuIGluIHRoZSBkZXNpcmVkIGZvcm1hdC4gQWxsICd4JyBjaGFyYWN0ZXJzIHdpbGwgYmUgcmVwbGFjZWQgd2l0aCBhIHJhbmRvbSBudW1iZXIgMC05LlxuICAqIFxuICAqIEV4YW1wbGU6XG4gICogJ3h4eHh4JyBwcm9kdWNlcyAnMjg1MzUnXG4gICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJ1xuICAqL1xuZnVuY3Rpb24gZ2VuZXJhdGVOdW1lcmljVG9rZW4oZm9ybWF0KSB7XG4gICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykge1xuICAgICAgICB2YXIgciA9IE1hdGgucmFuZG9tKCkqMTB8MDtcbiAgICAgICAgdmFyIHYgPSByO1xuICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7XG4gICAgfSk7XG59XG4i\"}"
+            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Display sharedState, transientState, and headers.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"debug\",\"script\":\"LyogZGVidWcKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogRGlzcGxheSBzaGFyZWRTdGF0ZSwgdHJhbnNpZW50U3RhdGUsIGFuZCBoZWFkZXJzLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSB0cnVlCiAqLwp2YXIgYW5jaG9yID0gImFuY2hvci0iLmNvbmNhdChnZW5lcmF0ZU51bWVyaWNUb2tlbigneHh4JykpOwp2YXIgaGFsaWduID0gImxlZnQiOwp2YXIgbWVzc2FnZSA9ICI8cD48Yj5TaGFyZWQgU3RhdGU8L2I+Ojxici8+Ii5jb25jYXQoCiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdCgiPC9wPiIpLmNvbmNhdCgKICAgICI8cD48Yj5UcmFuc2llbnQgU3RhdGU8L2I+Ojxici8+IikuY29uY2F0KAogICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoIjwvcD4iKS5jb25jYXQoCiAgICAiPHA+PGI+UmVxdWVzdCBIZWFkZXJzPC9iPjo8YnIvPiIpLmNvbmNhdCgKICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KCI8L3A+IikKdmFyIHNjcmlwdCA9ICJBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbChcbiIuY29uY2F0KAogICJkb2N1bWVudC5nZXRFbGVtZW50c0J5Q2xhc3NOYW1lKCdjYWxsYmFjay1jb21wb25lbnQnKSkuZm9yRWFjaChcbiIpLmNvbmNhdCgKICAiZnVuY3Rpb24gKGUpIHtcbiIpLmNvbmNhdCgKICAiICB2YXIgbWVzc2FnZSA9IGUuZmlyc3RFbGVtZW50Q2hpbGQ7XG4iKS5jb25jYXQoCiAgIiAgaWYgKG1lc3NhZ2UuZmlyc3RDaGlsZCAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZU5hbWUgPT0gJyN0ZXh0JyAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZVZhbHVlLnRyaW0oKSA9PSAnIikuY29uY2F0KGFuY2hvcikuY29uY2F0KCInKSB7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmNsYXNzTmFtZSA9IFwidGV4dC1sZWZ0XCI7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmFsaWduID0gXCIiKS5jb25jYXQoaGFsaWduKS5jb25jYXQoIlwiO1xuIikuY29uY2F0KAogICIgICAgbWVzc2FnZS5pbm5lckhUTUwgPSAnIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdCgiJztcbiIpLmNvbmNhdCgKICAiICB9XG4iKS5jb25jYXQoCiAgIn0pIikKdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKICAgIGNvbS5zdW4uaWRlbnRpdHkuYXV0aGVudGljYXRpb24uY2FsbGJhY2tzLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjawopCmlmIChtZXNzYWdlLmxlbmd0aCAmJiBjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICBhY3Rpb24gPSBmci5BY3Rpb24uc2VuZCgKICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKAogICAgICAgICAgICBmci5UZXh0T3V0cHV0Q2FsbGJhY2suSU5GT1JNQVRJT04sCiAgICAgICAgICAgIGFuY2hvcgogICAgICAgICksCiAgICAgICAgbmV3IGZyLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjayhzY3JpcHQpCiAgICApLmJ1aWxkKCkKfQplbHNlIHsKICBhY3Rpb24gPSBmci5BY3Rpb24uZ29UbygidHJ1ZSIpLmJ1aWxkKCk7Cn0KCiAvKgogICogR2VuZXJhdGUgYSB0b2tlbiBpbiB0aGUgZGVzaXJlZCBmb3JtYXQuIEFsbCAneCcgY2hhcmFjdGVycyB3aWxsIGJlIHJlcGxhY2VkIHdpdGggYSByYW5kb20gbnVtYmVyIDAtOS4KICAqIAogICogRXhhbXBsZToKICAqICd4eHh4eCcgcHJvZHVjZXMgJzI4NTM1JwogICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJwogICovCmZ1bmN0aW9uIGdlbmVyYXRlTnVtZXJpY1Rva2VuKGZvcm1hdCkgewogICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykgewogICAgICAgIHZhciByID0gTWF0aC5yYW5kb20oKSoxMHwwOwogICAgICAgIHZhciB2ID0gcjsKICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7CiAgICB9KTsKfQo=\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/3cb43516-ae69-433a-8787-501d45db14e9"
         },
         "response": {
-          "bodySize": 3403,
+          "bodySize": 3239,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3403,
-            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"name\":\"debug\",\"description\":\"Display sharedState, transientState, and headers.\",\"script\":\"Ii8qIGRlYnVnXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBEaXNwbGF5IHNoYXJlZFN0YXRlLCB0cmFuc2llbnRTdGF0ZSwgYW5kIGhlYWRlcnMuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gdHJ1ZVxuICovXG52YXIgYW5jaG9yID0gXCJhbmNob3ItXCIuY29uY2F0KGdlbmVyYXRlTnVtZXJpY1Rva2VuKCd4eHgnKSk7XG52YXIgaGFsaWduID0gXCJsZWZ0XCI7XG52YXIgbWVzc2FnZSA9IFwiPHA+PGI+U2hhcmVkIFN0YXRlPC9iPjo8YnIvPlwiLmNvbmNhdChcbiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdChcIjwvcD5cIikuY29uY2F0KFxuICAgIFwiPHA+PGI+VHJhbnNpZW50IFN0YXRlPC9iPjo8YnIvPlwiKS5jb25jYXQoXG4gICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoXCI8L3A+XCIpLmNvbmNhdChcbiAgICBcIjxwPjxiPlJlcXVlc3QgSGVhZGVyczwvYj46PGJyLz5cIikuY29uY2F0KFxuICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KFwiPC9wPlwiKVxudmFyIHNjcmlwdCA9IFwiQXJyYXkucHJvdG90eXBlLnNsaWNlLmNhbGwoXFxuXCIuY29uY2F0KFxuICBcImRvY3VtZW50LmdldEVsZW1lbnRzQnlDbGFzc05hbWUoJ2NhbGxiYWNrLWNvbXBvbmVudCcpKS5mb3JFYWNoKFxcblwiKS5jb25jYXQoXG4gIFwiZnVuY3Rpb24gKGUpIHtcXG5cIikuY29uY2F0KFxuICBcIiAgdmFyIG1lc3NhZ2UgPSBlLmZpcnN0RWxlbWVudENoaWxkO1xcblwiKS5jb25jYXQoXG4gIFwiICBpZiAobWVzc2FnZS5maXJzdENoaWxkICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlTmFtZSA9PSAnI3RleHQnICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlVmFsdWUudHJpbSgpID09ICdcIikuY29uY2F0KGFuY2hvcikuY29uY2F0KFwiJykge1xcblwiKS5jb25jYXQoXG4gIFwiICAgIG1lc3NhZ2UuY2xhc3NOYW1lID0gXFxcInRleHQtbGVmdFxcXCI7XFxuXCIpLmNvbmNhdChcbiAgXCIgICAgbWVzc2FnZS5hbGlnbiA9IFxcXCJcIikuY29uY2F0KGhhbGlnbikuY29uY2F0KFwiXFxcIjtcXG5cIikuY29uY2F0KFxuICBcIiAgICBtZXNzYWdlLmlubmVySFRNTCA9ICdcIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdChcIic7XFxuXCIpLmNvbmNhdChcbiAgXCIgIH1cXG5cIikuY29uY2F0KFxuICBcIn0pXCIpXG52YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sXG4gICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5UZXh0T3V0cHV0Q2FsbGJhY2ssXG4gICAgY29tLnN1bi5pZGVudGl0eS5hdXRoZW50aWNhdGlvbi5jYWxsYmFja3MuU2NyaXB0VGV4dE91dHB1dENhbGxiYWNrXG4pXG5pZiAobWVzc2FnZS5sZW5ndGggJiYgY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFxuICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKFxuICAgICAgICAgICAgZnIuVGV4dE91dHB1dENhbGxiYWNrLklORk9STUFUSU9OLFxuICAgICAgICAgICAgYW5jaG9yXG4gICAgICAgICksXG4gICAgICAgIG5ldyBmci5TY3JpcHRUZXh0T3V0cHV0Q2FsbGJhY2soc2NyaXB0KVxuICAgICkuYnVpbGQoKVxufVxuZWxzZSB7XG4gIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKFwidHJ1ZVwiKS5idWlsZCgpO1xufVxuXG4gLypcbiAgKiBHZW5lcmF0ZSBhIHRva2VuIGluIHRoZSBkZXNpcmVkIGZvcm1hdC4gQWxsICd4JyBjaGFyYWN0ZXJzIHdpbGwgYmUgcmVwbGFjZWQgd2l0aCBhIHJhbmRvbSBudW1iZXIgMC05LlxuICAqIFxuICAqIEV4YW1wbGU6XG4gICogJ3h4eHh4JyBwcm9kdWNlcyAnMjg1MzUnXG4gICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJ1xuICAqL1xuZnVuY3Rpb24gZ2VuZXJhdGVOdW1lcmljVG9rZW4oZm9ybWF0KSB7XG4gICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykge1xuICAgICAgICB2YXIgciA9IE1hdGgucmFuZG9tKCkqMTB8MDtcbiAgICAgICAgdmFyIHYgPSByO1xuICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7XG4gICAgfSk7XG59XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574338026,\"evaluatorVersion\":\"1.0\"}"
+            "size": 3239,
+            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"name\":\"debug\",\"description\":\"Display sharedState, transientState, and headers.\",\"script\":\"LyogZGVidWcKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogRGlzcGxheSBzaGFyZWRTdGF0ZSwgdHJhbnNpZW50U3RhdGUsIGFuZCBoZWFkZXJzLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSB0cnVlCiAqLwp2YXIgYW5jaG9yID0gImFuY2hvci0iLmNvbmNhdChnZW5lcmF0ZU51bWVyaWNUb2tlbigneHh4JykpOwp2YXIgaGFsaWduID0gImxlZnQiOwp2YXIgbWVzc2FnZSA9ICI8cD48Yj5TaGFyZWQgU3RhdGU8L2I+Ojxici8+Ii5jb25jYXQoCiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdCgiPC9wPiIpLmNvbmNhdCgKICAgICI8cD48Yj5UcmFuc2llbnQgU3RhdGU8L2I+Ojxici8+IikuY29uY2F0KAogICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoIjwvcD4iKS5jb25jYXQoCiAgICAiPHA+PGI+UmVxdWVzdCBIZWFkZXJzPC9iPjo8YnIvPiIpLmNvbmNhdCgKICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KCI8L3A+IikKdmFyIHNjcmlwdCA9ICJBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbChcbiIuY29uY2F0KAogICJkb2N1bWVudC5nZXRFbGVtZW50c0J5Q2xhc3NOYW1lKCdjYWxsYmFjay1jb21wb25lbnQnKSkuZm9yRWFjaChcbiIpLmNvbmNhdCgKICAiZnVuY3Rpb24gKGUpIHtcbiIpLmNvbmNhdCgKICAiICB2YXIgbWVzc2FnZSA9IGUuZmlyc3RFbGVtZW50Q2hpbGQ7XG4iKS5jb25jYXQoCiAgIiAgaWYgKG1lc3NhZ2UuZmlyc3RDaGlsZCAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZU5hbWUgPT0gJyN0ZXh0JyAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZVZhbHVlLnRyaW0oKSA9PSAnIikuY29uY2F0KGFuY2hvcikuY29uY2F0KCInKSB7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmNsYXNzTmFtZSA9IFwidGV4dC1sZWZ0XCI7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmFsaWduID0gXCIiKS5jb25jYXQoaGFsaWduKS5jb25jYXQoIlwiO1xuIikuY29uY2F0KAogICIgICAgbWVzc2FnZS5pbm5lckhUTUwgPSAnIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdCgiJztcbiIpLmNvbmNhdCgKICAiICB9XG4iKS5jb25jYXQoCiAgIn0pIikKdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKICAgIGNvbS5zdW4uaWRlbnRpdHkuYXV0aGVudGljYXRpb24uY2FsbGJhY2tzLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjawopCmlmIChtZXNzYWdlLmxlbmd0aCAmJiBjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICBhY3Rpb24gPSBmci5BY3Rpb24uc2VuZCgKICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKAogICAgICAgICAgICBmci5UZXh0T3V0cHV0Q2FsbGJhY2suSU5GT1JNQVRJT04sCiAgICAgICAgICAgIGFuY2hvcgogICAgICAgICksCiAgICAgICAgbmV3IGZyLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjayhzY3JpcHQpCiAgICApLmJ1aWxkKCkKfQplbHNlIHsKICBhY3Rpb24gPSBmci5BY3Rpb24uZ29UbygidHJ1ZSIpLmJ1aWxkKCk7Cn0KCiAvKgogICogR2VuZXJhdGUgYSB0b2tlbiBpbiB0aGUgZGVzaXJlZCBmb3JtYXQuIEFsbCAneCcgY2hhcmFjdGVycyB3aWxsIGJlIHJlcGxhY2VkIHdpdGggYSByYW5kb20gbnVtYmVyIDAtOS4KICAqIAogICogRXhhbXBsZToKICAqICd4eHh4eCcgcHJvZHVjZXMgJzI4NTM1JwogICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJwogICovCmZ1bmN0aW9uIGdlbmVyYXRlTnVtZXJpY1Rva2VuKGZvcm1hdCkgewogICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykgewogICAgICAgIHZhciByID0gTWF0aC5yYW5kb20oKSoxMHwwOwogICAgICAgIHZhciB2ID0gcjsKICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7CiAgICB9KTsKfQo=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329927815,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -15086,15 +15086,15 @@
             },
             {
               "name": "content-length",
-              "value": "3403"
+              "value": "3239"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -15119,8 +15119,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:17.968Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:07.758Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15128,15 +15128,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 77
         }
       },
       {
-        "_id": "9d93ce8c0cada398e926fde6717de656",
+        "_id": "ea15b364abb396f2b5708090ab733b71",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 709,
+          "bodySize": 697,
           "cookies": [],
           "headers": [
             {
@@ -15149,11 +15149,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -15165,7 +15165,7 @@
             },
             {
               "name": "content-length",
-              "value": "709"
+              "value": "697"
             },
             {
               "name": "accept-encoding",
@@ -15182,17 +15182,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set per level shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"level\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnbGV2ZWwnICsgbGV2ZWwgKyAnVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2V0IGF0IGVhY2ggbGV2ZWwgb2YgdGhlIG5lc3RlZCBqb3VybmV5cy4gSXQgY29udGFpbnMgYW4gaW5kaWNhdG9yIGluIHdoaWNoIGxldmVsIGl0IHdhcyBzZXQuJyk7XG59KCkpO1xuIg==\"}"
+            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set per level shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"level\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdsZXZlbCcgKyBsZXZlbCArICdWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzZXQgYXQgZWFjaCBsZXZlbCBvZiB0aGUgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIHNldC4nKTsKfSgpKTsK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/41c24257-d7fc-4654-8b46-c2666dc5b56d"
         },
         "response": {
-          "bodySize": 777,
+          "bodySize": 765,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 777,
-            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"name\":\"level\",\"description\":\"set per level shared state variable\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnbGV2ZWwnICsgbGV2ZWwgKyAnVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2V0IGF0IGVhY2ggbGV2ZWwgb2YgdGhlIG5lc3RlZCBqb3VybmV5cy4gSXQgY29udGFpbnMgYW4gaW5kaWNhdG9yIGluIHdoaWNoIGxldmVsIGl0IHdhcyBzZXQuJyk7XG59KCkpO1xuIg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574338100,\"evaluatorVersion\":\"1.0\"}"
+            "size": 765,
+            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"name\":\"level\",\"description\":\"set per level shared state variable\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdsZXZlbCcgKyBsZXZlbCArICdWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzZXQgYXQgZWFjaCBsZXZlbCBvZiB0aGUgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIHNldC4nKTsKfSgpKTsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329927889,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -15242,15 +15242,15 @@
             },
             {
               "name": "content-length",
-              "value": "777"
+              "value": "765"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -15275,8 +15275,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.050Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:07.839Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15284,15 +15284,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 70
         }
       },
       {
-        "_id": "9f6c4ef1a2f56dd677351662221cc6bf",
+        "_id": "d367dbb7190523aee15f268dccbe87af",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2016,
+          "bodySize": 1960,
           "cookies": [],
           "headers": [
             {
@@ -15305,11 +15305,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -15321,7 +15321,7 @@
             },
             {
               "name": "content-length",
-              "value": "2016"
+              "value": "1960"
             },
             {
               "name": "accept-encoding",
@@ -15338,17 +15338,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if mode has already been set.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"mode\",\"script\":\"Ii8qIG1vZGVcbiAqXG4gKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tXG4gKiBcbiAqIENvbGxlY3QgbW9kZSBpZiBub3QgYWxyZWFkeSBzZXQgYW5kIHNldCBvdXRjb21lIHRvIG1vZGUuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gJ3NoYXJlZCBhbmQgbGV2ZWwnXG4gKiAtICdzaGFyZWQgb25seSdcbiAqIC0gJ2xldmVsIG9ubHknXG4gKiAtICdub25lJ1xuICovXG4oZnVuY3Rpb24gKCkge1xuICB2YXIgbW9kZSA9IG5vZGVTdGF0ZS5nZXQoJ21vZGUnKTtcbiAgaWYgKG1vZGUpIHtcbiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpO1xuICAgIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCkgKyAxO1xuICAgIGxvZ2dlci5lcnJvcignbW9kZTogbW9kZT0nICsgbW9kZS5hc1N0cmluZygpICsgJywgbGV2ZWw9JyArIGxldmVsKTtcbiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpO1xuICB9XG4gIGVsc2Uge1xuICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddO1xuICBcbiAgICB2YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbixcbiAgICAgIGphdmF4LnNlY3VyaXR5LmF1dGguY2FsbGJhY2suQ2hvaWNlQ2FsbGJhY2tcbiAgICApXG5cbiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQoW1xuICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSlcbiAgICAgIF0pLmJ1aWxkKCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTtcbiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ21vZGUnLCBjaG9pY2VzW2Nob2ljZV0pO1xuICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbGV2ZWwnLCAwKTtcbiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTtcbiAgICB9XG4gIH1cbn0oKSk7XG4i\"}"
+            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if mode has already been set.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"mode\",\"script\":\"LyogbW9kZQogKgogKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tCiAqIAogKiBDb2xsZWN0IG1vZGUgaWYgbm90IGFscmVhZHkgc2V0IGFuZCBzZXQgb3V0Y29tZSB0byBtb2RlLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSAnc2hhcmVkIGFuZCBsZXZlbCcKICogLSAnc2hhcmVkIG9ubHknCiAqIC0gJ2xldmVsIG9ubHknCiAqIC0gJ25vbmUnCiAqLwooZnVuY3Rpb24gKCkgewogIHZhciBtb2RlID0gbm9kZVN0YXRlLmdldCgnbW9kZScpOwogIGlmIChtb2RlKSB7CiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpOwogICAgdmFyIGxldmVsID0gbm9kZVN0YXRlLmdldCgnbGV2ZWwnKS5hc0ludGVnZXIoKSArIDE7CiAgICBsb2dnZXIuZXJyb3IoJ21vZGU6IG1vZGU9JyArIG1vZGUuYXNTdHJpbmcoKSArICcsIGxldmVsPScgKyBsZXZlbCk7CiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpOwogIH0KICBlbHNlIHsKICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddOwogIAogICAgdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbiwKICAgICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5DaG9pY2VDYWxsYmFjawogICAgKQoKICAgIGlmIChjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFsKICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSkKICAgICAgXSkuYnVpbGQoKTsKICAgIH0gZWxzZSB7CiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTsKICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbW9kZScsIGNob2ljZXNbY2hvaWNlXSk7CiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ2xldmVsJywgMCk7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTsKICAgIH0KICB9Cn0oKSk7Cg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/5bbdaeff-ddee-44b9-b608-8d413d7d65a6"
         },
         "response": {
-          "bodySize": 2084,
+          "bodySize": 2028,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 2084,
-            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"name\":\"mode\",\"description\":\"Check if mode has already been set.\",\"script\":\"Ii8qIG1vZGVcbiAqXG4gKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tXG4gKiBcbiAqIENvbGxlY3QgbW9kZSBpZiBub3QgYWxyZWFkeSBzZXQgYW5kIHNldCBvdXRjb21lIHRvIG1vZGUuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gJ3NoYXJlZCBhbmQgbGV2ZWwnXG4gKiAtICdzaGFyZWQgb25seSdcbiAqIC0gJ2xldmVsIG9ubHknXG4gKiAtICdub25lJ1xuICovXG4oZnVuY3Rpb24gKCkge1xuICB2YXIgbW9kZSA9IG5vZGVTdGF0ZS5nZXQoJ21vZGUnKTtcbiAgaWYgKG1vZGUpIHtcbiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpO1xuICAgIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCkgKyAxO1xuICAgIGxvZ2dlci5lcnJvcignbW9kZTogbW9kZT0nICsgbW9kZS5hc1N0cmluZygpICsgJywgbGV2ZWw9JyArIGxldmVsKTtcbiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpO1xuICB9XG4gIGVsc2Uge1xuICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddO1xuICBcbiAgICB2YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbixcbiAgICAgIGphdmF4LnNlY3VyaXR5LmF1dGguY2FsbGJhY2suQ2hvaWNlQ2FsbGJhY2tcbiAgICApXG5cbiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQoW1xuICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSlcbiAgICAgIF0pLmJ1aWxkKCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTtcbiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ21vZGUnLCBjaG9pY2VzW2Nob2ljZV0pO1xuICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbGV2ZWwnLCAwKTtcbiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTtcbiAgICB9XG4gIH1cbn0oKSk7XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574338172,\"evaluatorVersion\":\"1.0\"}"
+            "size": 2028,
+            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"name\":\"mode\",\"description\":\"Check if mode has already been set.\",\"script\":\"LyogbW9kZQogKgogKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tCiAqIAogKiBDb2xsZWN0IG1vZGUgaWYgbm90IGFscmVhZHkgc2V0IGFuZCBzZXQgb3V0Y29tZSB0byBtb2RlLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSAnc2hhcmVkIGFuZCBsZXZlbCcKICogLSAnc2hhcmVkIG9ubHknCiAqIC0gJ2xldmVsIG9ubHknCiAqIC0gJ25vbmUnCiAqLwooZnVuY3Rpb24gKCkgewogIHZhciBtb2RlID0gbm9kZVN0YXRlLmdldCgnbW9kZScpOwogIGlmIChtb2RlKSB7CiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpOwogICAgdmFyIGxldmVsID0gbm9kZVN0YXRlLmdldCgnbGV2ZWwnKS5hc0ludGVnZXIoKSArIDE7CiAgICBsb2dnZXIuZXJyb3IoJ21vZGU6IG1vZGU9JyArIG1vZGUuYXNTdHJpbmcoKSArICcsIGxldmVsPScgKyBsZXZlbCk7CiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpOwogIH0KICBlbHNlIHsKICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddOwogIAogICAgdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbiwKICAgICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5DaG9pY2VDYWxsYmFjawogICAgKQoKICAgIGlmIChjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFsKICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSkKICAgICAgXSkuYnVpbGQoKTsKICAgIH0gZWxzZSB7CiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTsKICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbW9kZScsIGNob2ljZXNbY2hvaWNlXSk7CiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ2xldmVsJywgMCk7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTsKICAgIH0KICB9Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329927961,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -15398,15 +15398,15 @@
             },
             {
               "name": "content-length",
-              "value": "2084"
+              "value": "2028"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:07 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -15431,8 +15431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.123Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:07.914Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15440,7 +15440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 66
         }
       },
       {
@@ -15461,15 +15461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -15526,7 +15526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -15562,11 +15562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -15591,8 +15591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.200Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:07.984Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15600,7 +15600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 66
         }
       },
       {
@@ -15621,15 +15621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -15686,7 +15686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -15722,11 +15722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -15751,8 +15751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.283Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:32:08.056Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15760,7 +15760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 68
         }
       },
       {
@@ -15781,15 +15781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -15846,7 +15846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -15882,11 +15882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -15911,8 +15911,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.371Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:08.130Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15920,7 +15920,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 70
         }
       },
       {
@@ -15941,15 +15941,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16006,7 +16006,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16042,11 +16042,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -16071,7 +16071,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.442Z",
+        "startedDateTime": "2024-12-04T16:32:08.205Z",
         "time": 69,
         "timings": {
           "blocked": -1,
@@ -16101,15 +16101,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16166,7 +16166,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16202,11 +16202,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -16231,8 +16231,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.515Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:08.279Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16240,7 +16240,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 70
         }
       },
       {
@@ -16261,15 +16261,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16326,7 +16326,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16362,11 +16362,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -16391,8 +16391,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.587Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:08.354Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16400,7 +16400,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 74
         }
       },
       {
@@ -16421,15 +16421,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16486,7 +16486,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16522,11 +16522,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -16551,8 +16551,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.658Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:32:08.433Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16560,7 +16560,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 68
         }
       },
       {
@@ -16581,15 +16581,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16646,7 +16646,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16682,11 +16682,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -16711,8 +16711,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:18.938Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:08.732Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16720,7 +16720,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 72
         }
       },
       {
@@ -16741,15 +16741,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16806,7 +16806,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16842,11 +16842,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -16871,8 +16871,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.014Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:08.808Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16880,7 +16880,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 79
         }
       },
       {
@@ -16901,15 +16901,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16966,7 +16966,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17002,11 +17002,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -17031,8 +17031,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.088Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:08.891Z",
+        "time": 97,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17040,7 +17040,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 97
         }
       },
       {
@@ -17061,15 +17061,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17126,7 +17126,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17162,11 +17162,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -17191,8 +17191,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.164Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:32:08.992Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17200,7 +17200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 78
         }
       },
       {
@@ -17221,15 +17221,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17286,7 +17286,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17322,11 +17322,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -17351,8 +17351,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.243Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:09.074Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17360,7 +17360,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 75
         }
       },
       {
@@ -17381,15 +17381,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17446,7 +17446,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17482,11 +17482,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -17511,8 +17511,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.317Z",
-        "time": 63,
+        "startedDateTime": "2024-12-04T16:32:09.153Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17520,7 +17520,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 63
+          "wait": 77
         }
       },
       {
@@ -17541,15 +17541,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17606,7 +17606,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17642,11 +17642,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -17671,8 +17671,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.385Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:09.236Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17680,7 +17680,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 80
         }
       },
       {
@@ -17701,15 +17701,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17766,7 +17766,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17802,11 +17802,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -17831,8 +17831,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.670Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:09.535Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17840,7 +17840,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 65
         }
       },
       {
@@ -17861,15 +17861,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17926,7 +17926,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17962,11 +17962,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -17991,8 +17991,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.745Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:09.604Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18000,7 +18000,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 93
         }
       },
       {
@@ -18021,15 +18021,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18086,7 +18086,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18122,11 +18122,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -18151,8 +18151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.819Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:32:09.703Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18160,7 +18160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 68
         }
       },
       {
@@ -18181,15 +18181,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18246,7 +18246,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18282,11 +18282,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -18311,8 +18311,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.899Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:09.776Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18320,7 +18320,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 80
         }
       },
       {
@@ -18341,15 +18341,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18406,7 +18406,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18442,11 +18442,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -18471,8 +18471,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:19.972Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:09.860Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18480,7 +18480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 76
         }
       },
       {
@@ -18501,15 +18501,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18566,7 +18566,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18602,11 +18602,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -18631,8 +18631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.044Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:32:09.941Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18640,7 +18640,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 76
         }
       },
       {
@@ -18661,15 +18661,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18726,7 +18726,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18762,11 +18762,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -18791,8 +18791,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.122Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:10.022Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18800,7 +18800,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 69
         }
       },
       {
@@ -18821,15 +18821,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18886,7 +18886,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18922,11 +18922,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -18951,8 +18951,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.422Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:32:10.308Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18960,7 +18960,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 66
         }
       },
       {
@@ -18981,15 +18981,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19046,7 +19046,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19082,11 +19082,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -19111,8 +19111,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.500Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:10.378Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19120,7 +19120,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 64
         }
       },
       {
@@ -19141,15 +19141,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19206,7 +19206,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19242,11 +19242,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -19271,8 +19271,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.573Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:10.447Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19280,7 +19280,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 72
         }
       },
       {
@@ -19301,15 +19301,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19366,7 +19366,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19402,11 +19402,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -19431,8 +19431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.646Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:32:10.526Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19440,7 +19440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 65
         }
       },
       {
@@ -19461,15 +19461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19526,7 +19526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19562,11 +19562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -19591,8 +19591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.731Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:10.595Z",
+        "time": 67,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19600,7 +19600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 67
         }
       },
       {
@@ -19621,15 +19621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19686,7 +19686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19722,11 +19722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -19751,8 +19751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.806Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:32:10.666Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19760,7 +19760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 76
         }
       },
       {
@@ -19781,15 +19781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19846,7 +19846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19882,11 +19882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:10 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -19911,7 +19911,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:20.883Z",
+        "startedDateTime": "2024-12-04T16:32:10.747Z",
         "time": 66,
         "timings": {
           "blocked": -1,
@@ -19941,15 +19941,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20006,7 +20006,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20042,11 +20042,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -20071,8 +20071,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.170Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:32:11.034Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20080,7 +20080,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 81
         }
       },
       {
@@ -20101,15 +20101,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20166,7 +20166,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20202,11 +20202,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -20231,8 +20231,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.248Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:32:11.121Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20240,7 +20240,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 72
         }
       },
       {
@@ -20261,15 +20261,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20326,7 +20326,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20362,11 +20362,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -20391,8 +20391,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.327Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:11.197Z",
+        "time": 71,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20400,7 +20400,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 71
         }
       },
       {
@@ -20421,15 +20421,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20486,7 +20486,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20522,11 +20522,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -20551,8 +20551,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.401Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:11.272Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20560,7 +20560,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 88
         }
       },
       {
@@ -20581,15 +20581,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20646,7 +20646,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20682,11 +20682,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -20711,8 +20711,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.471Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:11.365Z",
+        "time": 100,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20720,7 +20720,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 100
         }
       },
       {
@@ -20741,15 +20741,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20806,7 +20806,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20842,11 +20842,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -20871,8 +20871,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.542Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:11.470Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20880,7 +20880,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 74
         }
       },
       {
@@ -20901,15 +20901,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20966,7 +20966,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21002,11 +21002,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -21031,7 +21031,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.618Z",
+        "startedDateTime": "2024-12-04T16:32:11.549Z",
         "time": 64,
         "timings": {
           "blocked": -1,
@@ -21061,15 +21061,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21126,7 +21126,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21162,11 +21162,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -21191,8 +21191,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:21.949Z",
-        "time": 85,
+        "startedDateTime": "2024-12-04T16:32:11.848Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21200,7 +21200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 73
         }
       },
       {
@@ -21221,15 +21221,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21286,7 +21286,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21322,11 +21322,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:11 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -21351,8 +21351,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.039Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:11.925Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21360,7 +21360,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 69
         }
       },
       {
@@ -21381,15 +21381,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21446,7 +21446,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21482,11 +21482,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -21511,8 +21511,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.114Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:11.999Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21520,7 +21520,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 72
         }
       },
       {
@@ -21541,15 +21541,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21606,7 +21606,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21642,11 +21642,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -21671,8 +21671,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.188Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:12.075Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21680,7 +21680,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 65
         }
       },
       {
@@ -21701,15 +21701,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21766,7 +21766,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21802,11 +21802,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -21831,8 +21831,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.260Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:12.144Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21840,7 +21840,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 76
         }
       },
       {
@@ -21861,15 +21861,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21926,7 +21926,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21962,11 +21962,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -21991,8 +21991,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.336Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:32:12.223Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22000,7 +22000,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 74
         }
       },
       {
@@ -22021,15 +22021,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22086,7 +22086,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22122,11 +22122,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -22151,8 +22151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.416Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:12.302Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22160,7 +22160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 82
         }
       },
       {
@@ -22181,15 +22181,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22246,7 +22246,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22282,11 +22282,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -22311,8 +22311,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.702Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:12.598Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22320,7 +22320,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 70
         }
       },
       {
@@ -22341,15 +22341,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22406,7 +22406,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22442,11 +22442,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -22471,8 +22471,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.774Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:12.672Z",
+        "time": 96,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22480,7 +22480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 96
         }
       },
       {
@@ -22501,15 +22501,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22566,7 +22566,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22602,11 +22602,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -22631,8 +22631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.850Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:32:12.773Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22640,7 +22640,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 72
         }
       },
       {
@@ -22661,15 +22661,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22726,7 +22726,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22762,11 +22762,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -22791,8 +22791,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:22.931Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:12.850Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22800,7 +22800,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 64
         }
       },
       {
@@ -22821,15 +22821,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22886,7 +22886,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22922,11 +22922,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:12 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -22951,8 +22951,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.007Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:12.919Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22960,7 +22960,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 65
         }
       },
       {
@@ -22981,15 +22981,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23046,7 +23046,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23082,11 +23082,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -23111,8 +23111,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.078Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:12.988Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23120,7 +23120,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 80
         }
       },
       {
@@ -23141,15 +23141,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23206,7 +23206,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23242,11 +23242,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -23271,8 +23271,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.151Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:13.072Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23280,7 +23280,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 70
         }
       },
       {
@@ -23301,15 +23301,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23366,7 +23366,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23402,11 +23402,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -23431,8 +23431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.453Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:13.379Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23440,7 +23440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 77
         }
       },
       {
@@ -23461,15 +23461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23526,7 +23526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23562,11 +23562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -23591,8 +23591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.535Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:32:13.460Z",
+        "time": 62,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23600,7 +23600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 62
         }
       },
       {
@@ -23621,15 +23621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23686,7 +23686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23722,11 +23722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -23751,8 +23751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.614Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:32:13.532Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23760,7 +23760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 72
         }
       },
       {
@@ -23781,15 +23781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23846,7 +23846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23882,11 +23882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -23911,8 +23911,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.691Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:13.608Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23920,7 +23920,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 65
         }
       },
       {
@@ -23941,15 +23941,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24006,7 +24006,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24042,11 +24042,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -24071,8 +24071,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.764Z",
-        "time": 95,
+        "startedDateTime": "2024-12-04T16:32:13.677Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24080,7 +24080,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 95
+          "wait": 83
         }
       },
       {
@@ -24101,15 +24101,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24166,7 +24166,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24202,11 +24202,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -24231,8 +24231,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.863Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:13.765Z",
+        "time": 71,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24240,7 +24240,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 71
         }
       },
       {
@@ -24261,15 +24261,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24326,7 +24326,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24362,11 +24362,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:13 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -24391,8 +24391,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:23.947Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:32:13.841Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24400,7 +24400,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 64
         }
       },
       {
@@ -24421,15 +24421,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24486,7 +24486,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24522,11 +24522,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -24551,8 +24551,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:24.239Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:32:14.131Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24560,7 +24560,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 80
         }
       },
       {
@@ -24581,15 +24581,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24646,7 +24646,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24682,11 +24682,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -24711,8 +24711,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:24.318Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:14.216Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24720,7 +24720,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 73
         }
       },
       {
@@ -24741,15 +24741,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24806,7 +24806,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24842,11 +24842,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -24871,8 +24871,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:24.400Z",
-        "time": 76,
+        "startedDateTime": "2024-12-04T16:32:14.294Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24880,7 +24880,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 75
         }
       },
       {
@@ -24901,15 +24901,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24966,7 +24966,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25002,11 +25002,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -25031,8 +25031,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:24.479Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:32:14.373Z",
+        "time": 67,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25040,7 +25040,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 67
         }
       },
       {
@@ -25061,15 +25061,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25126,7 +25126,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25162,11 +25162,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -25191,8 +25191,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:24.562Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:14.445Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25200,7 +25200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 64
         }
       },
       {
@@ -25221,15 +25221,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25286,7 +25286,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25322,11 +25322,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -25351,8 +25351,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:24.636Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:32:14.514Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25360,7 +25360,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 73
         }
       },
       {
@@ -25381,15 +25381,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25446,7 +25446,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25482,11 +25482,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -25511,8 +25511,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:24.711Z",
-        "time": 151,
+        "startedDateTime": "2024-12-04T16:32:14.591Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25520,7 +25520,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 151
+          "wait": 78
         }
       },
       {
@@ -25541,15 +25541,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25606,7 +25606,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25642,11 +25642,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:14 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -25671,8 +25671,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.072Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:32:14.892Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25680,7 +25680,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 74
         }
       },
       {
@@ -25701,15 +25701,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25766,7 +25766,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25802,11 +25802,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -25831,8 +25831,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.147Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:14.972Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25840,7 +25840,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 64
         }
       },
       {
@@ -25861,15 +25861,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25926,7 +25926,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25962,11 +25962,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -25991,8 +25991,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.219Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:32:15.042Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26000,7 +26000,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 70
         }
       },
       {
@@ -26021,15 +26021,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26086,7 +26086,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26122,11 +26122,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -26151,8 +26151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.297Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:15.116Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26160,7 +26160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 88
         }
       },
       {
@@ -26181,15 +26181,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26246,7 +26246,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26282,11 +26282,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -26311,8 +26311,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.369Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:32:15.208Z",
+        "time": 63,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26320,7 +26320,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 63
         }
       },
       {
@@ -26341,15 +26341,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26406,7 +26406,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26442,11 +26442,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -26471,8 +26471,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.441Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:15.275Z",
+        "time": 63,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26480,7 +26480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 63
         }
       },
       {
@@ -26501,15 +26501,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26566,7 +26566,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26602,11 +26602,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -26631,8 +26631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.511Z",
-        "time": 63,
+        "startedDateTime": "2024-12-04T16:32:15.344Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26640,7 +26640,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 63
+          "wait": 66
         }
       },
       {
@@ -26661,15 +26661,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26726,7 +26726,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26762,11 +26762,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -26791,8 +26791,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.786Z",
-        "time": 108,
+        "startedDateTime": "2024-12-04T16:32:15.643Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26800,7 +26800,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 108
+          "wait": 65
         }
       },
       {
@@ -26821,15 +26821,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26886,7 +26886,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26922,11 +26922,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -26951,8 +26951,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.898Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:15.714Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26960,7 +26960,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 64
         }
       },
       {
@@ -26981,15 +26981,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27046,7 +27046,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27082,11 +27082,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -27111,8 +27111,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:25.969Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:15.783Z",
+        "time": 65,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27120,7 +27120,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 65
         }
       },
       {
@@ -27141,15 +27141,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27206,7 +27206,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27242,11 +27242,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -27271,8 +27271,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:26.045Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:32:15.853Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27280,7 +27280,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 69
         }
       },
       {
@@ -27301,15 +27301,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27366,7 +27366,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27402,11 +27402,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:15 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -27431,8 +27431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:26.116Z",
-        "time": 79,
+        "startedDateTime": "2024-12-04T16:32:15.927Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27440,7 +27440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 79
+          "wait": 72
         }
       },
       {
@@ -27461,15 +27461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27526,7 +27526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27562,11 +27562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:16 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -27591,8 +27591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:26.199Z",
-        "time": 76,
+        "startedDateTime": "2024-12-04T16:32:16.005Z",
+        "time": 62,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27600,7 +27600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 62
         }
       },
       {
@@ -27621,15 +27621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27686,7 +27686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27722,11 +27722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:16 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -27751,8 +27751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:26.279Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:32:16.074Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27760,7 +27760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 64
         }
       },
       {
@@ -27781,15 +27781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27846,7 +27846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27882,11 +27882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:16 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -27911,8 +27911,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:26.357Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:16.141Z",
+        "time": 60,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27920,7 +27920,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 60
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_af_3559436575/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_af_3559436575/oauth2_393036114/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "accept-api-version",
@@ -98,11 +98,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:58 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -127,8 +127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:07.615Z",
-        "time": 91,
+        "startedDateTime": "2024-12-04T16:31:58.801Z",
+        "time": 97,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -136,7 +136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 91
+          "wait": 97
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_af_3559436575/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_af_3559436575/openidm_3290118515/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -66,7 +66,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "cache-control",
@@ -114,7 +114,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -139,8 +139,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:07.743Z",
-        "time": 108,
+        "startedDateTime": "2024-12-04T16:31:58.934Z",
+        "time": 133,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 108
+          "wait": 133
         }
       },
       {
@@ -169,11 +169,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -210,7 +210,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "cache-control",
@@ -258,7 +258,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -283,8 +283,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:07.793Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:58.978Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -292,7 +292,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 77
         }
       },
       {
@@ -313,11 +313,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -362,7 +362,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:07 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:59 GMT"
             },
             {
               "name": "cache-control",
@@ -406,7 +406,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -431,8 +431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:07.955Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:59.153Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -440,7 +440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 75
         }
       },
       {
@@ -461,11 +461,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -510,7 +510,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "cache-control",
@@ -554,7 +554,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -579,8 +579,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.657Z",
-        "time": 62,
+        "startedDateTime": "2024-12-04T16:32:00.531Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -588,7 +588,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 62
+          "wait": 70
         }
       },
       {
@@ -609,11 +609,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -645,7 +645,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "cache-control",
@@ -689,7 +689,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -718,8 +718,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.724Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:32:00.607Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -727,7 +727,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 76
         }
       },
       {
@@ -748,11 +748,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -793,7 +793,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:00 GMT"
             },
             {
               "name": "cache-control",
@@ -837,7 +837,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -866,8 +866,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:09.810Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:32:00.696Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -875,7 +875,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 93
         }
       },
       {
@@ -896,11 +896,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -945,7 +945,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:05 GMT"
             },
             {
               "name": "cache-control",
@@ -989,7 +989,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1014,8 +1014,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:15.200Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:32:05.264Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1023,7 +1023,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 64
         }
       },
       {
@@ -1044,11 +1044,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -1093,7 +1093,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "cache-control",
@@ -1137,7 +1137,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1162,8 +1162,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.105Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:32:06.124Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1171,7 +1171,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 80
         }
       },
       {
@@ -1192,11 +1192,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "authorization",
@@ -1241,7 +1241,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:32:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:32:06 GMT"
             },
             {
               "name": "cache-control",
@@ -1285,7 +1285,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-1e2b71be-e06e-4077-94d2-c0deb6eb7005"
+              "value": "frodo-3123611d-5e04-4acf-b414-2a1b84abc47e"
             },
             {
               "name": "strict-transport-security",
@@ -1310,8 +1310,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:32:16.788Z",
-        "time": 277,
+        "startedDateTime": "2024-12-04T16:32:06.816Z",
+        "time": 47,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1319,7 +1319,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 277
+          "wait": 47
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_af_D_262722764/am_1076162899/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_af_D_262722764/am_1076162899/recording.har
@@ -25,15 +25,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.1"
             },
             {
               "name": "accept-encoding",
@@ -51,11 +51,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
         },
         "response": {
-          "bodySize": 538,
+          "bodySize": 553,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 538,
-            "text": "{\"_id\":\"*\",\"_rev\":\"36966512\",\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
           },
           "cookies": [],
           "headers": [
@@ -77,7 +77,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.1"
             },
             {
               "name": "content-security-policy",
@@ -93,7 +93,7 @@
             },
             {
               "name": "etag",
-              "value": "\"36966512\""
+              "value": "\"1874515102\""
             },
             {
               "name": "expires",
@@ -109,15 +109,15 @@
             },
             {
               "name": "content-length",
-              "value": "538"
+              "value": "553"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -136,14 +136,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 785,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.053Z",
-        "time": 233,
+        "startedDateTime": "2024-12-04T16:31:24.432Z",
+        "time": 91,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -151,7 +151,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 233
+          "wait": 91
         }
       },
       {
@@ -172,11 +172,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -206,7 +206,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 282,
-            "text": "{\"_id\":\"version\",\"_rev\":\"355151460\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 493165657bbb9390016bd43ca767a46f23d8d24a (2024-September-23 14:30)\",\"revision\":\"493165657bbb9390016bd43ca767a46f23d8d24a\",\"date\":\"2024-September-23 14:30\"}"
+            "text": "{\"_id\":\"version\",\"_rev\":\"-1964495080\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 7cab9c08465b06ed66fff4b458eef61d6b6825da (2024-November-15 10:51)\",\"revision\":\"7cab9c08465b06ed66fff4b458eef61d6b6825da\",\"date\":\"2024-November-15 10:51\"}"
           },
           "cookies": [],
           "headers": [
@@ -244,7 +244,7 @@
             },
             {
               "name": "etag",
-              "value": "\"355151460\""
+              "value": "\"-1964495080\""
             },
             {
               "name": "expires",
@@ -264,11 +264,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -287,14 +287,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 786,
+          "headersSize": 788,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.396Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:31:24.635Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -302,7 +302,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 74
         }
       },
       {
@@ -323,15 +323,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -362,7 +362,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 31869,
-            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-501795106\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"description\":\"Reset Password Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"OrphanedTest\",\"_rev\":\"-764260244\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"343e745f-923a-43c4-8675-649a490fd0a3\",\"innerTreeOnly\":false,\"nodes\":{\"343e745f-923a-43c4-8675-649a490fd0a3\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":407.046875,\"y\":190.015625}},\"description\":\"Test orphaned nodes\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":704,\"y\":129},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":707,\"y\":381},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"test\",\"_rev\":\"279923916\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{},\"entryNodeId\":\"d26176be-ea6f-4f2a-81cd-3d41dd6cee4d\",\"innerTreeOnly\":false,\"nodes\":{},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":50,\"y\":117},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":152,\"y\":25},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ForgottenUsername\",\"_rev\":\"1703131230\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":0,\"y\":0},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":0,\"y\":0},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":0,\"y\":0}},\"description\":\"Forgotten Username Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j10\",\"_rev\":\"751431822\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"c91d626e-1156-41bd-b1fb-d292f640fba6\",\"innerTreeOnly\":false,\"nodes\":{\"300feda0-3248-49a9-b60f-01df802b2229\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"40afb384-e9b6-4dcb-acde-04de109474c8\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"8d7d64ee-da20-461f-a2ca-206b7479dd67\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\":{\"connections\":{\"true\":\"8d7d64ee-da20-461f-a2ca-206b7479dd67\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"c91d626e-1156-41bd-b1fb-d292f640fba6\":{\"connections\":{\"level only\":\"300feda0-3248-49a9-b60f-01df802b2229\",\"none\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\",\"shared and level\":\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\",\"shared only\":\"40afb384-e9b6-4dcb-acde-04de109474c8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j01\",\"_rev\":\"-523887030\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"f129f0df-b49e-453b-97fb-db508e3893ce\",\"innerTreeOnly\":false,\"nodes\":{\"6674b4ac-dd89-4e13-9440-6f81194e3a22\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\":{\"connections\":{\"true\":\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"f129f0df-b49e-453b-97fb-db508e3893ce\":{\"connections\":{\"level only\":\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\",\"none\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\",\"shared and level\":\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\",\"shared only\":\"6674b4ac-dd89-4e13-9440-6f81194e3a22\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"UpdatePassword\",\"_rev\":\"-1067190791\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"description\":\"Update password using active session\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j00\",\"_rev\":\"214130857\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\",\"innerTreeOnly\":false,\"nodes\":{\"01d3785f-7fb4-44a7-9458-72c380a9818f\":{\"connections\":{\"true\":\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":348,\"y\":61},\"39b48197-f4be-42b9-800a-866587b4b9b5\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":365,\"y\":252},\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":567,\"y\":64},\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\":{\"connections\":{\"level only\":\"39b48197-f4be-42b9-800a-866587b4b9b5\",\"none\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\",\"shared and level\":\"01d3785f-7fb4-44a7-9458-72c380a9818f\",\"shared only\":\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":117,\"y\":117},\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\":{\"connections\":{\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":760,\"y\":137},\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":338,\"y\":156}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":132,\"y\":364},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":137},\"startNode\":{\"x\":0,\"y\":0}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Login\",\"_rev\":\"-453684268\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"nodes\":{\"2119f332-0f69-4088-a7a1-6582bf0f2001\":{\"connections\":{\"Reject\":\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\",\"Retry\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\"},\"displayName\":\"Retry Limit Decision\",\"nodeType\":\"RetryLimitDecisionNode\",\"x\":612,\"y\":105.015625},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":827,\"y\":13},\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Account Lockout\",\"nodeType\":\"AccountLockoutNode\",\"x\":836,\"y\":184.015625},\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\":{\"connections\":{\"CANCELLED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EXPIRED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"FALSE\":\"2119f332-0f69-4088-a7a1-6582bf0f2001\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":352,\"y\":40.015625},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":579,\"y\":34}},\"description\":\"Platform Login Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1073,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":761,\"y\":401},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j03\",\"_rev\":\"-1352811052\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\",\"innerTreeOnly\":false,\"nodes\":{\"35a4f94b-c895-46b9-bc0a-93cf59233759\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"3a92300d-6d64-451d-8156-30cb51781026\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"6f9de973-9ed4-41f5-b43d-4036041e2b96\":{\"connections\":{\"true\":\"3a92300d-6d64-451d-8156-30cb51781026\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\":{\"connections\":{\"level only\":\"35a4f94b-c895-46b9-bc0a-93cf59233759\",\"none\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\",\"shared and level\":\"6f9de973-9ed4-41f5-b43d-4036041e2b96\",\"shared only\":\"fae7424e-13c9-45bd-b3a2-045773671a3f\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"fae7424e-13c9-45bd-b3a2-045773671a3f\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j02\",\"_rev\":\"2029292005\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"59b06306-a886-443d-92df-7a27a60c394e\",\"innerTreeOnly\":false,\"nodes\":{\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"56899fef-92a1-4f2a-ade3-973c81eb3af1\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"59b06306-a886-443d-92df-7a27a60c394e\":{\"connections\":{\"level only\":\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\",\"none\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\",\"shared and level\":\"e0983ead-4918-48f6-858d-9aff0f03759c\",\"shared only\":\"cbb3d506-b267-4b99-9edd-363e90aac997\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"cbb3d506-b267-4b99-9edd-363e90aac997\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e0983ead-4918-48f6-858d-9aff0f03759c\":{\"connections\":{\"true\":\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j05\",\"_rev\":\"1652057497\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"622179cb-98f1-484a-820d-9a0df6e45e95\",\"innerTreeOnly\":false,\"nodes\":{\"11f1c31c-50a9-4717-8213-420f6932481f\":{\"connections\":{\"true\":\"e90ae257-c279-46e0-9b43-5ecd89784d77\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"3c106772-ace7-4808-8f3a-9840de8f67f0\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"622179cb-98f1-484a-820d-9a0df6e45e95\":{\"connections\":{\"level only\":\"3c106772-ace7-4808-8f3a-9840de8f67f0\",\"none\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\",\"shared and level\":\"11f1c31c-50a9-4717-8213-420f6932481f\",\"shared only\":\"a0782616-84b7-4bf5-87ed-a01fb3018563\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"a0782616-84b7-4bf5-87ed-a01fb3018563\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e90ae257-c279-46e0-9b43-5ecd89784d77\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j04\",\"_rev\":\"-1089876293\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"040b6c89-313b-4664-92e0-6732017384b8\",\"innerTreeOnly\":false,\"nodes\":{\"00e75aa0-2f9b-4895-9257-d515286fd64b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"040b6c89-313b-4664-92e0-6732017384b8\":{\"connections\":{\"level only\":\"d10104e9-1f8d-4da6-a110-28d879d13959\",\"none\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\",\"shared and level\":\"f5c317ce-fabd-4a10-9907-c71cea037844\",\"shared only\":\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"69ae8ec1-de43-44ac-98e5-733db80ac176\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d10104e9-1f8d-4da6-a110-28d879d13959\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"f5c317ce-fabd-4a10-9907-c71cea037844\":{\"connections\":{\"true\":\"69ae8ec1-de43-44ac-98e5-733db80ac176\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j07\",\"_rev\":\"-937100459\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\",\"innerTreeOnly\":false,\"nodes\":{\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\":{\"connections\":{\"level only\":\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\",\"none\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\",\"shared and level\":\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\",\"shared only\":\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\":{\"connections\":{\"true\":\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j06\",\"_rev\":\"605160891\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\",\"innerTreeOnly\":false,\"nodes\":{\"1d59caff-243c-45bd-b7d0-6dcc563989c5\":{\"connections\":{\"true\":\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"409c251f-c23b-411d-9009-d3b3d26d1b90\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\":{\"connections\":{\"level only\":\"fe8f27df-8a27-4d88-9196-834ce398b2b7\",\"none\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\",\"shared and level\":\"1d59caff-243c-45bd-b7d0-6dcc563989c5\",\"shared only\":\"da878771-421c-463f-aad7-4d5f2ad5e59a\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"da878771-421c-463f-aad7-4d5f2ad5e59a\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"fe8f27df-8a27-4d88-9196-834ce398b2b7\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j09\",\"_rev\":\"-1358707527\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"251f35c3-1a32-4520-be10-1f4af9600935\",\"innerTreeOnly\":false,\"nodes\":{\"251f35c3-1a32-4520-be10-1f4af9600935\":{\"connections\":{\"level only\":\"56b82371-0c61-4dc3-8d06-c1158415b8f9\",\"none\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\",\"shared and level\":\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\",\"shared only\":\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"56b82371-0c61-4dc3-8d06-c1158415b8f9\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"6df24fdd-0b6c-4def-bf42-77af998f28b8\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\":{\"connections\":{\"true\":\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j08\",\"_rev\":\"-1997695217\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"d429b2b5-b215-46a5-b239-4994df65cb8b\",\"innerTreeOnly\":false,\"nodes\":{\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\":{\"connections\":{\"true\":\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"8096649e-973e-4209-88ce-e1d87ae2bb96\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"948e21f4-c512-450a-9d42-e0d629217834\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d429b2b5-b215-46a5-b239-4994df65cb8b\":{\"connections\":{\"level only\":\"8096649e-973e-4209-88ce-e1d87ae2bb96\",\"none\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\",\"shared and level\":\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\",\"shared only\":\"948e21f4-c512-450a-9d42-e0d629217834\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Registration\",\"_rev\":\"-340494482\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"466f8b54-07fb-4e31-a11d-a6842618cc37\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"466f8b54-07fb-4e31-a11d-a6842618cc37\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":484,\"y\":267.015625},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":861,\"y\":221},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":717,\"y\":283}},\"description\":\"Platform Registration Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1085,\"y\":248},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":921,\"y\":370},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"512701181\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"description\":\"Prompt for missing preferences on 3rd login\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"FrodoTest\",\"_rev\":\"1975823900\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"e2c39477-847a-4df2-9c5d-b449a752638b\",\"innerTreeOnly\":false,\"nodes\":{\"278bf084-9eea-46fe-8ce9-2600dde3b046\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":444,\"y\":273.015625},\"64157fca-bd5b-4405-a4c8-64ffd98a5461\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"SAML2 Authentication\",\"nodeType\":\"product-Saml2Node\",\"x\":1196,\"y\":188.015625},\"731c5810-020b-45c8-a7fc-3c21903ae2b3\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":443,\"y\":26.015625},\"bf153f37-83dd-4f39-aa0c-74135430242e\":{\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"64157fca-bd5b-4405-a4c8-64ffd98a5461\"},\"displayName\":\"Email Template Node\",\"nodeType\":\"EmailTemplateNode\",\"x\":967,\"y\":222.015625},\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"bf153f37-83dd-4f39-aa0c-74135430242e\"},\"displayName\":\"Social Login\",\"nodeType\":\"SocialProviderHandlerNode\",\"x\":702,\"y\":116.015625},\"e2c39477-847a-4df2-9c5d-b449a752638b\":{\"connections\":{\"known\":\"731c5810-020b-45c8-a7fc-3c21903ae2b3\",\"unknown\":\"278bf084-9eea-46fe-8ce9-2600dde3b046\"},\"displayName\":\"Check Username\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":200,\"y\":235.015625},\"fc7e47cd-c679-4211-8e05-a36654f23c67\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Validate Creds\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":702,\"y\":292.015625}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1434,\"y\":60},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1433,\"y\":459},\"startNode\":{\"x\":63,\"y\":252}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"RadioChoice\",\"_rev\":\"947126104\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"5d6cd20e-5074-43de-8832-fddd95fb078e\",\"innerTreeOnly\":false,\"nodes\":{\"5d6cd20e-5074-43de-8832-fddd95fb078e\":{\"connections\":{\"one\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"three\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"two\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":260,\"y\":409.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":50},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":744,\"y\":327},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true}],\"resultCount\":21,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-501795106\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"description\":\"Reset Password Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"OrphanedTest\",\"_rev\":\"-764260244\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"343e745f-923a-43c4-8675-649a490fd0a3\",\"innerTreeOnly\":false,\"nodes\":{\"343e745f-923a-43c4-8675-649a490fd0a3\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":407.046875,\"y\":190.015625}},\"description\":\"Test orphaned nodes\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":704,\"y\":129},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":707,\"y\":381},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"test\",\"_rev\":\"279923916\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{},\"entryNodeId\":\"d26176be-ea6f-4f2a-81cd-3d41dd6cee4d\",\"innerTreeOnly\":false,\"nodes\":{},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":50,\"y\":117},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":152,\"y\":25},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ForgottenUsername\",\"_rev\":\"1703131230\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":0,\"y\":0},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":0,\"y\":0},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":0,\"y\":0}},\"description\":\"Forgotten Username Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j10\",\"_rev\":\"751431822\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"c91d626e-1156-41bd-b1fb-d292f640fba6\",\"innerTreeOnly\":false,\"nodes\":{\"300feda0-3248-49a9-b60f-01df802b2229\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"40afb384-e9b6-4dcb-acde-04de109474c8\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"8d7d64ee-da20-461f-a2ca-206b7479dd67\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\":{\"connections\":{\"true\":\"8d7d64ee-da20-461f-a2ca-206b7479dd67\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"c91d626e-1156-41bd-b1fb-d292f640fba6\":{\"connections\":{\"level only\":\"300feda0-3248-49a9-b60f-01df802b2229\",\"none\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\",\"shared and level\":\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\",\"shared only\":\"40afb384-e9b6-4dcb-acde-04de109474c8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j01\",\"_rev\":\"-523887030\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"f129f0df-b49e-453b-97fb-db508e3893ce\",\"innerTreeOnly\":false,\"nodes\":{\"6674b4ac-dd89-4e13-9440-6f81194e3a22\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\":{\"connections\":{\"true\":\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"f129f0df-b49e-453b-97fb-db508e3893ce\":{\"connections\":{\"level only\":\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\",\"none\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\",\"shared and level\":\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\",\"shared only\":\"6674b4ac-dd89-4e13-9440-6f81194e3a22\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"UpdatePassword\",\"_rev\":\"-1067190791\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"description\":\"Update password using active session\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Login\",\"_rev\":\"-453684268\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"nodes\":{\"2119f332-0f69-4088-a7a1-6582bf0f2001\":{\"connections\":{\"Reject\":\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\",\"Retry\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\"},\"displayName\":\"Retry Limit Decision\",\"nodeType\":\"RetryLimitDecisionNode\",\"x\":612,\"y\":105.015625},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":827,\"y\":13},\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Account Lockout\",\"nodeType\":\"AccountLockoutNode\",\"x\":836,\"y\":184.015625},\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\":{\"connections\":{\"CANCELLED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EXPIRED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"FALSE\":\"2119f332-0f69-4088-a7a1-6582bf0f2001\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":352,\"y\":40.015625},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":579,\"y\":34}},\"description\":\"Platform Login Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1073,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":761,\"y\":401},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j00\",\"_rev\":\"214130857\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\",\"innerTreeOnly\":false,\"nodes\":{\"01d3785f-7fb4-44a7-9458-72c380a9818f\":{\"connections\":{\"true\":\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":348,\"y\":61},\"39b48197-f4be-42b9-800a-866587b4b9b5\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":365,\"y\":252},\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":567,\"y\":64},\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\":{\"connections\":{\"level only\":\"39b48197-f4be-42b9-800a-866587b4b9b5\",\"none\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\",\"shared and level\":\"01d3785f-7fb4-44a7-9458-72c380a9818f\",\"shared only\":\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":117,\"y\":117},\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\":{\"connections\":{\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":760,\"y\":137},\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":338,\"y\":156}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":132,\"y\":364},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":137},\"startNode\":{\"x\":0,\"y\":0}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j03\",\"_rev\":\"-1352811052\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\",\"innerTreeOnly\":false,\"nodes\":{\"35a4f94b-c895-46b9-bc0a-93cf59233759\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"3a92300d-6d64-451d-8156-30cb51781026\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"6f9de973-9ed4-41f5-b43d-4036041e2b96\":{\"connections\":{\"true\":\"3a92300d-6d64-451d-8156-30cb51781026\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\":{\"connections\":{\"level only\":\"35a4f94b-c895-46b9-bc0a-93cf59233759\",\"none\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\",\"shared and level\":\"6f9de973-9ed4-41f5-b43d-4036041e2b96\",\"shared only\":\"fae7424e-13c9-45bd-b3a2-045773671a3f\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"fae7424e-13c9-45bd-b3a2-045773671a3f\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j02\",\"_rev\":\"2029292005\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"59b06306-a886-443d-92df-7a27a60c394e\",\"innerTreeOnly\":false,\"nodes\":{\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"56899fef-92a1-4f2a-ade3-973c81eb3af1\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"59b06306-a886-443d-92df-7a27a60c394e\":{\"connections\":{\"level only\":\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\",\"none\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\",\"shared and level\":\"e0983ead-4918-48f6-858d-9aff0f03759c\",\"shared only\":\"cbb3d506-b267-4b99-9edd-363e90aac997\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"cbb3d506-b267-4b99-9edd-363e90aac997\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e0983ead-4918-48f6-858d-9aff0f03759c\":{\"connections\":{\"true\":\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j05\",\"_rev\":\"1652057497\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"622179cb-98f1-484a-820d-9a0df6e45e95\",\"innerTreeOnly\":false,\"nodes\":{\"11f1c31c-50a9-4717-8213-420f6932481f\":{\"connections\":{\"true\":\"e90ae257-c279-46e0-9b43-5ecd89784d77\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"3c106772-ace7-4808-8f3a-9840de8f67f0\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"622179cb-98f1-484a-820d-9a0df6e45e95\":{\"connections\":{\"level only\":\"3c106772-ace7-4808-8f3a-9840de8f67f0\",\"none\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\",\"shared and level\":\"11f1c31c-50a9-4717-8213-420f6932481f\",\"shared only\":\"a0782616-84b7-4bf5-87ed-a01fb3018563\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"a0782616-84b7-4bf5-87ed-a01fb3018563\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e90ae257-c279-46e0-9b43-5ecd89784d77\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j04\",\"_rev\":\"-1089876293\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"040b6c89-313b-4664-92e0-6732017384b8\",\"innerTreeOnly\":false,\"nodes\":{\"00e75aa0-2f9b-4895-9257-d515286fd64b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"040b6c89-313b-4664-92e0-6732017384b8\":{\"connections\":{\"level only\":\"d10104e9-1f8d-4da6-a110-28d879d13959\",\"none\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\",\"shared and level\":\"f5c317ce-fabd-4a10-9907-c71cea037844\",\"shared only\":\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"69ae8ec1-de43-44ac-98e5-733db80ac176\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d10104e9-1f8d-4da6-a110-28d879d13959\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"f5c317ce-fabd-4a10-9907-c71cea037844\":{\"connections\":{\"true\":\"69ae8ec1-de43-44ac-98e5-733db80ac176\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j07\",\"_rev\":\"-937100459\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\",\"innerTreeOnly\":false,\"nodes\":{\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\":{\"connections\":{\"level only\":\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\",\"none\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\",\"shared and level\":\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\",\"shared only\":\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\":{\"connections\":{\"true\":\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j06\",\"_rev\":\"605160891\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\",\"innerTreeOnly\":false,\"nodes\":{\"1d59caff-243c-45bd-b7d0-6dcc563989c5\":{\"connections\":{\"true\":\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"409c251f-c23b-411d-9009-d3b3d26d1b90\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\":{\"connections\":{\"level only\":\"fe8f27df-8a27-4d88-9196-834ce398b2b7\",\"none\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\",\"shared and level\":\"1d59caff-243c-45bd-b7d0-6dcc563989c5\",\"shared only\":\"da878771-421c-463f-aad7-4d5f2ad5e59a\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"da878771-421c-463f-aad7-4d5f2ad5e59a\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"fe8f27df-8a27-4d88-9196-834ce398b2b7\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j09\",\"_rev\":\"-1358707527\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"251f35c3-1a32-4520-be10-1f4af9600935\",\"innerTreeOnly\":false,\"nodes\":{\"251f35c3-1a32-4520-be10-1f4af9600935\":{\"connections\":{\"level only\":\"56b82371-0c61-4dc3-8d06-c1158415b8f9\",\"none\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\",\"shared and level\":\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\",\"shared only\":\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"56b82371-0c61-4dc3-8d06-c1158415b8f9\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"6df24fdd-0b6c-4def-bf42-77af998f28b8\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\":{\"connections\":{\"true\":\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j08\",\"_rev\":\"-1997695217\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"d429b2b5-b215-46a5-b239-4994df65cb8b\",\"innerTreeOnly\":false,\"nodes\":{\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\":{\"connections\":{\"true\":\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"8096649e-973e-4209-88ce-e1d87ae2bb96\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"948e21f4-c512-450a-9d42-e0d629217834\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d429b2b5-b215-46a5-b239-4994df65cb8b\":{\"connections\":{\"level only\":\"8096649e-973e-4209-88ce-e1d87ae2bb96\",\"none\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\",\"shared and level\":\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\",\"shared only\":\"948e21f4-c512-450a-9d42-e0d629217834\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Registration\",\"_rev\":\"-340494482\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"466f8b54-07fb-4e31-a11d-a6842618cc37\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"466f8b54-07fb-4e31-a11d-a6842618cc37\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":484,\"y\":267.015625},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":861,\"y\":221},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":717,\"y\":283}},\"description\":\"Platform Registration Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1085,\"y\":248},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":921,\"y\":370},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"512701181\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"description\":\"Prompt for missing preferences on 3rd login\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"FrodoTest\",\"_rev\":\"1975823900\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"e2c39477-847a-4df2-9c5d-b449a752638b\",\"innerTreeOnly\":false,\"nodes\":{\"278bf084-9eea-46fe-8ce9-2600dde3b046\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":444,\"y\":273.015625},\"64157fca-bd5b-4405-a4c8-64ffd98a5461\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"SAML2 Authentication\",\"nodeType\":\"product-Saml2Node\",\"x\":1196,\"y\":188.015625},\"731c5810-020b-45c8-a7fc-3c21903ae2b3\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":443,\"y\":26.015625},\"bf153f37-83dd-4f39-aa0c-74135430242e\":{\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"64157fca-bd5b-4405-a4c8-64ffd98a5461\"},\"displayName\":\"Email Template Node\",\"nodeType\":\"EmailTemplateNode\",\"x\":967,\"y\":222.015625},\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"bf153f37-83dd-4f39-aa0c-74135430242e\"},\"displayName\":\"Social Login\",\"nodeType\":\"SocialProviderHandlerNode\",\"x\":702,\"y\":116.015625},\"e2c39477-847a-4df2-9c5d-b449a752638b\":{\"connections\":{\"known\":\"731c5810-020b-45c8-a7fc-3c21903ae2b3\",\"unknown\":\"278bf084-9eea-46fe-8ce9-2600dde3b046\"},\"displayName\":\"Check Username\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":200,\"y\":235.015625},\"fc7e47cd-c679-4211-8e05-a36654f23c67\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Validate Creds\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":702,\"y\":292.015625}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1434,\"y\":60},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1433,\"y\":459},\"startNode\":{\"x\":63,\"y\":252}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"RadioChoice\",\"_rev\":\"947126104\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"5d6cd20e-5074-43de-8832-fddd95fb078e\",\"innerTreeOnly\":false,\"nodes\":{\"5d6cd20e-5074-43de-8832-fddd95fb078e\":{\"connections\":{\"one\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"three\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"two\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":260,\"y\":409.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":50},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":744,\"y\":327},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true}],\"resultCount\":21,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
           },
           "cookies": [],
           "headers": [
@@ -384,7 +384,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "protocol=2.1,resource=2.0, resource=2.0"
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -412,11 +412,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -445,8 +445,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.541Z",
-        "time": 87,
+        "startedDateTime": "2024-12-04T16:31:24.792Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -454,7 +454,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 86
         }
       },
       {
@@ -475,15 +475,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -540,7 +540,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -576,11 +576,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -605,8 +605,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.704Z",
-        "time": 206,
+        "startedDateTime": "2024-12-04T16:31:24.963Z",
+        "time": 157,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -614,7 +614,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 206
+          "wait": 157
         }
       },
       {
@@ -635,15 +635,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -700,7 +700,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -736,11 +736,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -765,8 +765,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.915Z",
-        "time": 177,
+        "startedDateTime": "2024-12-04T16:31:25.125Z",
+        "time": 126,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -774,7 +774,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 177
+          "wait": 126
         }
       },
       {
@@ -795,15 +795,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -860,7 +860,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -896,11 +896,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -925,8 +925,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.097Z",
-        "time": 241,
+        "startedDateTime": "2024-12-04T16:31:25.254Z",
+        "time": 141,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -934,7 +934,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 241
+          "wait": 141
         }
       },
       {
@@ -955,15 +955,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1020,7 +1020,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1056,11 +1056,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1085,8 +1085,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.343Z",
-        "time": 94,
+        "startedDateTime": "2024-12-04T16:31:25.400Z",
+        "time": 158,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1094,7 +1094,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 94
+          "wait": 158
         }
       },
       {
@@ -1115,15 +1115,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1180,7 +1180,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1216,11 +1216,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1245,8 +1245,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.442Z",
-        "time": 113,
+        "startedDateTime": "2024-12-04T16:31:25.564Z",
+        "time": 102,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1254,7 +1254,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 113
+          "wait": 102
         }
       },
       {
@@ -1275,15 +1275,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1340,7 +1340,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1376,11 +1376,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1405,8 +1405,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.561Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:31:25.671Z",
+        "time": 96,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1414,15 +1414,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 96
         }
       },
       {
-        "_id": "683a2255bd43586b9d44750ce010ca82",
+        "_id": "9dc8bcea13a507715e6733c8ac72ea6f",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1489,
+          "bodySize": 1437,
           "cookies": [],
           "headers": [
             {
@@ -1435,11 +1435,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -1451,7 +1451,7 @@
             },
             {
               "name": "content-length",
-              "value": "1489"
+              "value": "1437"
             },
             {
               "name": "accept-encoding",
@@ -1468,17 +1468,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"GitHub Profile Normalization (VS)\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSlcbiI=\"}"
+            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"GitHub Profile Normalization (VS)\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJHaXRIdWIgcmF3UHJvZmlsZTogIityYXdQcm9maWxlKQoKcmV0dXJuIGpzb24ob2JqZWN0KAogICAgICAgIGZpZWxkKCJpZCIsIHJhd1Byb2ZpbGUuaWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIHJhd1Byb2ZpbGUubmFtZSksCiAgICAgICAgZmllbGQoImdpdmVuTmFtZSIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksCiAgICAgICAgZmllbGQoImZhbWlseU5hbWUiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksCiAgICAgICAgZmllbGQoInBob3RvVXJsIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSwKICAgICAgICBmaWVsZCgiZW1haWwiLCByYXdQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCByYXdQcm9maWxlLmVtYWlsKSkpCg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/23143919-6b78-40c3-b25e-beca19b229e0"
         },
         "response": {
-          "bodySize": 1557,
+          "bodySize": 1505,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1557,
-            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIkdpdEh1YiByYXdQcm9maWxlOiBcIityYXdQcm9maWxlKVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5pZCksXG4gICAgICAgIGZpZWxkKFwiZGlzcGxheU5hbWVcIiwgcmF3UHJvZmlsZS5uYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5maXJzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJmYW1pbHlOYW1lXCIsIHJhd1Byb2ZpbGUubGFzdF9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUuZGF0YS51cmwpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpKSlcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574390685,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1505,
+            "text": "{\"_id\":\"23143919-6b78-40c3-b25e-beca19b229e0\",\"name\":\"GitHub Profile Normalization (VS)\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjAgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJHaXRIdWIgcmF3UHJvZmlsZTogIityYXdQcm9maWxlKQoKcmV0dXJuIGpzb24ob2JqZWN0KAogICAgICAgIGZpZWxkKCJpZCIsIHJhd1Byb2ZpbGUuaWQpLAogICAgICAgIGZpZWxkKCJkaXNwbGF5TmFtZSIsIHJhd1Byb2ZpbGUubmFtZSksCiAgICAgICAgZmllbGQoImdpdmVuTmFtZSIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksCiAgICAgICAgZmllbGQoImZhbWlseU5hbWUiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksCiAgICAgICAgZmllbGQoInBob3RvVXJsIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSwKICAgICAgICBmaWVsZCgiZW1haWwiLCByYXdQcm9maWxlLmVtYWlsKSwKICAgICAgICBmaWVsZCgidXNlcm5hbWUiLCByYXdQcm9maWxlLmVtYWlsKSkpCg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329885834,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1528,15 +1528,15 @@
             },
             {
               "name": "content-length",
-              "value": "1557"
+              "value": "1505"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1561,8 +1561,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.640Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:25.771Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1570,15 +1570,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 84
         }
       },
       {
-        "_id": "0c352d31a9bc8be2496b8ae6c2c92245",
+        "_id": "27fecf30018919bfaf247e6bc83f9f50",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 3085,
+          "bodySize": 2921,
           "cookies": [],
           "headers": [
             {
@@ -1591,11 +1591,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -1607,7 +1607,7 @@
             },
             {
               "name": "content-length",
-              "value": "3085"
+              "value": "2921"
             },
             {
               "name": "accept-encoding",
@@ -1624,17 +1624,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Apple\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Apple Profile Normalization\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxcbiAqXFxuICogVXNlIG9mIHRoaXMgY29kZSByZXF1aXJlcyBhIGNvbW1lcmNpYWwgc29mdHdhcmUgbGljZW5zZSB3aXRoIEZvcmdlUm9jayBBUy5cXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXFxuICpcXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcXG4gKiB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cXG4gKlxcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcXG4gKiBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cXG4gKiBBIHplcm8tbGVuZ3RoIGNoYXJhY3RlciBzdHJpbmcgaXMgbm90IHBlcm1pdHRlZC5cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5TdHJpbmcgZW1haWwgPSBcXFwiY2hhbmdlQG1lLmNvbVxcXCJcXG5TdHJpbmcgc3ViamVjdElkID0gcmF3UHJvZmlsZS5zdWJcXG5TdHJpbmcgZmlyc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIGxhc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIHVzZXJuYW1lID0gc3ViamVjdElkXFxuU3RyaW5nIG5hbWVcXG5cXG5pZiAocmF3UHJvZmlsZS5pc0RlZmluZWQoXFxcImVtYWlsXFxcIikgJiYgcmF3UHJvZmlsZS5lbWFpbC5pc05vdE51bGwoKSl7IC8vIFVzZXIgY2FuIGVsZWN0IHRvIG5vdCBzaGFyZSB0aGVpciBlbWFpbFxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxcbiAgICB1c2VybmFtZSA9IGVtYWlsXFxufVxcbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcXFwibmFtZVxcXCIpICYmIHJhd1Byb2ZpbGUubmFtZS5pc05vdE51bGwoKSkge1xcbiAgICBpZiAocmF3UHJvZmlsZS5uYW1lLmlzRGVmaW5lZChcXFwiZmlyc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xcbiAgICAgICAgZmlyc3ROYW1lID0gcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXFxcImxhc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmxhc3ROYW1lLmlzTm90TnVsbCgpKSB7XFxuICAgICAgICBsYXN0TmFtZSA9IHJhd1Byb2ZpbGUubmFtZS5sYXN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG59XFxuXFxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFxcXCJcXFwiKSArIChsYXN0TmFtZT8udHJpbSgpID8gKChmaXJzdE5hbWU/LnRyaW0oKSA/IFxcXCIgXFxcIiA6IFxcXCJcXFwiKSArIGxhc3ROYW1lKSA6IFxcXCJcXFwiKVxcbm5hbWUgPSAgKCFuYW1lPy50cmltKCkpID8gXFxcIiBcXFwiIDogbmFtZVxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHN1YmplY3RJZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCBuYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJlbWFpbFxcXCIsIGVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCBmaXJzdE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImZhbWlseU5hbWVcXFwiLCBsYXN0TmFtZSksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCB1c2VybmFtZSkpKVwiXG4i\"}"
+            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Apple\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Apple Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxuICpcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcbiAqIHVzZXJuYW1lLCBnaXZlbk5hbWUsIGZhbWlseU5hbWUsIGVtYWlsLlxuICpcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcbiAqIGFyYml0cmFyeSBjaGFyYWN0ZXJzIGZyb20gdGhlIFVuaXZlcnNhbCBDaGFyYWN0ZXIgU2V0IChVQ1MpLlxuICogQSB6ZXJvLWxlbmd0aCBjaGFyYWN0ZXIgc3RyaW5nIGlzIG5vdCBwZXJtaXR0ZWQuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5TdHJpbmcgZW1haWwgPSBcImNoYW5nZUBtZS5jb21cIlxuU3RyaW5nIHN1YmplY3RJZCA9IHJhd1Byb2ZpbGUuc3ViXG5TdHJpbmcgZmlyc3ROYW1lID0gXCIgXCJcblN0cmluZyBsYXN0TmFtZSA9IFwiIFwiXG5TdHJpbmcgdXNlcm5hbWUgPSBzdWJqZWN0SWRcblN0cmluZyBuYW1lXG5cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcImVtYWlsXCIpICYmIHJhd1Byb2ZpbGUuZW1haWwuaXNOb3ROdWxsKCkpeyAvLyBVc2VyIGNhbiBlbGVjdCB0byBub3Qgc2hhcmUgdGhlaXIgZW1haWxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxuICAgIHVzZXJuYW1lID0gZW1haWxcbn1cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcIm5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmlzTm90TnVsbCgpKSB7XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJmaXJzdE5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xuICAgICAgICBmaXJzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUuZmlyc3ROYW1lLmFzU3RyaW5nKClcbiAgICB9XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJsYXN0TmFtZVwiKSAmJiByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuaXNOb3ROdWxsKCkpIHtcbiAgICAgICAgbGFzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuYXNTdHJpbmcoKVxuICAgIH1cbn1cblxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFwiXCIpICsgKGxhc3ROYW1lPy50cmltKCkgPyAoKGZpcnN0TmFtZT8udHJpbSgpID8gXCIgXCIgOiBcIlwiKSArIGxhc3ROYW1lKSA6IFwiXCIpXG5uYW1lID0gICghbmFtZT8udHJpbSgpKSA/IFwiIFwiIDogbmFtZVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgc3ViamVjdElkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCBuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCBlbWFpbCksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIGZpcnN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCBsYXN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwidXNlcm5hbWVcIiwgdXNlcm5hbWUpKSkiCg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/484e6246-dbc6-4288-97e6-54e55431402e"
         },
         "response": {
-          "bodySize": 3154,
+          "bodySize": 2990,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3154,
-            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"name\":\"Apple Profile Normalization\",\"description\":\"Normalizes raw profile data from Apple\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxcbiAqXFxuICogVXNlIG9mIHRoaXMgY29kZSByZXF1aXJlcyBhIGNvbW1lcmNpYWwgc29mdHdhcmUgbGljZW5zZSB3aXRoIEZvcmdlUm9jayBBUy5cXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXFxuICpcXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcXG4gKiB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cXG4gKlxcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcXG4gKiBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cXG4gKiBBIHplcm8tbGVuZ3RoIGNoYXJhY3RlciBzdHJpbmcgaXMgbm90IHBlcm1pdHRlZC5cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5TdHJpbmcgZW1haWwgPSBcXFwiY2hhbmdlQG1lLmNvbVxcXCJcXG5TdHJpbmcgc3ViamVjdElkID0gcmF3UHJvZmlsZS5zdWJcXG5TdHJpbmcgZmlyc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIGxhc3ROYW1lID0gXFxcIiBcXFwiXFxuU3RyaW5nIHVzZXJuYW1lID0gc3ViamVjdElkXFxuU3RyaW5nIG5hbWVcXG5cXG5pZiAocmF3UHJvZmlsZS5pc0RlZmluZWQoXFxcImVtYWlsXFxcIikgJiYgcmF3UHJvZmlsZS5lbWFpbC5pc05vdE51bGwoKSl7IC8vIFVzZXIgY2FuIGVsZWN0IHRvIG5vdCBzaGFyZSB0aGVpciBlbWFpbFxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxcbiAgICB1c2VybmFtZSA9IGVtYWlsXFxufVxcbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcXFwibmFtZVxcXCIpICYmIHJhd1Byb2ZpbGUubmFtZS5pc05vdE51bGwoKSkge1xcbiAgICBpZiAocmF3UHJvZmlsZS5uYW1lLmlzRGVmaW5lZChcXFwiZmlyc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xcbiAgICAgICAgZmlyc3ROYW1lID0gcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXFxcImxhc3ROYW1lXFxcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmxhc3ROYW1lLmlzTm90TnVsbCgpKSB7XFxuICAgICAgICBsYXN0TmFtZSA9IHJhd1Byb2ZpbGUubmFtZS5sYXN0TmFtZS5hc1N0cmluZygpXFxuICAgIH1cXG59XFxuXFxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFxcXCJcXFwiKSArIChsYXN0TmFtZT8udHJpbSgpID8gKChmaXJzdE5hbWU/LnRyaW0oKSA/IFxcXCIgXFxcIiA6IFxcXCJcXFwiKSArIGxhc3ROYW1lKSA6IFxcXCJcXFwiKVxcbm5hbWUgPSAgKCFuYW1lPy50cmltKCkpID8gXFxcIiBcXFwiIDogbmFtZVxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHN1YmplY3RJZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCBuYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJlbWFpbFxcXCIsIGVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCBmaXJzdE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImZhbWlseU5hbWVcXFwiLCBsYXN0TmFtZSksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCB1c2VybmFtZSkpKVwiXG4i\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574390759,\"evaluatorVersion\":\"1.0\"}"
+            "size": 2990,
+            "text": "{\"_id\":\"484e6246-dbc6-4288-97e6-54e55431402e\",\"name\":\"Apple Profile Normalization\",\"description\":\"Normalizes raw profile data from Apple\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMS0yMDIyIEZvcmdlUm9jayBBUy4gQWxsIFJpZ2h0cyBSZXNlcnZlZFxuICpcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqXG4gKiBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eTpcbiAqIHVzZXJuYW1lLCBnaXZlbk5hbWUsIGZhbWlseU5hbWUsIGVtYWlsLlxuICpcbiAqIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmVcbiAqIGFyYml0cmFyeSBjaGFyYWN0ZXJzIGZyb20gdGhlIFVuaXZlcnNhbCBDaGFyYWN0ZXIgU2V0IChVQ1MpLlxuICogQSB6ZXJvLWxlbmd0aCBjaGFyYWN0ZXIgc3RyaW5nIGlzIG5vdCBwZXJtaXR0ZWQuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5TdHJpbmcgZW1haWwgPSBcImNoYW5nZUBtZS5jb21cIlxuU3RyaW5nIHN1YmplY3RJZCA9IHJhd1Byb2ZpbGUuc3ViXG5TdHJpbmcgZmlyc3ROYW1lID0gXCIgXCJcblN0cmluZyBsYXN0TmFtZSA9IFwiIFwiXG5TdHJpbmcgdXNlcm5hbWUgPSBzdWJqZWN0SWRcblN0cmluZyBuYW1lXG5cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcImVtYWlsXCIpICYmIHJhd1Byb2ZpbGUuZW1haWwuaXNOb3ROdWxsKCkpeyAvLyBVc2VyIGNhbiBlbGVjdCB0byBub3Qgc2hhcmUgdGhlaXIgZW1haWxcbiAgICBlbWFpbCA9IHJhd1Byb2ZpbGUuZW1haWwuYXNTdHJpbmcoKVxuICAgIHVzZXJuYW1lID0gZW1haWxcbn1cbmlmIChyYXdQcm9maWxlLmlzRGVmaW5lZChcIm5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmlzTm90TnVsbCgpKSB7XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJmaXJzdE5hbWVcIikgJiYgcmF3UHJvZmlsZS5uYW1lLmZpcnN0TmFtZS5pc05vdE51bGwoKSkge1xuICAgICAgICBmaXJzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUuZmlyc3ROYW1lLmFzU3RyaW5nKClcbiAgICB9XG4gICAgaWYgKHJhd1Byb2ZpbGUubmFtZS5pc0RlZmluZWQoXCJsYXN0TmFtZVwiKSAmJiByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuaXNOb3ROdWxsKCkpIHtcbiAgICAgICAgbGFzdE5hbWUgPSByYXdQcm9maWxlLm5hbWUubGFzdE5hbWUuYXNTdHJpbmcoKVxuICAgIH1cbn1cblxubmFtZSA9IChmaXJzdE5hbWU/LnRyaW0oKSA/IGZpcnN0TmFtZSA6IFwiXCIpICsgKGxhc3ROYW1lPy50cmltKCkgPyAoKGZpcnN0TmFtZT8udHJpbSgpID8gXCIgXCIgOiBcIlwiKSArIGxhc3ROYW1lKSA6IFwiXCIpXG5uYW1lID0gICghbmFtZT8udHJpbSgpKSA/IFwiIFwiIDogbmFtZVxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgc3ViamVjdElkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCBuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCBlbWFpbCksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIGZpcnN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCBsYXN0TmFtZSksXG4gICAgICAgIGZpZWxkKFwidXNlcm5hbWVcIiwgdXNlcm5hbWUpKSkiCg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329885925,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1684,15 +1684,15 @@
             },
             {
               "name": "content-length",
-              "value": "3154"
+              "value": "2990"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:25 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1717,8 +1717,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.711Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:25.860Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1726,15 +1726,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 86
         }
       },
       {
-        "_id": "85ade8fc742dd01ea3b1adc2c17bde0c",
+        "_id": "e440e4911913e767714bc204aa5018cc",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 3209,
+          "bodySize": 3093,
           "cookies": [],
           "headers": [
             {
@@ -1747,11 +1747,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -1763,7 +1763,7 @@
             },
             {
               "name": "content-length",
-              "value": "3209"
+              "value": "3093"
             },
             {
               "name": "accept-encoding",
@@ -1780,17 +1780,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Converts a normalized social profile into a managed user\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Normalized Profile to Managed User\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbmltcG9ydCBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlXFxuXFxuSnNvblZhbHVlIG1hbmFnZWRVc2VyID0ganNvbihvYmplY3QoXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJzblxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmZhbWlseU5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcIm1haWxcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlck5hbWVcXFwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxcblxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXFxcInBvc3RhbEFkZHJlc3NcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwiY2l0eVxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJzdGF0ZVByb3ZpbmNlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbilcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJwb3N0YWxDb2RlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuY291bnRyeS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJjb3VudHJ5XFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuY291bnRyeSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwidGVsZXBob25lTnVtYmVyXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucGhvbmUpXFxuXFxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XFxuLy8gdGhlbiBhZGQgYSBib29sZWFuIGZsYWcgdG8gdGhlIHNoYXJlZCBzdGF0ZSB0byBpbmRpY2F0ZSBuYW1lcyBhcmUgbm90IHByZXNlbnRcXG4vLyB0aGlzIGNvdWxkIGJlIHVzZWQgZWxzZXdoZXJlXFxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcXG4vLyB0aGUgdXNlciBvYmplY3Qgd2l0aCBibGFuayB2YWx1ZXMgd2hlbiBnaXZlbk5hbWUgIGFuZCBmYW1pbHlOYW1lIGlzIG5vdCBwcmVzZW50XFxuYm9vbGVhbiBub0dpdmVuTmFtZSA9IG5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5pc051bGwoKSB8fCAoIW5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuc2hhcmVkU3RhdGUucHV0KFxcXCJuYW1lRW1wdHlPck51bGxcXFwiLCBub0dpdmVuTmFtZSAmJiBub0ZhbWlseU5hbWUpXFxuXFxucmV0dXJuIG1hbmFnZWRVc2VyXFxuXCJcbiI=\"}"
+            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Converts a normalized social profile into a managed user\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Normalized Profile to Managed User\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiIK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/58c824ae-84ed-4724-82cd-db128fc3f6c"
         },
         "response": {
-          "bodySize": 3278,
+          "bodySize": 3162,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3278,
-            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbmltcG9ydCBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlXFxuXFxuSnNvblZhbHVlIG1hbmFnZWRVc2VyID0ganNvbihvYmplY3QoXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJzblxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmZhbWlseU5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcIm1haWxcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlck5hbWVcXFwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxcblxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzLmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXFxcInBvc3RhbEFkZHJlc3NcXFwiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxcbmlmIChub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwiY2l0eVxcXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJzdGF0ZVByb3ZpbmNlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbilcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJwb3N0YWxDb2RlXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuY291bnRyeS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFxcXCJjb3VudHJ5XFxcIiwgbm9ybWFsaXplZFByb2ZpbGUuY291bnRyeSlcXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcXFwidGVsZXBob25lTnVtYmVyXFxcIiwgbm9ybWFsaXplZFByb2ZpbGUucGhvbmUpXFxuXFxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XFxuLy8gdGhlbiBhZGQgYSBib29sZWFuIGZsYWcgdG8gdGhlIHNoYXJlZCBzdGF0ZSB0byBpbmRpY2F0ZSBuYW1lcyBhcmUgbm90IHByZXNlbnRcXG4vLyB0aGlzIGNvdWxkIGJlIHVzZWQgZWxzZXdoZXJlXFxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcXG4vLyB0aGUgdXNlciBvYmplY3Qgd2l0aCBibGFuayB2YWx1ZXMgd2hlbiBnaXZlbk5hbWUgIGFuZCBmYW1pbHlOYW1lIGlzIG5vdCBwcmVzZW50XFxuYm9vbGVhbiBub0dpdmVuTmFtZSA9IG5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5pc051bGwoKSB8fCAoIW5vcm1hbGl6ZWRQcm9maWxlLmdpdmVuTmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXFxuc2hhcmVkU3RhdGUucHV0KFxcXCJuYW1lRW1wdHlPck51bGxcXFwiLCBub0dpdmVuTmFtZSAmJiBub0ZhbWlseU5hbWUpXFxuXFxucmV0dXJuIG1hbmFnZWRVc2VyXFxuXCJcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574390827,\"evaluatorVersion\":\"1.0\"}"
+            "size": 3162,
+            "text": "{\"_id\":\"58c824ae-84ed-4724-82cd-db128fc3f6c\",\"name\":\"Normalized Profile to Managed User\",\"description\":\"Converts a normalized social profile into a managed user\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5pbXBvcnQgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuXG5Kc29uVmFsdWUgbWFuYWdlZFVzZXIgPSBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgbm9ybWFsaXplZFByb2ZpbGUuZ2l2ZW5OYW1lKSxcbiAgICAgICAgZmllbGQoXCJzblwiLCBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJtYWlsXCIsIG5vcm1hbGl6ZWRQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VyTmFtZVwiLCBub3JtYWxpemVkUHJvZmlsZS51c2VybmFtZSkpKVxuXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQWRkcmVzcy5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwicG9zdGFsQWRkcmVzc1wiLCBub3JtYWxpemVkUHJvZmlsZS5wb3N0YWxBZGRyZXNzKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLmFkZHJlc3NMb2NhbGl0eS5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwiY2l0eVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzTG9jYWxpdHkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUuYWRkcmVzc1JlZ2lvbi5pc05vdE51bGwoKSkgbWFuYWdlZFVzZXIucHV0KFwic3RhdGVQcm92aW5jZVwiLCBub3JtYWxpemVkUHJvZmlsZS5hZGRyZXNzUmVnaW9uKVxuaWYgKG5vcm1hbGl6ZWRQcm9maWxlLnBvc3RhbENvZGUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInBvc3RhbENvZGVcIiwgbm9ybWFsaXplZFByb2ZpbGUucG9zdGFsQ29kZSlcbmlmIChub3JtYWxpemVkUHJvZmlsZS5jb3VudHJ5LmlzTm90TnVsbCgpKSBtYW5hZ2VkVXNlci5wdXQoXCJjb3VudHJ5XCIsIG5vcm1hbGl6ZWRQcm9maWxlLmNvdW50cnkpXG5pZiAobm9ybWFsaXplZFByb2ZpbGUucGhvbmUuaXNOb3ROdWxsKCkpIG1hbmFnZWRVc2VyLnB1dChcInRlbGVwaG9uZU51bWJlclwiLCBub3JtYWxpemVkUHJvZmlsZS5waG9uZSlcblxuLy8gaWYgdGhlIGdpdmVuTmFtZSBhbmQgZmFtaWx5TmFtZSBpcyBudWxsIG9yIGVtcHR5XG4vLyB0aGVuIGFkZCBhIGJvb2xlYW4gZmxhZyB0byB0aGUgc2hhcmVkIHN0YXRlIHRvIGluZGljYXRlIG5hbWVzIGFyZSBub3QgcHJlc2VudFxuLy8gdGhpcyBjb3VsZCBiZSB1c2VkIGVsc2V3aGVyZVxuLy8gZm9yIGVnLiB0aGlzIGNvdWxkIGJlIHVzZWQgaW4gYSBzY3JpcHRlZCBkZWNpc2lvbiBub2RlIHRvIGJ5LXBhc3MgcGF0Y2hpbmdcbi8vIHRoZSB1c2VyIG9iamVjdCB3aXRoIGJsYW5rIHZhbHVlcyB3aGVuIGdpdmVuTmFtZSAgYW5kIGZhbWlseU5hbWUgaXMgbm90IHByZXNlbnRcbmJvb2xlYW4gbm9HaXZlbk5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuaXNOdWxsKCkgfHwgKCFub3JtYWxpemVkUHJvZmlsZS5naXZlbk5hbWUuYXNTdHJpbmcoKT8udHJpbSgpKVxuYm9vbGVhbiBub0ZhbWlseU5hbWUgPSBub3JtYWxpemVkUHJvZmlsZS5mYW1pbHlOYW1lLmlzTnVsbCgpIHx8ICghbm9ybWFsaXplZFByb2ZpbGUuZmFtaWx5TmFtZS5hc1N0cmluZygpPy50cmltKCkpXG5zaGFyZWRTdGF0ZS5wdXQoXCJuYW1lRW1wdHlPck51bGxcIiwgbm9HaXZlbk5hbWUgJiYgbm9GYW1pbHlOYW1lKVxuXG5yZXR1cm4gbWFuYWdlZFVzZXJcbiIK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329886019,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1840,15 +1840,15 @@
             },
             {
               "name": "content-length",
-              "value": "3278"
+              "value": "3162"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1873,8 +1873,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.783Z",
-        "time": 63,
+        "startedDateTime": "2024-12-04T16:31:25.952Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1882,15 +1882,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 63
+          "wait": 88
         }
       },
       {
-        "_id": "3c18b6a5954c46c9eaf069280a91d2d6",
+        "_id": "c7c4491e9f8b5067c7f317f5616f1c01",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1539,
+          "bodySize": 1463,
           "cookies": [],
           "headers": [
             {
@@ -1903,11 +1903,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -1919,7 +1919,7 @@
             },
             {
               "name": "content-length",
-              "value": "1539"
+              "value": "1463"
             },
             {
               "name": "accept-encoding",
@@ -1936,17 +1936,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Google\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Google Profile Normalization\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHJhd1Byb2ZpbGUuc3ViKSxcXG4gICAgICAgIGZpZWxkKFxcXCJkaXNwbGF5TmFtZVxcXCIsIHJhd1Byb2ZpbGUubmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgcmF3UHJvZmlsZS5naXZlbl9uYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJmYW1pbHlOYW1lXFxcIiwgcmF3UHJvZmlsZS5mYW1pbHlfbmFtZSksXFxuICAgICAgICBmaWVsZChcXFwicGhvdG9VcmxcXFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxcbiAgICAgICAgZmllbGQoXFxcImVtYWlsXFxcIiwgcmF3UHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCByYXdQcm9maWxlLmVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJsb2NhbGVcXFwiLCByYXdQcm9maWxlLmxvY2FsZSkpKVwiXG4i\"}"
+            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Google\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Google Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5zdWIpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZ2l2ZW5fbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmZhbWlseV9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcImxvY2FsZVwiLCByYXdQcm9maWxlLmxvY2FsZSkpKSIK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/58d29080-4563-480b-89bb-1e7719776a21"
         },
         "response": {
-          "bodySize": 1608,
+          "bodySize": 1532,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1608,
-            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"name\":\"Google Profile Normalization\",\"description\":\"Normalizes raw profile data from Google\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uXFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxcblxcbnJldHVybiBqc29uKG9iamVjdChcXG4gICAgICAgIGZpZWxkKFxcXCJpZFxcXCIsIHJhd1Byb2ZpbGUuc3ViKSxcXG4gICAgICAgIGZpZWxkKFxcXCJkaXNwbGF5TmFtZVxcXCIsIHJhd1Byb2ZpbGUubmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZ2l2ZW5OYW1lXFxcIiwgcmF3UHJvZmlsZS5naXZlbl9uYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJmYW1pbHlOYW1lXFxcIiwgcmF3UHJvZmlsZS5mYW1pbHlfbmFtZSksXFxuICAgICAgICBmaWVsZChcXFwicGhvdG9VcmxcXFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxcbiAgICAgICAgZmllbGQoXFxcImVtYWlsXFxcIiwgcmF3UHJvZmlsZS5lbWFpbCksXFxuICAgICAgICBmaWVsZChcXFwidXNlcm5hbWVcXFwiLCByYXdQcm9maWxlLmVtYWlsKSxcXG4gICAgICAgIGZpZWxkKFxcXCJsb2NhbGVcXFwiLCByYXdQcm9maWxlLmxvY2FsZSkpKVwiXG4i\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574390899,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1532,
+            "text": "{\"_id\":\"58d29080-4563-480b-89bb-1e7719776a21\",\"name\":\"Google Profile Normalization\",\"description\":\"Normalizes raw profile data from Google\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5yZXR1cm4ganNvbihvYmplY3QoXG4gICAgICAgIGZpZWxkKFwiaWRcIiwgcmF3UHJvZmlsZS5zdWIpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZ2l2ZW5fbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmZhbWlseV9uYW1lKSxcbiAgICAgICAgZmllbGQoXCJwaG90b1VybFwiLCByYXdQcm9maWxlLnBpY3R1cmUpLFxuICAgICAgICBmaWVsZChcImVtYWlsXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcInVzZXJuYW1lXCIsIHJhd1Byb2ZpbGUuZW1haWwpLFxuICAgICAgICBmaWVsZChcImxvY2FsZVwiLCByYXdQcm9maWxlLmxvY2FsZSkpKSIK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329886117,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1996,15 +1996,15 @@
             },
             {
               "name": "content-length",
-              "value": "1608"
+              "value": "1532"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -2029,8 +2029,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.851Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:26.045Z",
+        "time": 92,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2038,15 +2038,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 92
         }
       },
       {
-        "_id": "bbb781f13b577c203d3c3c9f093650a0",
+        "_id": "d781078a77df6e3ad9e67899bc667868",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1498,
+          "bodySize": 1442,
           "cookies": [],
           "headers": [
             {
@@ -2059,11 +2059,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -2075,7 +2075,7 @@
             },
             {
               "name": "content-length",
-              "value": "1498"
+              "value": "1442"
             },
             {
               "name": "accept-encoding",
@@ -2092,17 +2092,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Okta Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIk9rdGEgcmF3UHJvZmlsZTogXCIrcmF3UHJvZmlsZSlcblxucmV0dXJuIGpzb24ob2JqZWN0KFxuICAgICAgICBmaWVsZChcImlkXCIsIHJhd1Byb2ZpbGUuaWQpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwicGhvdG9VcmxcIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnByZWZlcnJlZF91c2VybmFtZSkpKVxuIg==\"}"
+            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from GitHub\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Okta Profile Normalization\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJPa3RhIHJhd1Byb2ZpbGU6ICIrcmF3UHJvZmlsZSkKCnJldHVybiBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiaWQiLCByYXdQcm9maWxlLmlkKSwKICAgICAgICBmaWVsZCgiZGlzcGxheU5hbWUiLCByYXdQcm9maWxlLm5hbWUpLAogICAgICAgIGZpZWxkKCJnaXZlbk5hbWUiLCByYXdQcm9maWxlLmZpcnN0X25hbWUpLAogICAgICAgIGZpZWxkKCJmYW1pbHlOYW1lIiwgcmF3UHJvZmlsZS5sYXN0X25hbWUpLAogICAgICAgIGZpZWxkKCJwaG90b1VybCIsIHJhd1Byb2ZpbGUucGljdHVyZS5kYXRhLnVybCksCiAgICAgICAgZmllbGQoImVtYWlsIiwgcmF3UHJvZmlsZS5lbWFpbCksCiAgICAgICAgZmllbGQoInVzZXJuYW1lIiwgcmF3UHJvZmlsZS5wcmVmZXJyZWRfdXNlcm5hbWUpKSkK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/6325cf19-a49b-471e-8d26-7e4df76df0e2"
         },
         "response": {
-          "bodySize": 1566,
+          "bodySize": 1510,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1566,
-            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"name\":\"Okta Profile Normalization\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLm9iamVjdFxuXG5sb2dnZXIud2FybmluZyhcIk9rdGEgcmF3UHJvZmlsZTogXCIrcmF3UHJvZmlsZSlcblxucmV0dXJuIGpzb24ob2JqZWN0KFxuICAgICAgICBmaWVsZChcImlkXCIsIHJhd1Byb2ZpbGUuaWQpLFxuICAgICAgICBmaWVsZChcImRpc3BsYXlOYW1lXCIsIHJhd1Byb2ZpbGUubmFtZSksXG4gICAgICAgIGZpZWxkKFwiZ2l2ZW5OYW1lXCIsIHJhd1Byb2ZpbGUuZmlyc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwiZmFtaWx5TmFtZVwiLCByYXdQcm9maWxlLmxhc3RfbmFtZSksXG4gICAgICAgIGZpZWxkKFwicGhvdG9VcmxcIiwgcmF3UHJvZmlsZS5waWN0dXJlLmRhdGEudXJsKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLmVtYWlsKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnByZWZlcnJlZF91c2VybmFtZSkpKVxuIg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574390970,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1510,
+            "text": "{\"_id\":\"6325cf19-a49b-471e-8d26-7e4df76df0e2\",\"name\":\"Okta Profile Normalization\",\"description\":\"Normalizes raw profile data from GitHub\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuCiAqIG9yIHdpdGggb25lIG9mIGl0cyBhZmZpbGlhdGVzLiBBbGwgdXNlIHNoYWxsIGJlIGV4Y2x1c2l2ZWx5IHN1YmplY3QKICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuCiAqLwoKaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmZpZWxkCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5qc29uCmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3QKCmxvZ2dlci53YXJuaW5nKCJPa3RhIHJhd1Byb2ZpbGU6ICIrcmF3UHJvZmlsZSkKCnJldHVybiBqc29uKG9iamVjdCgKICAgICAgICBmaWVsZCgiaWQiLCByYXdQcm9maWxlLmlkKSwKICAgICAgICBmaWVsZCgiZGlzcGxheU5hbWUiLCByYXdQcm9maWxlLm5hbWUpLAogICAgICAgIGZpZWxkKCJnaXZlbk5hbWUiLCByYXdQcm9maWxlLmZpcnN0X25hbWUpLAogICAgICAgIGZpZWxkKCJmYW1pbHlOYW1lIiwgcmF3UHJvZmlsZS5sYXN0X25hbWUpLAogICAgICAgIGZpZWxkKCJwaG90b1VybCIsIHJhd1Byb2ZpbGUucGljdHVyZS5kYXRhLnVybCksCiAgICAgICAgZmllbGQoImVtYWlsIiwgcmF3UHJvZmlsZS5lbWFpbCksCiAgICAgICAgZmllbGQoInVzZXJuYW1lIiwgcmF3UHJvZmlsZS5wcmVmZXJyZWRfdXNlcm5hbWUpKSkK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329886216,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2152,15 +2152,15 @@
             },
             {
               "name": "content-length",
-              "value": "1566"
+              "value": "1510"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -2185,8 +2185,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.921Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:26.141Z",
+        "time": 99,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2194,15 +2194,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 99
         }
       },
       {
-        "_id": "61e02fc399a8567bd8c3bd359f0e7656",
+        "_id": "f6f8b416d52c96b4d98756f6f43be432",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1036,
+          "bodySize": 992,
           "cookies": [],
           "headers": [
             {
@@ -2215,11 +2215,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -2231,7 +2231,7 @@
             },
             {
               "name": "content-length",
-              "value": "1036"
+              "value": "992"
             },
             {
               "name": "accept-encoding",
@@ -2242,23 +2242,23 @@
               "value": "openam-frodo-dev.forgeblocks.com"
             }
           ],
-          "headersSize": 2022,
+          "headersSize": 2021,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if username has already been collected.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Check Username\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTtcbiI=\"}"
+            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if username has already been collected.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Check Username\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOwo=\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/739bdc48-fd24-4c52-b353-88706d75558a"
         },
         "response": {
-          "bodySize": 1104,
+          "bodySize": 1060,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1104,
-            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"Ii8qIENoZWNrIFVzZXJuYW1lXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBDaGVjayBpZiB1c2VybmFtZSBoYXMgYWxyZWFkeSBiZWVuIGNvbGxlY3RlZC5cbiAqIFJldHVybiBcImtub3duXCIgaWYgeWVzLCBcInVua25vd25cIiBvdGhlcndpc2UuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0ga25vd25cbiAqIC0gdW5rbm93blxuICovXG4oZnVuY3Rpb24gKCkge1xuICAgIGlmIChudWxsICE9IHNoYXJlZFN0YXRlLmdldChcInVzZXJuYW1lXCIpKSB7XG4gICAgICAgIG91dGNvbWUgPSBcImtub3duXCI7XG4gICAgfVxuICAgIGVsc2Uge1xuICAgICAgICBvdXRjb21lID0gXCJ1bmtub3duXCI7XG4gICAgfVxufSgpKTtcbiI=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574391044,\"evaluatorVersion\":\"1.0\"}"
+            "size": 1060,
+            "text": "{\"_id\":\"739bdc48-fd24-4c52-b353-88706d75558a\",\"name\":\"Check Username\",\"description\":\"Check if username has already been collected.\",\"script\":\"LyogQ2hlY2sgVXNlcm5hbWUKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogQ2hlY2sgaWYgdXNlcm5hbWUgaGFzIGFscmVhZHkgYmVlbiBjb2xsZWN0ZWQuCiAqIFJldHVybiAia25vd24iIGlmIHllcywgInVua25vd24iIG90aGVyd2lzZS4KICogCiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuCiAqIAogKiBUaGUgU2NyaXB0ZWQgRGVjaXNpb24gTm9kZSBuZWVkcyB0aGUgZm9sbG93aW5nIG91dGNvbWVzIGRlZmluZWQ6CiAqIC0ga25vd24KICogLSB1bmtub3duCiAqLwooZnVuY3Rpb24gKCkgewogICAgaWYgKG51bGwgIT0gc2hhcmVkU3RhdGUuZ2V0KCJ1c2VybmFtZSIpKSB7CiAgICAgICAgb3V0Y29tZSA9ICJrbm93biI7CiAgICB9CiAgICBlbHNlIHsKICAgICAgICBvdXRjb21lID0gInVua25vd24iOwogICAgfQp9KCkpOwo=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329886306,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2308,15 +2308,15 @@
             },
             {
               "name": "content-length",
-              "value": "1104"
+              "value": "1060"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -2341,8 +2341,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:10.993Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:26.245Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2350,15 +2350,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 84
         }
       },
       {
-        "_id": "f589e37b17c99f36912bbedd0f8ca3f9",
+        "_id": "6c7a3ecad7376b499678c33341d8e5d0",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2773,
+          "bodySize": 2553,
           "cookies": [],
           "headers": [
             {
@@ -2371,11 +2371,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -2387,7 +2387,7 @@
             },
             {
               "name": "content-length",
-              "value": "2773"
+              "value": "2553"
             },
             {
               "name": "accept-encoding",
@@ -2404,17 +2404,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Microsoft\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Microsoft Profile Normalization\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbi8qXFxue1xcbiAgICBcXFwiQG9kYXRhLmNvbnRleHRcXFwiOiBcXFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcXFwiLFxcbiAgICBcXFwiQG9kYXRhLmlkXFxcIjogXFxcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcXFwiLFxcbiAgICBcXFwiYnVzaW5lc3NQaG9uZXNcXFwiOiBbXFxuICAgICAgICBcXFwiMTgwMTQ3MzU0NTFcXFwiXFxuICAgIF0sXFxuICAgIFxcXCJkaXNwbGF5TmFtZVxcXCI6IFxcXCJWb2xrZXIgU2NoZXViZXJcXFwiLFxcbiAgICBcXFwiZ2l2ZW5OYW1lXFxcIjogXFxcIlZvbGtlclxcXCIsXFxuICAgIFxcXCJqb2JUaXRsZVxcXCI6IG51bGwsXFxuICAgIFxcXCJtYWlsXFxcIjogXFxcInZzY2hldWJlckB2c2NoZXViZXIub25taWNyb3NvZnQuY29tXFxcIixcXG4gICAgXFxcIm1vYmlsZVBob25lXFxcIjogbnVsbCxcXG4gICAgXFxcIm9mZmljZUxvY2F0aW9uXFxcIjogbnVsbCxcXG4gICAgXFxcInByZWZlcnJlZExhbmd1YWdlXFxcIjogbnVsbCxcXG4gICAgXFxcInN1cm5hbWVcXFwiOiBcXFwiU2NoZXViZXJcXFwiLFxcbiAgICBcXFwidXNlclByaW5jaXBhbE5hbWVcXFwiOiBcXFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cXFwiLFxcbiAgICBcXFwiaWRcXFwiOiBcXFwiN2Q3NzU5ZTItMzZkOC00ZTY0LWIxNzMtM2Y4OTBkN2Q0NmQ2XFxcIlxcbn1cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5sb2dnZXIubWVzc2FnZShcXFwiS2F1YWkgTWljcm9zb2Z0IFByb2ZpbGUgTm9ybWFsaXphdGlvbjogcmF3UHJvZmlsZT17fVxcXCIsIHJhd1Byb2ZpbGUpXFxuXFxucmV0dXJuIGpzb24ob2JqZWN0KFxcbiAgICAgICAgZmllbGQoXFxcImlkXFxcIiwgcmF3UHJvZmlsZS5pZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCByYXdQcm9maWxlLmdpdmVuTmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZmFtaWx5TmFtZVxcXCIsIHJhd1Byb2ZpbGUuc3VybmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZW1haWxcXFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJ1c2VybmFtZVxcXCIsIHJhd1Byb2ZpbGUudXNlclByaW5jaXBhbE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImdyb3Vwc1xcXCIsIHJhd1Byb2ZpbGUuZ3JvdXBzKSkpXCJcbiI=\"}"
+            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":true,\"description\":\"Normalizes raw profile data from Microsoft\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"Microsoft Profile Normalization\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuLypcbntcbiAgICBcIkBvZGF0YS5jb250ZXh0XCI6IFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcIixcbiAgICBcIkBvZGF0YS5pZFwiOiBcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcIixcbiAgICBcImJ1c2luZXNzUGhvbmVzXCI6IFtcbiAgICAgICAgXCIxODAxNDczNTQ1MVwiXG4gICAgXSxcbiAgICBcImRpc3BsYXlOYW1lXCI6IFwiVm9sa2VyIFNjaGV1YmVyXCIsXG4gICAgXCJnaXZlbk5hbWVcIjogXCJWb2xrZXJcIixcbiAgICBcImpvYlRpdGxlXCI6IG51bGwsXG4gICAgXCJtYWlsXCI6IFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cIixcbiAgICBcIm1vYmlsZVBob25lXCI6IG51bGwsXG4gICAgXCJvZmZpY2VMb2NhdGlvblwiOiBudWxsLFxuICAgIFwicHJlZmVycmVkTGFuZ3VhZ2VcIjogbnVsbCxcbiAgICBcInN1cm5hbWVcIjogXCJTY2hldWJlclwiLFxuICAgIFwidXNlclByaW5jaXBhbE5hbWVcIjogXCJ2c2NoZXViZXJAdnNjaGV1YmVyLm9ubWljcm9zb2Z0LmNvbVwiLFxuICAgIFwiaWRcIjogXCI3ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDZcIlxufVxuICovXG5cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmpzb25cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcblxubG9nZ2VyLm1lc3NhZ2UoXCJLYXVhaSBNaWNyb3NvZnQgUHJvZmlsZSBOb3JtYWxpemF0aW9uOiByYXdQcm9maWxlPXt9XCIsIHJhd1Byb2ZpbGUpXG5cbnJldHVybiBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJpZFwiLCByYXdQcm9maWxlLmlkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5naXZlbk5hbWUpLFxuICAgICAgICBmaWVsZChcImZhbWlseU5hbWVcIiwgcmF3UHJvZmlsZS5zdXJuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJncm91cHNcIiwgcmF3UHJvZmlsZS5ncm91cHMpKSkiCg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/73cecbfc-dad0-4395-be6a-6858ee3a80e5"
         },
         "response": {
-          "bodySize": 2842,
+          "bodySize": 2622,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 2842,
-            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"name\":\"Microsoft Profile Normalization\",\"description\":\"Normalizes raw profile data from Microsoft\",\"script\":\"IlwiLypcXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcXG4gKlxcbiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMuXFxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxcbiAqIHRvIHN1Y2ggbGljZW5zZSBiZXR3ZWVuIHRoZSBsaWNlbnNlZSBhbmQgRm9yZ2VSb2NrIEFTLlxcbiAqL1xcblxcbi8qXFxue1xcbiAgICBcXFwiQG9kYXRhLmNvbnRleHRcXFwiOiBcXFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcXFwiLFxcbiAgICBcXFwiQG9kYXRhLmlkXFxcIjogXFxcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcXFwiLFxcbiAgICBcXFwiYnVzaW5lc3NQaG9uZXNcXFwiOiBbXFxuICAgICAgICBcXFwiMTgwMTQ3MzU0NTFcXFwiXFxuICAgIF0sXFxuICAgIFxcXCJkaXNwbGF5TmFtZVxcXCI6IFxcXCJWb2xrZXIgU2NoZXViZXJcXFwiLFxcbiAgICBcXFwiZ2l2ZW5OYW1lXFxcIjogXFxcIlZvbGtlclxcXCIsXFxuICAgIFxcXCJqb2JUaXRsZVxcXCI6IG51bGwsXFxuICAgIFxcXCJtYWlsXFxcIjogXFxcInZzY2hldWJlckB2c2NoZXViZXIub25taWNyb3NvZnQuY29tXFxcIixcXG4gICAgXFxcIm1vYmlsZVBob25lXFxcIjogbnVsbCxcXG4gICAgXFxcIm9mZmljZUxvY2F0aW9uXFxcIjogbnVsbCxcXG4gICAgXFxcInByZWZlcnJlZExhbmd1YWdlXFxcIjogbnVsbCxcXG4gICAgXFxcInN1cm5hbWVcXFwiOiBcXFwiU2NoZXViZXJcXFwiLFxcbiAgICBcXFwidXNlclByaW5jaXBhbE5hbWVcXFwiOiBcXFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cXFwiLFxcbiAgICBcXFwiaWRcXFwiOiBcXFwiN2Q3NzU5ZTItMzZkOC00ZTY0LWIxNzMtM2Y4OTBkN2Q0NmQ2XFxcIlxcbn1cXG4gKi9cXG5cXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuZmllbGRcXG5pbXBvcnQgc3RhdGljIG9yZy5mb3JnZXJvY2suanNvbi5Kc29uVmFsdWUuanNvblxcbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcXG5cXG5sb2dnZXIubWVzc2FnZShcXFwiS2F1YWkgTWljcm9zb2Z0IFByb2ZpbGUgTm9ybWFsaXphdGlvbjogcmF3UHJvZmlsZT17fVxcXCIsIHJhd1Byb2ZpbGUpXFxuXFxucmV0dXJuIGpzb24ob2JqZWN0KFxcbiAgICAgICAgZmllbGQoXFxcImlkXFxcIiwgcmF3UHJvZmlsZS5pZCksXFxuICAgICAgICBmaWVsZChcXFwiZGlzcGxheU5hbWVcXFwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJnaXZlbk5hbWVcXFwiLCByYXdQcm9maWxlLmdpdmVuTmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZmFtaWx5TmFtZVxcXCIsIHJhd1Byb2ZpbGUuc3VybmFtZSksXFxuICAgICAgICBmaWVsZChcXFwiZW1haWxcXFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcXG4gICAgICAgIGZpZWxkKFxcXCJ1c2VybmFtZVxcXCIsIHJhd1Byb2ZpbGUudXNlclByaW5jaXBhbE5hbWUpLFxcbiAgICAgICAgZmllbGQoXFxcImdyb3Vwc1xcXCIsIHJhd1Byb2ZpbGUuZ3JvdXBzKSkpXCJcbiI=\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574391127,\"evaluatorVersion\":\"1.0\"}"
+            "size": 2622,
+            "text": "{\"_id\":\"73cecbfc-dad0-4395-be6a-6858ee3a80e5\",\"name\":\"Microsoft Profile Normalization\",\"description\":\"Normalizes raw profile data from Microsoft\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMCBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTLlxuICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdFxuICogdG8gc3VjaCBsaWNlbnNlIGJldHdlZW4gdGhlIGxpY2Vuc2VlIGFuZCBGb3JnZVJvY2sgQVMuXG4gKi9cblxuLypcbntcbiAgICBcIkBvZGF0YS5jb250ZXh0XCI6IFwiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tL3YxLjAvJG1ldGFkYXRhI3VzZXJzLyRlbnRpdHlcIixcbiAgICBcIkBvZGF0YS5pZFwiOiBcImh0dHBzOi8vZ3JhcGgubWljcm9zb2Z0LmNvbS92Mi83MTFmZmE5Yy01OTcyLTQ3MTMtYWNlMy02ODhjOTczMjYxNGEvZGlyZWN0b3J5T2JqZWN0cy83ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDYvTWljcm9zb2Z0LkRpcmVjdG9yeVNlcnZpY2VzLlVzZXJcIixcbiAgICBcImJ1c2luZXNzUGhvbmVzXCI6IFtcbiAgICAgICAgXCIxODAxNDczNTQ1MVwiXG4gICAgXSxcbiAgICBcImRpc3BsYXlOYW1lXCI6IFwiVm9sa2VyIFNjaGV1YmVyXCIsXG4gICAgXCJnaXZlbk5hbWVcIjogXCJWb2xrZXJcIixcbiAgICBcImpvYlRpdGxlXCI6IG51bGwsXG4gICAgXCJtYWlsXCI6IFwidnNjaGV1YmVyQHZzY2hldWJlci5vbm1pY3Jvc29mdC5jb21cIixcbiAgICBcIm1vYmlsZVBob25lXCI6IG51bGwsXG4gICAgXCJvZmZpY2VMb2NhdGlvblwiOiBudWxsLFxuICAgIFwicHJlZmVycmVkTGFuZ3VhZ2VcIjogbnVsbCxcbiAgICBcInN1cm5hbWVcIjogXCJTY2hldWJlclwiLFxuICAgIFwidXNlclByaW5jaXBhbE5hbWVcIjogXCJ2c2NoZXViZXJAdnNjaGV1YmVyLm9ubWljcm9zb2Z0LmNvbVwiLFxuICAgIFwiaWRcIjogXCI3ZDc3NTllMi0zNmQ4LTRlNjQtYjE3My0zZjg5MGQ3ZDQ2ZDZcIlxufVxuICovXG5cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5maWVsZFxuaW1wb3J0IHN0YXRpYyBvcmcuZm9yZ2Vyb2NrLmpzb24uSnNvblZhbHVlLmpzb25cbmltcG9ydCBzdGF0aWMgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZS5vYmplY3RcblxubG9nZ2VyLm1lc3NhZ2UoXCJLYXVhaSBNaWNyb3NvZnQgUHJvZmlsZSBOb3JtYWxpemF0aW9uOiByYXdQcm9maWxlPXt9XCIsIHJhd1Byb2ZpbGUpXG5cbnJldHVybiBqc29uKG9iamVjdChcbiAgICAgICAgZmllbGQoXCJpZFwiLCByYXdQcm9maWxlLmlkKSxcbiAgICAgICAgZmllbGQoXCJkaXNwbGF5TmFtZVwiLCByYXdQcm9maWxlLmRpc3BsYXlOYW1lKSxcbiAgICAgICAgZmllbGQoXCJnaXZlbk5hbWVcIiwgcmF3UHJvZmlsZS5naXZlbk5hbWUpLFxuICAgICAgICBmaWVsZChcImZhbWlseU5hbWVcIiwgcmF3UHJvZmlsZS5zdXJuYW1lKSxcbiAgICAgICAgZmllbGQoXCJlbWFpbFwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJ1c2VybmFtZVwiLCByYXdQcm9maWxlLnVzZXJQcmluY2lwYWxOYW1lKSxcbiAgICAgICAgZmllbGQoXCJncm91cHNcIiwgcmF3UHJvZmlsZS5ncm91cHMpKSkiCg==\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329886400,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2464,15 +2464,15 @@
             },
             {
               "name": "content-length",
-              "value": "2842"
+              "value": "2622"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -2497,8 +2497,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.068Z",
-        "time": 82,
+        "startedDateTime": "2024-12-04T16:31:26.334Z",
+        "time": 87,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2506,15 +2506,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 82
+          "wait": 87
         }
       },
       {
-        "_id": "5c399317a57917ea99761372d2d40e14",
+        "_id": "72a6d1011be243a7380bba9f2bd08145",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 7389,
+          "bodySize": 7225,
           "cookies": [],
           "headers": [
             {
@@ -2527,11 +2527,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -2543,7 +2543,7 @@
             },
             {
               "name": "content-length",
-              "value": "7389"
+              "value": "7225"
             },
             {
               "name": "accept-encoding",
@@ -2560,17 +2560,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from ADFS\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"ADFS Profile Normalization (JS)\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgICAgIC8vbG9nZ2VyLm1lc3NhZ2UoJ1NlZ3VpbiByYXdQcm9maWxlOiAnK3Jhd1Byb2ZpbGUpO1xuXG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnaWQnLCByYXdQcm9maWxlLmdldCgnc3ViJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZGlzcGxheU5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSArICcgJyArIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdnaXZlbk5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZmFtaWx5TmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3JvbGVzJywgcmF3UHJvZmlsZS5nZXQoJ3JvbGVzJykuYXNTdHJpbmcoKSk7XG4gIFxuICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpO1xuXG4gICAgcmV0dXJuIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTtcbn0oKSk7XG4i\"}"
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Normalizes raw profile data from ADFS\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"ADFS Profile Normalization (JS)\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7Cg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/dbe0bf9a-72aa-49d5-8483-9db147985a47"
         },
         "response": {
-          "bodySize": 7457,
+          "bodySize": 7293,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 7457,
-            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"Ii8qXG4gKiBDb3B5cmlnaHQgMjAyMiBGb3JnZVJvY2sgQVMuIEFsbCBSaWdodHMgUmVzZXJ2ZWRcbiAqXG4gKiBVc2Ugb2YgdGhpcyBjb2RlIHJlcXVpcmVzIGEgY29tbWVyY2lhbCBzb2Z0d2FyZSBsaWNlbnNlIHdpdGggRm9yZ2VSb2NrIEFTXG4gKiBvciB3aXRoIG9uZSBvZiBpdHMgYWZmaWxpYXRlcy4gQWxsIHVzZSBzaGFsbCBiZSBleGNsdXNpdmVseSBzdWJqZWN0XG4gKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy5cbiAqL1xuXG4vKlxuICogVGhpcyBzY3JpcHQgcmV0dXJucyB0aGUgc29jaWFsIGlkZW50aXR5IHByb2ZpbGUgaW5mb3JtYXRpb24gZm9yIHRoZSBhdXRoZW50aWNhdGluZyB1c2VyXG4gKiBpbiBhIHN0YW5kYXJkIGZvcm0gZXhwZWN0ZWQgYnkgdGhlIFNvY2lhbCBQcm92aWRlciBIYW5kbGVyIE5vZGUuXG4gKlxuICogRGVmaW5lZCB2YXJpYWJsZXM6XG4gKiByYXdQcm9maWxlIC0gVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBwcm9maWxlIGluZm9ybWF0aW9uIGZvciB0aGUgYXV0aGVudGljYXRpbmcgdXNlci5cbiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLlxuICogbG9nZ2VyIC0gVGhlIGRlYnVnIGxvZ2dlciBpbnN0YW5jZTpcbiAqICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L3NjcmlwdGluZy1ndWlkZS9zY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuaHRtbCNzY3JpcHRpbmctYXBpLWdsb2JhbC1sb2dnZXIuXG4gKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS5cbiAqICAgICAgICAgVGhlIG5hbWUgb2YgdGhlIHJlYWxtIHRoZSB1c2VyIGlzIGF1dGhlbnRpY2F0aW5nIHRvLlxuICogcmVxdWVzdEhlYWRlcnMgLSBUcmVlTWFwICgyKS5cbiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OlxuICogICAgICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoZW50aWNhdGlvbi1ndWlkZS9zY3JpcHRpbmctYXBpLW5vZGUuaHRtbCNzY3JpcHRpbmctYXBpLW5vZGUtcmVxdWVzdEhlYWRlcnMuXG4gKiByZXF1ZXN0UGFyYW1ldGVycyAtIFRyZWVNYXAgKDIpLlxuICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy5cbiAqIHNlbGVjdGVkSWRwIC0gU3RyaW5nIChwcmltaXRpdmUpLlxuICogICAgICAgICAgICAgICBUaGUgc29jaWFsIGlkZW50aXR5IHByb3ZpZGVyIG5hbWUuIEZvciBleGFtcGxlOiBnb29nbGUuXG4gKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLlxuICogICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgaG9sZHMgdGhlIHN0YXRlIG9mIHRoZSBhdXRoZW50aWNhdGlvbiB0cmVlIGFuZCBhbGxvd3MgZGF0YSBleGNoYW5nZSBiZXR3ZWVuIHRoZSBzdGF0ZWxlc3Mgbm9kZXM6XG4gKiAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuXG4gKiAgICAgICAgICAgICAgICAgIFRoZSBvYmplY3QgZm9yIHN0b3Jpbmcgc2Vuc2l0aXZlIGluZm9ybWF0aW9uIHRoYXQgbXVzdCBub3QgbGVhdmUgdGhlIHNlcnZlciB1bmVuY3J5cHRlZCxcbiAqICAgICAgICAgICAgICAgICAgYW5kIHRoYXQgbWF5IG5vdCBuZWVkIHRvIHBlcnNpc3QgYmV0d2VlbiBhdXRoZW50aWNhdGlvbiByZXF1ZXN0cyBkdXJpbmcgdGhlIGF1dGhlbnRpY2F0aW9uIHNlc3Npb246XG4gKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS5cbiAqXG4gKiBSZXR1cm4gLSBhIEpzb25WYWx1ZSAoMSkuXG4gKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuXG4gKiAgICAgICAgICBDdXJyZW50bHksIHRoZSBJbW1lZGlhdGVseSBJbnZva2VkIEZ1bmN0aW9uIEV4cHJlc3Npb24gKGFsc28ga25vd24gYXMgU2VsZi1FeGVjdXRpbmcgQW5vbnltb3VzIEZ1bmN0aW9uKVxuICogICAgICAgICAgaXMgdGhlIGxhc3QgKGFuZCBvbmx5KSBzdGF0ZW1lbnQgaW4gdGhpcyBzY3JpcHQsIGFuZCBpdHMgcmV0dXJuIHZhbHVlIHdpbGwgYmVjb21lIHRoZSBzY3JpcHQgcmVzdWx0LlxuICogICAgICAgICAgRG8gbm90IHVzZSBcInJldHVybiB2YXJpYWJsZVwiIHN0YXRlbWVudCBvdXRzaWRlIG9mIGEgZnVuY3Rpb24gZGVmaW5pdGlvbi5cbiAqXG4gKiAgICAgICAgICBUaGlzIHNjcmlwdCdzIGxhc3Qgc3RhdGVtZW50IHNob3VsZCByZXN1bHQgaW4gYSBKc29uVmFsdWUgKDEpIHdpdGggdGhlIGZvbGxvd2luZyBrZXlzOlxuICogICAgICAgICAge1xuICogICAgICAgICAgICAgIHtcImRpc3BsYXlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZW1haWxcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJmYW1pbHlOYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiZ2l2ZW5OYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn0sXG4gKiAgICAgICAgICAgICAge1wiaWRcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJsb2NhbGVcIjogXCJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZVwifSxcbiAqICAgICAgICAgICAgICB7XCJwaG90b1VybFwiOiBcImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlXCJ9LFxuICogICAgICAgICAgICAgIHtcInVzZXJuYW1lXCI6IFwiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWVcIn1cbiAqICAgICAgICAgIH1cbiAqXG4gKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC5cbiAqICAgICAgICAgIEZvciBleGFtcGxlLCB0aGUgc2NyaXB0IGFzc29jaWF0ZWQgd2l0aCB0aGUgU29jaWFsIFByb3ZpZGVyIEhhbmRsZXIgTm9kZSBhbmQsXG4gKiAgICAgICAgICB1bHRpbWF0ZWx5LCB0aGUgbWFuYWdlZCBvYmplY3QgY3JlYXRlZC91cGRhdGVkIHdpdGggdGhpcyBkYXRhXG4gKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLlxuICogICAgICAgICAgSW4gc29tZSBjb21tb24gZGVmYXVsdCBjb25maWd1cmF0aW9ucywgdGhlIGZvbGxvd2luZyBrZXlzIGFyZSByZXF1aXJlZCB0byBiZSBub3QgZW1wdHk6XG4gKiAgICAgICAgICB1c2VybmFtZSwgZ2l2ZW5OYW1lLCBmYW1pbHlOYW1lLCBlbWFpbC5cbiAqXG4gKiAgICAgICAgICBGcm9tIFJGQzQ1MTc6IEEgdmFsdWUgb2YgdGhlIERpcmVjdG9yeSBTdHJpbmcgc3ludGF4IGlzIGEgc3RyaW5nIG9mIG9uZSBvciBtb3JlXG4gKiAgICAgICAgICBhcmJpdHJhcnkgY2hhcmFjdGVycyBmcm9tIHRoZSBVbml2ZXJzYWwgQ2hhcmFjdGVyIFNldCAoVUNTKS5cbiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLlxuICpcbiAqICgxKSBKc29uVmFsdWUgLSBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hcGlkb2NzL29yZy9mb3JnZXJvY2svanNvbi9Kc29uVmFsdWUuaHRtbC5cbiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuXG4gKiAoMykgTGlua2VkSGFzaE1hcCAtIGh0dHBzOi8vZG9jcy5vcmFjbGUuY29tL2VuL2phdmEvamF2YXNlLzExL2RvY3MvYXBpL2phdmEuYmFzZS9qYXZhL3V0aWwvTGlua2VkSGFzaE1hcC5odG1sLlxuICovXG5cbihmdW5jdGlvbiAoKSB7XG4gICAgdmFyIGZySmF2YSA9IEphdmFJbXBvcnRlcihcbiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZVxuICAgICk7XG5cbiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpO1xuICBcbiAgICAgIC8vbG9nZ2VyLm1lc3NhZ2UoJ1NlZ3VpbiByYXdQcm9maWxlOiAnK3Jhd1Byb2ZpbGUpO1xuXG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnaWQnLCByYXdQcm9maWxlLmdldCgnc3ViJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZGlzcGxheU5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSArICcgJyArIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTtcbiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdnaXZlbk5hbWUnLCByYXdQcm9maWxlLmdldCgnZ2l2ZW5OYW1lJykuYXNTdHJpbmcoKSk7XG4gICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgnZmFtaWx5TmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdzbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpO1xuICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3JvbGVzJywgcmF3UHJvZmlsZS5nZXQoJ3JvbGVzJykuYXNTdHJpbmcoKSk7XG4gIFxuICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpO1xuXG4gICAgcmV0dXJuIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTtcbn0oKSk7XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574391207,\"evaluatorVersion\":\"1.0\"}"
+            "size": 7293,
+            "text": "{\"_id\":\"dbe0bf9a-72aa-49d5-8483-9db147985a47\",\"name\":\"ADFS Profile Normalization (JS)\",\"description\":\"Normalizes raw profile data from ADFS\",\"script\":\"LyoKICogQ29weXJpZ2h0IDIwMjIgRm9yZ2VSb2NrIEFTLiBBbGwgUmlnaHRzIFJlc2VydmVkCiAqCiAqIFVzZSBvZiB0aGlzIGNvZGUgcmVxdWlyZXMgYSBjb21tZXJjaWFsIHNvZnR3YXJlIGxpY2Vuc2Ugd2l0aCBGb3JnZVJvY2sgQVMKICogb3Igd2l0aCBvbmUgb2YgaXRzIGFmZmlsaWF0ZXMuIEFsbCB1c2Ugc2hhbGwgYmUgZXhjbHVzaXZlbHkgc3ViamVjdAogKiB0byBzdWNoIGxpY2Vuc2UgYmV0d2VlbiB0aGUgbGljZW5zZWUgYW5kIEZvcmdlUm9jayBBUy4KICovCgovKgogKiBUaGlzIHNjcmlwdCByZXR1cm5zIHRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIKICogaW4gYSBzdGFuZGFyZCBmb3JtIGV4cGVjdGVkIGJ5IHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlLgogKgogKiBEZWZpbmVkIHZhcmlhYmxlczoKICogcmF3UHJvZmlsZSAtIFRoZSBzb2NpYWwgaWRlbnRpdHkgcHJvdmlkZXIgcHJvZmlsZSBpbmZvcm1hdGlvbiBmb3IgdGhlIGF1dGhlbnRpY2F0aW5nIHVzZXIuCiAqICAgICAgICAgICAgICBKc29uVmFsdWUgKDEpLgogKiBsb2dnZXIgLSBUaGUgZGVidWcgbG9nZ2VyIGluc3RhbmNlOgogKiAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9zY3JpcHRpbmctZ3VpZGUvc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLmh0bWwjc2NyaXB0aW5nLWFwaS1nbG9iYWwtbG9nZ2VyLgogKiByZWFsbSAtIFN0cmluZyAocHJpbWl0aXZlKS4KICogICAgICAgICBUaGUgbmFtZSBvZiB0aGUgcmVhbG0gdGhlIHVzZXIgaXMgYXV0aGVudGljYXRpbmcgdG8uCiAqIHJlcXVlc3RIZWFkZXJzIC0gVHJlZU1hcCAoMikuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCB0aGF0IHByb3ZpZGVzIG1ldGhvZHMgZm9yIGFjY2Vzc2luZyBoZWFkZXJzIGluIHRoZSBsb2dpbiByZXF1ZXN0OgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGhlbnRpY2F0aW9uLWd1aWRlL3NjcmlwdGluZy1hcGktbm9kZS5odG1sI3NjcmlwdGluZy1hcGktbm9kZS1yZXF1ZXN0SGVhZGVycy4KICogcmVxdWVzdFBhcmFtZXRlcnMgLSBUcmVlTWFwICgyKS4KICogICAgICAgICAgICAgICAgICAgICBUaGUgb2JqZWN0IHRoYXQgY29udGFpbnMgdGhlIGF1dGhlbnRpY2F0aW9uIHJlcXVlc3QgcGFyYW1ldGVycy4KICogc2VsZWN0ZWRJZHAgLSBTdHJpbmcgKHByaW1pdGl2ZSkuCiAqICAgICAgICAgICAgICAgVGhlIHNvY2lhbCBpZGVudGl0eSBwcm92aWRlciBuYW1lLiBGb3IgZXhhbXBsZTogZ29vZ2xlLgogKiBzaGFyZWRTdGF0ZSAtIExpbmtlZEhhc2hNYXAgKDMpLgogKiAgICAgICAgICAgICAgIFRoZSBvYmplY3QgdGhhdCBob2xkcyB0aGUgc3RhdGUgb2YgdGhlIGF1dGhlbnRpY2F0aW9uIHRyZWUgYW5kIGFsbG93cyBkYXRhIGV4Y2hhbmdlIGJldHdlZW4gdGhlIHN0YXRlbGVzcyBub2RlczoKICogICAgICAgICAgICAgICBodHRwczovL2JhY2tzdGFnZS5mb3JnZXJvY2suY29tL2RvY3MvYW0vNy9hdXRoLW5vZGVzL2NvcmUtYWN0aW9uLmh0bWwjYWNjZXNzaW5nLXRyZWUtc3RhdGUuCiAqIHRyYW5zaWVudFN0YXRlIC0gTGlua2VkSGFzaE1hcCAoMykuCiAqICAgICAgICAgICAgICAgICAgVGhlIG9iamVjdCBmb3Igc3RvcmluZyBzZW5zaXRpdmUgaW5mb3JtYXRpb24gdGhhdCBtdXN0IG5vdCBsZWF2ZSB0aGUgc2VydmVyIHVuZW5jcnlwdGVkLAogKiAgICAgICAgICAgICAgICAgIGFuZCB0aGF0IG1heSBub3QgbmVlZCB0byBwZXJzaXN0IGJldHdlZW4gYXV0aGVudGljYXRpb24gcmVxdWVzdHMgZHVyaW5nIHRoZSBhdXRoZW50aWNhdGlvbiBzZXNzaW9uOgogKiAgICAgICAgICAgICAgICAgIGh0dHBzOi8vYmFja3N0YWdlLmZvcmdlcm9jay5jb20vZG9jcy9hbS83L2F1dGgtbm9kZXMvY29yZS1hY3Rpb24uaHRtbCNhY2Nlc3NpbmctdHJlZS1zdGF0ZS4KICoKICogUmV0dXJuIC0gYSBKc29uVmFsdWUgKDEpLgogKiAgICAgICAgICBUaGUgcmVzdWx0IG9mIHRoZSBsYXN0IHN0YXRlbWVudCBpbiB0aGUgc2NyaXB0IGlzIHJldHVybmVkIHRvIHRoZSBzZXJ2ZXIuCiAqICAgICAgICAgIEN1cnJlbnRseSwgdGhlIEltbWVkaWF0ZWx5IEludm9rZWQgRnVuY3Rpb24gRXhwcmVzc2lvbiAoYWxzbyBrbm93biBhcyBTZWxmLUV4ZWN1dGluZyBBbm9ueW1vdXMgRnVuY3Rpb24pCiAqICAgICAgICAgIGlzIHRoZSBsYXN0IChhbmQgb25seSkgc3RhdGVtZW50IGluIHRoaXMgc2NyaXB0LCBhbmQgaXRzIHJldHVybiB2YWx1ZSB3aWxsIGJlY29tZSB0aGUgc2NyaXB0IHJlc3VsdC4KICogICAgICAgICAgRG8gbm90IHVzZSAicmV0dXJuIHZhcmlhYmxlIiBzdGF0ZW1lbnQgb3V0c2lkZSBvZiBhIGZ1bmN0aW9uIGRlZmluaXRpb24uCiAqCiAqICAgICAgICAgIFRoaXMgc2NyaXB0J3MgbGFzdCBzdGF0ZW1lbnQgc2hvdWxkIHJlc3VsdCBpbiBhIEpzb25WYWx1ZSAoMSkgd2l0aCB0aGUgZm9sbG93aW5nIGtleXM6CiAqICAgICAgICAgIHsKICogICAgICAgICAgICAgIHsiZGlzcGxheU5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZW1haWwiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiZmFtaWx5TmFtZSI6ICJjb3JyZXNwb25kaW5nLXNvY2lhbC1pZGVudGl0eS1wcm92aWRlci12YWx1ZSJ9LAogKiAgICAgICAgICAgICAgeyJnaXZlbk5hbWUiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsiaWQiOiAiY29ycmVzcG9uZGluZy1zb2NpYWwtaWRlbnRpdHktcHJvdmlkZXItdmFsdWUifSwKICogICAgICAgICAgICAgIHsibG9jYWxlIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InBob3RvVXJsIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0sCiAqICAgICAgICAgICAgICB7InVzZXJuYW1lIjogImNvcnJlc3BvbmRpbmctc29jaWFsLWlkZW50aXR5LXByb3ZpZGVyLXZhbHVlIn0KICogICAgICAgICAgfQogKgogKiAgICAgICAgICBUaGUgY29uc3VtZXIgb2YgdGhpcyBkYXRhIGRlZmluZXMgd2hpY2gga2V5cyBhcmUgcmVxdWlyZWQgYW5kIHdoaWNoIGFyZSBvcHRpb25hbC4KICogICAgICAgICAgRm9yIGV4YW1wbGUsIHRoZSBzY3JpcHQgYXNzb2NpYXRlZCB3aXRoIHRoZSBTb2NpYWwgUHJvdmlkZXIgSGFuZGxlciBOb2RlIGFuZCwKICogICAgICAgICAgdWx0aW1hdGVseSwgdGhlIG1hbmFnZWQgb2JqZWN0IGNyZWF0ZWQvdXBkYXRlZCB3aXRoIHRoaXMgZGF0YQogKiAgICAgICAgICB3aWxsIGV4cGVjdCBjZXJ0YWluIGtleXMgdG8gYmUgcG9wdWxhdGVkLgogKiAgICAgICAgICBJbiBzb21lIGNvbW1vbiBkZWZhdWx0IGNvbmZpZ3VyYXRpb25zLCB0aGUgZm9sbG93aW5nIGtleXMgYXJlIHJlcXVpcmVkIHRvIGJlIG5vdCBlbXB0eToKICogICAgICAgICAgdXNlcm5hbWUsIGdpdmVuTmFtZSwgZmFtaWx5TmFtZSwgZW1haWwuCiAqCiAqICAgICAgICAgIEZyb20gUkZDNDUxNzogQSB2YWx1ZSBvZiB0aGUgRGlyZWN0b3J5IFN0cmluZyBzeW50YXggaXMgYSBzdHJpbmcgb2Ygb25lIG9yIG1vcmUKICogICAgICAgICAgYXJiaXRyYXJ5IGNoYXJhY3RlcnMgZnJvbSB0aGUgVW5pdmVyc2FsIENoYXJhY3RlciBTZXQgKFVDUykuCiAqICAgICAgICAgIEEgemVyby1sZW5ndGggY2hhcmFjdGVyIHN0cmluZyBpcyBub3QgcGVybWl0dGVkLgogKgogKiAoMSkgSnNvblZhbHVlIC0gaHR0cHM6Ly9iYWNrc3RhZ2UuZm9yZ2Vyb2NrLmNvbS9kb2NzL2FtLzcvYXBpZG9jcy9vcmcvZm9yZ2Vyb2NrL2pzb24vSnNvblZhbHVlLmh0bWwuCiAqICgyKSBUcmVlTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9UcmVlTWFwLmh0bWwuCiAqICgzKSBMaW5rZWRIYXNoTWFwIC0gaHR0cHM6Ly9kb2NzLm9yYWNsZS5jb20vZW4vamF2YS9qYXZhc2UvMTEvZG9jcy9hcGkvamF2YS5iYXNlL2phdmEvdXRpbC9MaW5rZWRIYXNoTWFwLmh0bWwuCiAqLwoKKGZ1bmN0aW9uICgpIHsKICAgIHZhciBmckphdmEgPSBKYXZhSW1wb3J0ZXIoCiAgICAgICAgb3JnLmZvcmdlcm9jay5qc29uLkpzb25WYWx1ZQogICAgKTsKCiAgICB2YXIgbm9ybWFsaXplZFByb2ZpbGVEYXRhID0gZnJKYXZhLkpzb25WYWx1ZS5qc29uKGZySmF2YS5Kc29uVmFsdWUub2JqZWN0KCkpOwogIAogICAgICAvL2xvZ2dlci5tZXNzYWdlKCdTZWd1aW4gcmF3UHJvZmlsZTogJytyYXdQcm9maWxlKTsKCiAgICBub3JtYWxpemVkUHJvZmlsZURhdGEucHV0KCdpZCcsIHJhd1Byb2ZpbGUuZ2V0KCdzdWInKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2Rpc3BsYXlOYW1lJywgcmF3UHJvZmlsZS5nZXQoJ2dpdmVuTmFtZScpLmFzU3RyaW5nKCkgKyAnICcgKyByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2VtYWlsJywgcmF3UHJvZmlsZS5nZXQoJ21haWwnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2dpdmVuTmFtZScsIHJhd1Byb2ZpbGUuZ2V0KCdnaXZlbk5hbWUnKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ2ZhbWlseU5hbWUnLCByYXdQcm9maWxlLmdldCgnc24nKS5hc1N0cmluZygpKTsKICAgIG5vcm1hbGl6ZWRQcm9maWxlRGF0YS5wdXQoJ3VzZXJuYW1lJywgcmF3UHJvZmlsZS5nZXQoJ3VwbicpLmFzU3RyaW5nKCkpOwogICAgbm9ybWFsaXplZFByb2ZpbGVEYXRhLnB1dCgncm9sZXMnLCByYXdQcm9maWxlLmdldCgncm9sZXMnKS5hc1N0cmluZygpKTsKICAKICAgICAgLy9sb2dnZXIubWVzc2FnZSgnU2VndWluIG5vcm1hbGl6ZWRQcm9maWxlRGF0YTogJytub3JtYWxpemVkUHJvZmlsZURhdGEpOwoKICAgIHJldHVybiBub3JtYWxpemVkUHJvZmlsZURhdGE7Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SOCIAL_IDP_PROFILE_TRANSFORMATION\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329886489,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -2620,15 +2620,15 @@
             },
             {
               "name": "content-length",
-              "value": "7457"
+              "value": "7293"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:10 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -2653,8 +2653,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.155Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:26.427Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2662,7 +2662,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 86
         }
       },
       {
@@ -2683,11 +2683,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -2784,11 +2784,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -2813,8 +2813,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.489Z",
-        "time": 102,
+        "startedDateTime": "2024-12-04T16:31:26.784Z",
+        "time": 135,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2822,7 +2822,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 102
+          "wait": 135
         }
       },
       {
@@ -2843,11 +2843,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -2944,11 +2944,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -2973,8 +2973,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.596Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:31:26.924Z",
+        "time": 111,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2982,7 +2982,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 111
         }
       },
       {
@@ -3003,11 +3003,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -3104,11 +3104,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -3133,8 +3133,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.682Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:27.041Z",
+        "time": 96,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3142,7 +3142,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 96
         }
       },
       {
@@ -3163,11 +3163,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -3264,11 +3264,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -3293,8 +3293,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.756Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:31:27.142Z",
+        "time": 103,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3302,7 +3302,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 103
         }
       },
       {
@@ -3323,11 +3323,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -3424,11 +3424,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -3453,8 +3453,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.841Z",
-        "time": 92,
+        "startedDateTime": "2024-12-04T16:31:27.252Z",
+        "time": 109,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3462,7 +3462,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 92
+          "wait": 109
         }
       },
       {
@@ -3483,11 +3483,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -3584,11 +3584,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -3613,8 +3613,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.938Z",
-        "time": 87,
+        "startedDateTime": "2024-12-04T16:31:27.366Z",
+        "time": 98,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3622,7 +3622,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 98
         }
       },
       {
@@ -3643,11 +3643,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -3744,11 +3744,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -3773,8 +3773,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.030Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:27.469Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3782,7 +3782,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 84
         }
       },
       {
@@ -3803,11 +3803,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -3900,11 +3900,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -3929,8 +3929,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.109Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:31:27.559Z",
+        "time": 106,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3938,7 +3938,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 106
         }
       },
       {
@@ -3959,11 +3959,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -4060,11 +4060,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -4089,8 +4089,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.186Z",
-        "time": 101,
+        "startedDateTime": "2024-12-04T16:31:27.672Z",
+        "time": 159,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4098,7 +4098,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 101
+          "wait": 159
         }
       },
       {
@@ -4119,11 +4119,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -4216,11 +4216,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:27 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -4245,8 +4245,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.290Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:31:27.837Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4254,7 +4254,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 76
         }
       },
       {
@@ -4275,11 +4275,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -4314,11 +4314,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/saml2/remote/dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l"
         },
         "response": {
-          "bodySize": 1581,
+          "bodySize": 1604,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 1581,
-            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"1007701944\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"accountMapper\":{},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{}}}}"
+            "size": 1604,
+            "text": "{\"_id\":\"dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l\",\"_rev\":\"-901720656\",\"entityId\":\"urn:federation:MicrosoftOnline\",\"serviceProvider\":{\"assertionContent\":{\"signingAndEncryption\":{\"requestResponseSigning\":{\"assertion\":true},\"encryption\":{},\"secretIdAndAlgorithms\":{}},\"nameIdFormat\":{\"nameIdFormatList\":[\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\",\"urn:mace:shibboleth:1.0:nameIdentifier\",\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\",\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"]},\"secrets\":{},\"basicAuthentication\":{}},\"assertionProcessing\":{\"attributeMapper\":{\"attributeMap\":[{\"samlAttribute\":\"IDPEmail\",\"localAttribute\":\"mail\",\"binary\":false},{\"samlAttribute\":\"UOPClassID\",\"localAttribute\":\"UOPClassID\",\"binary\":false}]},\"accountMapper\":{},\"responseArtifactMessageEncoding\":{\"encoding\":\"URI\"}},\"services\":{\"serviceAttributes\":{\"singleLogoutService\":[{\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\"}],\"assertionConsumerService\":[{\"isDefault\":true,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":0},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":1},{\"isDefault\":false,\"binding\":\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\",\"location\":\"https://login.microsoftonline.com/login.srf\",\"index\":2}]}},\"advanced\":{\"saeConfiguration\":{},\"idpProxy\":{},\"treeConfiguration\":{}}}}"
           },
           "cookies": [],
           "headers": [
@@ -4356,7 +4356,7 @@
             },
             {
               "name": "etag",
-              "value": "\"1007701944\""
+              "value": "\"-901720656\""
             },
             {
               "name": "expires",
@@ -4372,15 +4372,15 @@
             },
             {
               "name": "content-length",
-              "value": "1581"
+              "value": "1604"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -4405,8 +4405,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.372Z",
-        "time": 89,
+        "startedDateTime": "2024-12-04T16:31:27.919Z",
+        "time": 133,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4414,7 +4414,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 89
+          "wait": 133
         }
       },
       {
@@ -4435,15 +4435,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4505,7 +4505,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4537,11 +4537,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -4566,8 +4566,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2024-10-10T15:33:12.465Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:28.056Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4575,7 +4575,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 88
         }
       },
       {
@@ -4596,15 +4596,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4661,7 +4661,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4697,11 +4697,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -4726,8 +4726,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.540Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:28.150Z",
+        "time": 98,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4735,7 +4735,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 98
         }
       },
       {
@@ -4756,15 +4756,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4826,7 +4826,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -4858,11 +4858,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -4887,8 +4887,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2024-10-10T15:33:12.618Z",
-        "time": 59,
+        "startedDateTime": "2024-12-04T16:31:28.253Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4896,7 +4896,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 59
+          "wait": 85
         }
       },
       {
@@ -4917,15 +4917,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -4982,7 +4982,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5018,11 +5018,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -5047,8 +5047,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.681Z",
-        "time": 80,
+        "startedDateTime": "2024-12-04T16:31:28.344Z",
+        "time": 107,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5056,7 +5056,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 80
+          "wait": 107
         }
       },
       {
@@ -5077,15 +5077,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5142,7 +5142,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5178,11 +5178,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -5207,8 +5207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.766Z",
-        "time": 104,
+        "startedDateTime": "2024-12-04T16:31:28.455Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5216,7 +5216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 104
+          "wait": 86
         }
       },
       {
@@ -5237,15 +5237,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5302,7 +5302,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5338,11 +5338,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -5367,8 +5367,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.874Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:28.546Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5376,7 +5376,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 72
         }
       },
       {
@@ -5397,15 +5397,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5462,7 +5462,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5498,11 +5498,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -5527,8 +5527,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:12.946Z",
-        "time": 112,
+        "startedDateTime": "2024-12-04T16:31:28.625Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5536,7 +5536,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 112
+          "wait": 90
         }
       },
       {
@@ -5557,15 +5557,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5622,7 +5622,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5658,11 +5658,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -5687,8 +5687,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.064Z",
-        "time": 156,
+        "startedDateTime": "2024-12-04T16:31:28.721Z",
+        "time": 116,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5696,7 +5696,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 156
+          "wait": 116
         }
       },
       {
@@ -5717,15 +5717,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5782,7 +5782,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5818,11 +5818,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -5847,8 +5847,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.226Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:28.842Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5856,7 +5856,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 85
         }
       },
       {
@@ -5877,15 +5877,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -5942,7 +5942,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -5978,11 +5978,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:28 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -6007,8 +6007,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.297Z",
-        "time": 76,
+        "startedDateTime": "2024-12-04T16:31:28.930Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6016,7 +6016,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 80
         }
       },
       {
@@ -6037,15 +6037,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6102,7 +6102,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6138,11 +6138,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:12 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -6167,8 +6167,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.378Z",
-        "time": 88,
+        "startedDateTime": "2024-12-04T16:31:29.016Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6176,7 +6176,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 88
+          "wait": 86
         }
       },
       {
@@ -6197,15 +6197,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6262,7 +6262,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6298,11 +6298,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -6327,8 +6327,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.471Z",
-        "time": 85,
+        "startedDateTime": "2024-12-04T16:31:29.107Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6336,7 +6336,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 76
         }
       },
       {
@@ -6357,15 +6357,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6422,7 +6422,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6458,11 +6458,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -6487,8 +6487,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.561Z",
-        "time": 87,
+        "startedDateTime": "2024-12-04T16:31:29.189Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6496,7 +6496,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 84
         }
       },
       {
@@ -6517,15 +6517,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6582,7 +6582,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6618,11 +6618,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:13 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -6647,8 +6647,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.654Z",
-        "time": 86,
+        "startedDateTime": "2024-12-04T16:31:29.276Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6656,7 +6656,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 86
+          "wait": 93
         }
       },
       {
@@ -6677,15 +6677,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6742,7 +6742,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6778,11 +6778,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -6807,8 +6807,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:13.747Z",
-        "time": 792,
+        "startedDateTime": "2024-12-04T16:31:29.373Z",
+        "time": 277,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6816,7 +6816,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 792
+          "wait": 277
         }
       },
       {
@@ -6837,15 +6837,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -6902,7 +6902,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -6938,11 +6938,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -6967,8 +6967,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:14.544Z",
-        "time": 106,
+        "startedDateTime": "2024-12-04T16:31:29.656Z",
+        "time": 109,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6976,7 +6976,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 106
+          "wait": 109
         }
       },
       {
@@ -6997,15 +6997,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7062,7 +7062,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7098,11 +7098,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -7127,8 +7127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:14.655Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:29.770Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7136,7 +7136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 78
         }
       },
       {
@@ -7157,15 +7157,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7222,7 +7222,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7258,11 +7258,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:29 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -7287,8 +7287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:14.729Z",
-        "time": 156,
+        "startedDateTime": "2024-12-04T16:31:29.854Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7296,7 +7296,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 156
+          "wait": 79
         }
       },
       {
@@ -7317,15 +7317,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7382,7 +7382,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7418,11 +7418,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -7447,8 +7447,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:14.890Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:29.938Z",
+        "time": 92,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7456,7 +7456,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 92
         }
       },
       {
@@ -7477,15 +7477,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7542,7 +7542,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7578,11 +7578,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -7607,8 +7607,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:14.962Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:31:30.037Z",
+        "time": 101,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7616,7 +7616,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 101
         }
       },
       {
@@ -7637,15 +7637,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7702,7 +7702,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7738,11 +7738,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -7767,8 +7767,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.047Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:30.142Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7776,7 +7776,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 83
         }
       },
       {
@@ -7797,15 +7797,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -7862,7 +7862,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -7898,11 +7898,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -7927,8 +7927,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.122Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:31:30.231Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7936,7 +7936,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 86
         }
       },
       {
@@ -7957,15 +7957,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8022,7 +8022,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8058,11 +8058,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -8087,8 +8087,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.211Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:31:30.323Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8096,7 +8096,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 73
         }
       },
       {
@@ -8117,15 +8117,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8182,7 +8182,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8218,11 +8218,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -8247,8 +8247,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.278Z",
-        "time": 96,
+        "startedDateTime": "2024-12-04T16:31:30.401Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8256,7 +8256,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 96
+          "wait": 74
         }
       },
       {
@@ -8277,15 +8277,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8342,7 +8342,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8378,11 +8378,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -8407,8 +8407,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.379Z",
-        "time": 88,
+        "startedDateTime": "2024-12-04T16:31:30.480Z",
+        "time": 106,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8416,7 +8416,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 88
+          "wait": 106
         }
       },
       {
@@ -8437,15 +8437,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8502,7 +8502,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8538,11 +8538,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:14 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -8567,8 +8567,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.471Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:31:30.592Z",
+        "time": 103,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8576,7 +8576,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 103
         }
       },
       {
@@ -8597,15 +8597,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8662,7 +8662,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8698,11 +8698,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -8727,8 +8727,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.537Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:31:30.702Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8736,7 +8736,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 74
         }
       },
       {
@@ -8757,15 +8757,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8822,7 +8822,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -8858,11 +8858,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -8887,8 +8887,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.622Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:30.781Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8896,7 +8896,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 78
         }
       },
       {
@@ -8917,15 +8917,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -8982,7 +8982,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9018,11 +9018,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:30 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -9047,8 +9047,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.693Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:30.863Z",
+        "time": 100,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9056,7 +9056,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 100
         }
       },
       {
@@ -9077,15 +9077,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9142,7 +9142,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9178,11 +9178,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -9207,8 +9207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.765Z",
-        "time": 106,
+        "startedDateTime": "2024-12-04T16:31:30.967Z",
+        "time": 140,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9216,7 +9216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 106
+          "wait": 140
         }
       },
       {
@@ -9237,15 +9237,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9302,7 +9302,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9338,11 +9338,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -9367,8 +9367,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.876Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:31:31.113Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9376,7 +9376,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 88
         }
       },
       {
@@ -9397,15 +9397,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9462,7 +9462,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9498,11 +9498,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -9527,8 +9527,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:15.961Z",
-        "time": 100,
+        "startedDateTime": "2024-12-04T16:31:31.207Z",
+        "time": 94,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9536,7 +9536,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 100
+          "wait": 94
         }
       },
       {
@@ -9557,15 +9557,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9622,7 +9622,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9658,11 +9658,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -9687,8 +9687,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.065Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:31.305Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9696,7 +9696,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 82
         }
       },
       {
@@ -9717,15 +9717,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9782,7 +9782,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9818,11 +9818,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -9847,8 +9847,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.136Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:31.393Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9856,7 +9856,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 76
         }
       },
       {
@@ -9877,15 +9877,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -9942,7 +9942,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -9978,11 +9978,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -10007,8 +10007,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.208Z",
-        "time": 85,
+        "startedDateTime": "2024-12-04T16:31:31.473Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10016,7 +10016,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 86
         }
       },
       {
@@ -10037,15 +10037,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10102,7 +10102,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10138,11 +10138,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -10167,8 +10167,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.298Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:31.562Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10176,7 +10176,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 78
         }
       },
       {
@@ -10197,15 +10197,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10262,7 +10262,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10298,11 +10298,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -10327,8 +10327,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.371Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:31.644Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10336,7 +10336,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 75
         }
       },
       {
@@ -10357,15 +10357,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10422,7 +10422,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10458,11 +10458,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:15 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -10487,8 +10487,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.510Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:31.796Z",
+        "time": 95,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10496,7 +10496,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 95
         }
       },
       {
@@ -10517,15 +10517,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10582,7 +10582,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10618,11 +10618,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -10647,8 +10647,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.589Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:31.896Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10656,7 +10656,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 78
         }
       },
       {
@@ -10677,15 +10677,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10742,7 +10742,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10778,11 +10778,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -10807,8 +10807,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.661Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:31:31.979Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10816,7 +10816,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 79
         }
       },
       {
@@ -10837,15 +10837,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -10902,7 +10902,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -10938,11 +10938,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -10967,8 +10967,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.744Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:31:32.064Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -10976,7 +10976,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 85
         }
       },
       {
@@ -10997,15 +10997,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11062,7 +11062,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11098,11 +11098,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -11127,8 +11127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.830Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:32.153Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11136,7 +11136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 75
         }
       },
       {
@@ -11157,15 +11157,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11222,7 +11222,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11258,11 +11258,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -11287,8 +11287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.900Z",
-        "time": 62,
+        "startedDateTime": "2024-12-04T16:31:32.234Z",
+        "time": 107,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11296,7 +11296,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 62
+          "wait": 107
         }
       },
       {
@@ -11317,15 +11317,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11382,7 +11382,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11418,11 +11418,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -11447,8 +11447,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.967Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:32.344Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11456,7 +11456,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 86
         }
       },
       {
@@ -11477,15 +11477,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11542,7 +11542,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11578,11 +11578,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -11607,8 +11607,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.040Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:32.434Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11616,7 +11616,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 81
         }
       },
       {
@@ -11637,15 +11637,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11702,7 +11702,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11738,11 +11738,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -11767,8 +11767,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.116Z",
-        "time": 81,
+        "startedDateTime": "2024-12-04T16:31:32.520Z",
+        "time": 98,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11776,7 +11776,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 81
+          "wait": 98
         }
       },
       {
@@ -11797,15 +11797,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -11862,7 +11862,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -11898,11 +11898,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -11927,8 +11927,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.202Z",
-        "time": 58,
+        "startedDateTime": "2024-12-04T16:31:32.622Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -11936,7 +11936,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 58
+          "wait": 76
         }
       },
       {
@@ -11957,15 +11957,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12022,7 +12022,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12058,11 +12058,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -12087,8 +12087,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.354Z",
-        "time": 83,
+        "startedDateTime": "2024-12-04T16:31:32.777Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12096,7 +12096,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 83
+          "wait": 74
         }
       },
       {
@@ -12117,15 +12117,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12182,7 +12182,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12218,11 +12218,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -12247,8 +12247,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.441Z",
-        "time": 83,
+        "startedDateTime": "2024-12-04T16:31:32.857Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12256,7 +12256,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 83
+          "wait": 84
         }
       },
       {
@@ -12277,15 +12277,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12342,7 +12342,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12378,11 +12378,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -12407,8 +12407,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.528Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:32.947Z",
+        "time": 94,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12416,7 +12416,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 94
         }
       },
       {
@@ -12437,15 +12437,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12502,7 +12502,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12538,11 +12538,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -12567,8 +12567,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.599Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:31:33.045Z",
+        "time": 92,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12576,7 +12576,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 92
         }
       },
       {
@@ -12597,15 +12597,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12662,7 +12662,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12698,11 +12698,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -12727,8 +12727,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.665Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:31:33.142Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12736,7 +12736,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 93
         }
       },
       {
@@ -12757,15 +12757,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12822,7 +12822,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -12858,11 +12858,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -12887,8 +12887,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.730Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:33.240Z",
+        "time": 132,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -12896,7 +12896,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 132
         }
       },
       {
@@ -12917,15 +12917,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -12982,7 +12982,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13018,11 +13018,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -13047,8 +13047,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.804Z",
-        "time": 60,
+        "startedDateTime": "2024-12-04T16:31:33.377Z",
+        "time": 92,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13056,7 +13056,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 60
+          "wait": 92
         }
       },
       {
@@ -13077,15 +13077,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13142,7 +13142,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13178,11 +13178,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -13207,8 +13207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.869Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:33.474Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13216,7 +13216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 84
         }
       },
       {
@@ -13237,15 +13237,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13302,7 +13302,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13338,11 +13338,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -13367,8 +13367,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.995Z",
-        "time": 60,
+        "startedDateTime": "2024-12-04T16:31:33.628Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13376,7 +13376,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 60
+          "wait": 84
         }
       },
       {
@@ -13397,15 +13397,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13462,7 +13462,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13498,11 +13498,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -13527,8 +13527,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.060Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:31:33.718Z",
+        "time": 96,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13536,7 +13536,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 96
         }
       },
       {
@@ -13557,15 +13557,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13622,7 +13622,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13658,11 +13658,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -13687,8 +13687,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.138Z",
-        "time": 95,
+        "startedDateTime": "2024-12-04T16:31:33.818Z",
+        "time": 112,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13696,7 +13696,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 95
+          "wait": 112
         }
       },
       {
@@ -13717,15 +13717,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13782,7 +13782,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13818,11 +13818,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -13847,8 +13847,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.238Z",
-        "time": 76,
+        "startedDateTime": "2024-12-04T16:31:33.934Z",
+        "time": 90,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -13856,7 +13856,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 90
         }
       },
       {
@@ -13877,15 +13877,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -13942,7 +13942,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -13978,11 +13978,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -14007,8 +14007,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.319Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:34.030Z",
+        "time": 89,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14016,7 +14016,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 89
         }
       },
       {
@@ -14037,15 +14037,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14102,7 +14102,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14138,11 +14138,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -14167,8 +14167,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.391Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:34.123Z",
+        "time": 98,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14176,7 +14176,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 98
         }
       },
       {
@@ -14197,15 +14197,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14262,7 +14262,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14298,11 +14298,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -14327,8 +14327,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.470Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:34.228Z",
+        "time": 94,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14336,7 +14336,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 94
         }
       },
       {
@@ -14357,15 +14357,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14422,7 +14422,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14458,11 +14458,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -14487,8 +14487,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.543Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:31:34.325Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14496,7 +14496,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 82
         }
       },
       {
@@ -14517,15 +14517,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14582,7 +14582,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14618,11 +14618,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -14647,8 +14647,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.626Z",
-        "time": 90,
+        "startedDateTime": "2024-12-04T16:31:34.412Z",
+        "time": 89,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14656,7 +14656,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 90
+          "wait": 89
         }
       },
       {
@@ -14677,15 +14677,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -14742,7 +14742,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -14778,11 +14778,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -14807,8 +14807,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.722Z",
-        "time": 58,
+        "startedDateTime": "2024-12-04T16:31:34.507Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14816,15 +14816,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 58
+          "wait": 73
         }
       },
       {
-        "_id": "9cf0243aa28aad2f8450fabb17eae4a7",
+        "_id": "ecc5b4f2eb12840cf634a5faa3ca5784",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 689,
+          "bodySize": 681,
           "cookies": [],
           "headers": [
             {
@@ -14837,11 +14837,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -14853,7 +14853,7 @@
             },
             {
               "name": "content-length",
-              "value": "689"
+              "value": "681"
             },
             {
               "name": "accept-encoding",
@@ -14870,17 +14870,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set the same shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"shared\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnc2hhcmVkVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2hhcmVkIGFjcm9zcyBhbGwgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIGxhc3Qgc2V0LicpO1xufSgpKTtcbiI=\"}"
+            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set the same shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"shared\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdzaGFyZWRWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzaGFyZWQgYWNyb3NzIGFsbCBuZXN0ZWQgam91cm5leXMuIEl0IGNvbnRhaW5zIGFuIGluZGljYXRvciBpbiB3aGljaCBsZXZlbCBpdCB3YXMgbGFzdCBzZXQuJyk7Cn0oKSk7Cg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/1b52a7e0-4019-40fa-958a-15a49870e901"
         },
         "response": {
-          "bodySize": 757,
+          "bodySize": 749,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 757,
-            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"name\":\"shared\",\"description\":\"set the same shared state variable\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnc2hhcmVkVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2hhcmVkIGFjcm9zcyBhbGwgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIGxhc3Qgc2V0LicpO1xufSgpKTtcbiI=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574398825,\"evaluatorVersion\":\"1.0\"}"
+            "size": 749,
+            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"name\":\"shared\",\"description\":\"set the same shared state variable\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdzaGFyZWRWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzaGFyZWQgYWNyb3NzIGFsbCBuZXN0ZWQgam91cm5leXMuIEl0IGNvbnRhaW5zIGFuIGluZGljYXRvciBpbiB3aGljaCBsZXZlbCBpdCB3YXMgbGFzdCBzZXQuJyk7Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329894636,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -14930,15 +14930,15 @@
             },
             {
               "name": "content-length",
-              "value": "757"
+              "value": "749"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -14963,8 +14963,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.785Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:31:34.585Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -14972,15 +14972,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 72
         }
       },
       {
-        "_id": "589bc3213af463279e35284f3ac342ba",
+        "_id": "124e3260c3d3bd1d675f6cb1e5813068",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 3335,
+          "bodySize": 3171,
           "cookies": [],
           "headers": [
             {
@@ -14993,11 +14993,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -15009,7 +15009,7 @@
             },
             {
               "name": "content-length",
-              "value": "3335"
+              "value": "3171"
             },
             {
               "name": "accept-encoding",
@@ -15026,17 +15026,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Display sharedState, transientState, and headers.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"debug\",\"script\":\"Ii8qIGRlYnVnXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBEaXNwbGF5IHNoYXJlZFN0YXRlLCB0cmFuc2llbnRTdGF0ZSwgYW5kIGhlYWRlcnMuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gdHJ1ZVxuICovXG52YXIgYW5jaG9yID0gXCJhbmNob3ItXCIuY29uY2F0KGdlbmVyYXRlTnVtZXJpY1Rva2VuKCd4eHgnKSk7XG52YXIgaGFsaWduID0gXCJsZWZ0XCI7XG52YXIgbWVzc2FnZSA9IFwiPHA+PGI+U2hhcmVkIFN0YXRlPC9iPjo8YnIvPlwiLmNvbmNhdChcbiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdChcIjwvcD5cIikuY29uY2F0KFxuICAgIFwiPHA+PGI+VHJhbnNpZW50IFN0YXRlPC9iPjo8YnIvPlwiKS5jb25jYXQoXG4gICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoXCI8L3A+XCIpLmNvbmNhdChcbiAgICBcIjxwPjxiPlJlcXVlc3QgSGVhZGVyczwvYj46PGJyLz5cIikuY29uY2F0KFxuICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KFwiPC9wPlwiKVxudmFyIHNjcmlwdCA9IFwiQXJyYXkucHJvdG90eXBlLnNsaWNlLmNhbGwoXFxuXCIuY29uY2F0KFxuICBcImRvY3VtZW50LmdldEVsZW1lbnRzQnlDbGFzc05hbWUoJ2NhbGxiYWNrLWNvbXBvbmVudCcpKS5mb3JFYWNoKFxcblwiKS5jb25jYXQoXG4gIFwiZnVuY3Rpb24gKGUpIHtcXG5cIikuY29uY2F0KFxuICBcIiAgdmFyIG1lc3NhZ2UgPSBlLmZpcnN0RWxlbWVudENoaWxkO1xcblwiKS5jb25jYXQoXG4gIFwiICBpZiAobWVzc2FnZS5maXJzdENoaWxkICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlTmFtZSA9PSAnI3RleHQnICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlVmFsdWUudHJpbSgpID09ICdcIikuY29uY2F0KGFuY2hvcikuY29uY2F0KFwiJykge1xcblwiKS5jb25jYXQoXG4gIFwiICAgIG1lc3NhZ2UuY2xhc3NOYW1lID0gXFxcInRleHQtbGVmdFxcXCI7XFxuXCIpLmNvbmNhdChcbiAgXCIgICAgbWVzc2FnZS5hbGlnbiA9IFxcXCJcIikuY29uY2F0KGhhbGlnbikuY29uY2F0KFwiXFxcIjtcXG5cIikuY29uY2F0KFxuICBcIiAgICBtZXNzYWdlLmlubmVySFRNTCA9ICdcIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdChcIic7XFxuXCIpLmNvbmNhdChcbiAgXCIgIH1cXG5cIikuY29uY2F0KFxuICBcIn0pXCIpXG52YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sXG4gICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5UZXh0T3V0cHV0Q2FsbGJhY2ssXG4gICAgY29tLnN1bi5pZGVudGl0eS5hdXRoZW50aWNhdGlvbi5jYWxsYmFja3MuU2NyaXB0VGV4dE91dHB1dENhbGxiYWNrXG4pXG5pZiAobWVzc2FnZS5sZW5ndGggJiYgY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFxuICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKFxuICAgICAgICAgICAgZnIuVGV4dE91dHB1dENhbGxiYWNrLklORk9STUFUSU9OLFxuICAgICAgICAgICAgYW5jaG9yXG4gICAgICAgICksXG4gICAgICAgIG5ldyBmci5TY3JpcHRUZXh0T3V0cHV0Q2FsbGJhY2soc2NyaXB0KVxuICAgICkuYnVpbGQoKVxufVxuZWxzZSB7XG4gIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKFwidHJ1ZVwiKS5idWlsZCgpO1xufVxuXG4gLypcbiAgKiBHZW5lcmF0ZSBhIHRva2VuIGluIHRoZSBkZXNpcmVkIGZvcm1hdC4gQWxsICd4JyBjaGFyYWN0ZXJzIHdpbGwgYmUgcmVwbGFjZWQgd2l0aCBhIHJhbmRvbSBudW1iZXIgMC05LlxuICAqIFxuICAqIEV4YW1wbGU6XG4gICogJ3h4eHh4JyBwcm9kdWNlcyAnMjg1MzUnXG4gICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJ1xuICAqL1xuZnVuY3Rpb24gZ2VuZXJhdGVOdW1lcmljVG9rZW4oZm9ybWF0KSB7XG4gICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykge1xuICAgICAgICB2YXIgciA9IE1hdGgucmFuZG9tKCkqMTB8MDtcbiAgICAgICAgdmFyIHYgPSByO1xuICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7XG4gICAgfSk7XG59XG4i\"}"
+            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Display sharedState, transientState, and headers.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"debug\",\"script\":\"LyogZGVidWcKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogRGlzcGxheSBzaGFyZWRTdGF0ZSwgdHJhbnNpZW50U3RhdGUsIGFuZCBoZWFkZXJzLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSB0cnVlCiAqLwp2YXIgYW5jaG9yID0gImFuY2hvci0iLmNvbmNhdChnZW5lcmF0ZU51bWVyaWNUb2tlbigneHh4JykpOwp2YXIgaGFsaWduID0gImxlZnQiOwp2YXIgbWVzc2FnZSA9ICI8cD48Yj5TaGFyZWQgU3RhdGU8L2I+Ojxici8+Ii5jb25jYXQoCiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdCgiPC9wPiIpLmNvbmNhdCgKICAgICI8cD48Yj5UcmFuc2llbnQgU3RhdGU8L2I+Ojxici8+IikuY29uY2F0KAogICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoIjwvcD4iKS5jb25jYXQoCiAgICAiPHA+PGI+UmVxdWVzdCBIZWFkZXJzPC9iPjo8YnIvPiIpLmNvbmNhdCgKICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KCI8L3A+IikKdmFyIHNjcmlwdCA9ICJBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbChcbiIuY29uY2F0KAogICJkb2N1bWVudC5nZXRFbGVtZW50c0J5Q2xhc3NOYW1lKCdjYWxsYmFjay1jb21wb25lbnQnKSkuZm9yRWFjaChcbiIpLmNvbmNhdCgKICAiZnVuY3Rpb24gKGUpIHtcbiIpLmNvbmNhdCgKICAiICB2YXIgbWVzc2FnZSA9IGUuZmlyc3RFbGVtZW50Q2hpbGQ7XG4iKS5jb25jYXQoCiAgIiAgaWYgKG1lc3NhZ2UuZmlyc3RDaGlsZCAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZU5hbWUgPT0gJyN0ZXh0JyAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZVZhbHVlLnRyaW0oKSA9PSAnIikuY29uY2F0KGFuY2hvcikuY29uY2F0KCInKSB7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmNsYXNzTmFtZSA9IFwidGV4dC1sZWZ0XCI7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmFsaWduID0gXCIiKS5jb25jYXQoaGFsaWduKS5jb25jYXQoIlwiO1xuIikuY29uY2F0KAogICIgICAgbWVzc2FnZS5pbm5lckhUTUwgPSAnIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdCgiJztcbiIpLmNvbmNhdCgKICAiICB9XG4iKS5jb25jYXQoCiAgIn0pIikKdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKICAgIGNvbS5zdW4uaWRlbnRpdHkuYXV0aGVudGljYXRpb24uY2FsbGJhY2tzLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjawopCmlmIChtZXNzYWdlLmxlbmd0aCAmJiBjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICBhY3Rpb24gPSBmci5BY3Rpb24uc2VuZCgKICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKAogICAgICAgICAgICBmci5UZXh0T3V0cHV0Q2FsbGJhY2suSU5GT1JNQVRJT04sCiAgICAgICAgICAgIGFuY2hvcgogICAgICAgICksCiAgICAgICAgbmV3IGZyLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjayhzY3JpcHQpCiAgICApLmJ1aWxkKCkKfQplbHNlIHsKICBhY3Rpb24gPSBmci5BY3Rpb24uZ29UbygidHJ1ZSIpLmJ1aWxkKCk7Cn0KCiAvKgogICogR2VuZXJhdGUgYSB0b2tlbiBpbiB0aGUgZGVzaXJlZCBmb3JtYXQuIEFsbCAneCcgY2hhcmFjdGVycyB3aWxsIGJlIHJlcGxhY2VkIHdpdGggYSByYW5kb20gbnVtYmVyIDAtOS4KICAqIAogICogRXhhbXBsZToKICAqICd4eHh4eCcgcHJvZHVjZXMgJzI4NTM1JwogICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJwogICovCmZ1bmN0aW9uIGdlbmVyYXRlTnVtZXJpY1Rva2VuKGZvcm1hdCkgewogICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykgewogICAgICAgIHZhciByID0gTWF0aC5yYW5kb20oKSoxMHwwOwogICAgICAgIHZhciB2ID0gcjsKICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7CiAgICB9KTsKfQo=\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/3cb43516-ae69-433a-8787-501d45db14e9"
         },
         "response": {
-          "bodySize": 3403,
+          "bodySize": 3239,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 3403,
-            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"name\":\"debug\",\"description\":\"Display sharedState, transientState, and headers.\",\"script\":\"Ii8qIGRlYnVnXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBEaXNwbGF5IHNoYXJlZFN0YXRlLCB0cmFuc2llbnRTdGF0ZSwgYW5kIGhlYWRlcnMuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gdHJ1ZVxuICovXG52YXIgYW5jaG9yID0gXCJhbmNob3ItXCIuY29uY2F0KGdlbmVyYXRlTnVtZXJpY1Rva2VuKCd4eHgnKSk7XG52YXIgaGFsaWduID0gXCJsZWZ0XCI7XG52YXIgbWVzc2FnZSA9IFwiPHA+PGI+U2hhcmVkIFN0YXRlPC9iPjo8YnIvPlwiLmNvbmNhdChcbiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdChcIjwvcD5cIikuY29uY2F0KFxuICAgIFwiPHA+PGI+VHJhbnNpZW50IFN0YXRlPC9iPjo8YnIvPlwiKS5jb25jYXQoXG4gICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoXCI8L3A+XCIpLmNvbmNhdChcbiAgICBcIjxwPjxiPlJlcXVlc3QgSGVhZGVyczwvYj46PGJyLz5cIikuY29uY2F0KFxuICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KFwiPC9wPlwiKVxudmFyIHNjcmlwdCA9IFwiQXJyYXkucHJvdG90eXBlLnNsaWNlLmNhbGwoXFxuXCIuY29uY2F0KFxuICBcImRvY3VtZW50LmdldEVsZW1lbnRzQnlDbGFzc05hbWUoJ2NhbGxiYWNrLWNvbXBvbmVudCcpKS5mb3JFYWNoKFxcblwiKS5jb25jYXQoXG4gIFwiZnVuY3Rpb24gKGUpIHtcXG5cIikuY29uY2F0KFxuICBcIiAgdmFyIG1lc3NhZ2UgPSBlLmZpcnN0RWxlbWVudENoaWxkO1xcblwiKS5jb25jYXQoXG4gIFwiICBpZiAobWVzc2FnZS5maXJzdENoaWxkICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlTmFtZSA9PSAnI3RleHQnICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlVmFsdWUudHJpbSgpID09ICdcIikuY29uY2F0KGFuY2hvcikuY29uY2F0KFwiJykge1xcblwiKS5jb25jYXQoXG4gIFwiICAgIG1lc3NhZ2UuY2xhc3NOYW1lID0gXFxcInRleHQtbGVmdFxcXCI7XFxuXCIpLmNvbmNhdChcbiAgXCIgICAgbWVzc2FnZS5hbGlnbiA9IFxcXCJcIikuY29uY2F0KGhhbGlnbikuY29uY2F0KFwiXFxcIjtcXG5cIikuY29uY2F0KFxuICBcIiAgICBtZXNzYWdlLmlubmVySFRNTCA9ICdcIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdChcIic7XFxuXCIpLmNvbmNhdChcbiAgXCIgIH1cXG5cIikuY29uY2F0KFxuICBcIn0pXCIpXG52YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sXG4gICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5UZXh0T3V0cHV0Q2FsbGJhY2ssXG4gICAgY29tLnN1bi5pZGVudGl0eS5hdXRoZW50aWNhdGlvbi5jYWxsYmFja3MuU2NyaXB0VGV4dE91dHB1dENhbGxiYWNrXG4pXG5pZiAobWVzc2FnZS5sZW5ndGggJiYgY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFxuICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKFxuICAgICAgICAgICAgZnIuVGV4dE91dHB1dENhbGxiYWNrLklORk9STUFUSU9OLFxuICAgICAgICAgICAgYW5jaG9yXG4gICAgICAgICksXG4gICAgICAgIG5ldyBmci5TY3JpcHRUZXh0T3V0cHV0Q2FsbGJhY2soc2NyaXB0KVxuICAgICkuYnVpbGQoKVxufVxuZWxzZSB7XG4gIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKFwidHJ1ZVwiKS5idWlsZCgpO1xufVxuXG4gLypcbiAgKiBHZW5lcmF0ZSBhIHRva2VuIGluIHRoZSBkZXNpcmVkIGZvcm1hdC4gQWxsICd4JyBjaGFyYWN0ZXJzIHdpbGwgYmUgcmVwbGFjZWQgd2l0aCBhIHJhbmRvbSBudW1iZXIgMC05LlxuICAqIFxuICAqIEV4YW1wbGU6XG4gICogJ3h4eHh4JyBwcm9kdWNlcyAnMjg1MzUnXG4gICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJ1xuICAqL1xuZnVuY3Rpb24gZ2VuZXJhdGVOdW1lcmljVG9rZW4oZm9ybWF0KSB7XG4gICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykge1xuICAgICAgICB2YXIgciA9IE1hdGgucmFuZG9tKCkqMTB8MDtcbiAgICAgICAgdmFyIHYgPSByO1xuICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7XG4gICAgfSk7XG59XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574398904,\"evaluatorVersion\":\"1.0\"}"
+            "size": 3239,
+            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"name\":\"debug\",\"description\":\"Display sharedState, transientState, and headers.\",\"script\":\"LyogZGVidWcKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogRGlzcGxheSBzaGFyZWRTdGF0ZSwgdHJhbnNpZW50U3RhdGUsIGFuZCBoZWFkZXJzLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSB0cnVlCiAqLwp2YXIgYW5jaG9yID0gImFuY2hvci0iLmNvbmNhdChnZW5lcmF0ZU51bWVyaWNUb2tlbigneHh4JykpOwp2YXIgaGFsaWduID0gImxlZnQiOwp2YXIgbWVzc2FnZSA9ICI8cD48Yj5TaGFyZWQgU3RhdGU8L2I+Ojxici8+Ii5jb25jYXQoCiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdCgiPC9wPiIpLmNvbmNhdCgKICAgICI8cD48Yj5UcmFuc2llbnQgU3RhdGU8L2I+Ojxici8+IikuY29uY2F0KAogICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoIjwvcD4iKS5jb25jYXQoCiAgICAiPHA+PGI+UmVxdWVzdCBIZWFkZXJzPC9iPjo8YnIvPiIpLmNvbmNhdCgKICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KCI8L3A+IikKdmFyIHNjcmlwdCA9ICJBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbChcbiIuY29uY2F0KAogICJkb2N1bWVudC5nZXRFbGVtZW50c0J5Q2xhc3NOYW1lKCdjYWxsYmFjay1jb21wb25lbnQnKSkuZm9yRWFjaChcbiIpLmNvbmNhdCgKICAiZnVuY3Rpb24gKGUpIHtcbiIpLmNvbmNhdCgKICAiICB2YXIgbWVzc2FnZSA9IGUuZmlyc3RFbGVtZW50Q2hpbGQ7XG4iKS5jb25jYXQoCiAgIiAgaWYgKG1lc3NhZ2UuZmlyc3RDaGlsZCAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZU5hbWUgPT0gJyN0ZXh0JyAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZVZhbHVlLnRyaW0oKSA9PSAnIikuY29uY2F0KGFuY2hvcikuY29uY2F0KCInKSB7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmNsYXNzTmFtZSA9IFwidGV4dC1sZWZ0XCI7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmFsaWduID0gXCIiKS5jb25jYXQoaGFsaWduKS5jb25jYXQoIlwiO1xuIikuY29uY2F0KAogICIgICAgbWVzc2FnZS5pbm5lckhUTUwgPSAnIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdCgiJztcbiIpLmNvbmNhdCgKICAiICB9XG4iKS5jb25jYXQoCiAgIn0pIikKdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKICAgIGNvbS5zdW4uaWRlbnRpdHkuYXV0aGVudGljYXRpb24uY2FsbGJhY2tzLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjawopCmlmIChtZXNzYWdlLmxlbmd0aCAmJiBjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICBhY3Rpb24gPSBmci5BY3Rpb24uc2VuZCgKICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKAogICAgICAgICAgICBmci5UZXh0T3V0cHV0Q2FsbGJhY2suSU5GT1JNQVRJT04sCiAgICAgICAgICAgIGFuY2hvcgogICAgICAgICksCiAgICAgICAgbmV3IGZyLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjayhzY3JpcHQpCiAgICApLmJ1aWxkKCkKfQplbHNlIHsKICBhY3Rpb24gPSBmci5BY3Rpb24uZ29UbygidHJ1ZSIpLmJ1aWxkKCk7Cn0KCiAvKgogICogR2VuZXJhdGUgYSB0b2tlbiBpbiB0aGUgZGVzaXJlZCBmb3JtYXQuIEFsbCAneCcgY2hhcmFjdGVycyB3aWxsIGJlIHJlcGxhY2VkIHdpdGggYSByYW5kb20gbnVtYmVyIDAtOS4KICAqIAogICogRXhhbXBsZToKICAqICd4eHh4eCcgcHJvZHVjZXMgJzI4NTM1JwogICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJwogICovCmZ1bmN0aW9uIGdlbmVyYXRlTnVtZXJpY1Rva2VuKGZvcm1hdCkgewogICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykgewogICAgICAgIHZhciByID0gTWF0aC5yYW5kb20oKSoxMHwwOwogICAgICAgIHZhciB2ID0gcjsKICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7CiAgICB9KTsKfQo=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329894722,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -15086,15 +15086,15 @@
             },
             {
               "name": "content-length",
-              "value": "3403"
+              "value": "3239"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -15119,8 +15119,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.850Z",
-        "time": 76,
+        "startedDateTime": "2024-12-04T16:31:34.662Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15128,15 +15128,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 76
+          "wait": 84
         }
       },
       {
-        "_id": "9d93ce8c0cada398e926fde6717de656",
+        "_id": "ea15b364abb396f2b5708090ab733b71",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 709,
+          "bodySize": 697,
           "cookies": [],
           "headers": [
             {
@@ -15149,11 +15149,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -15165,7 +15165,7 @@
             },
             {
               "name": "content-length",
-              "value": "709"
+              "value": "697"
             },
             {
               "name": "accept-encoding",
@@ -15182,17 +15182,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set per level shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"level\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnbGV2ZWwnICsgbGV2ZWwgKyAnVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2V0IGF0IGVhY2ggbGV2ZWwgb2YgdGhlIG5lc3RlZCBqb3VybmV5cy4gSXQgY29udGFpbnMgYW4gaW5kaWNhdG9yIGluIHdoaWNoIGxldmVsIGl0IHdhcyBzZXQuJyk7XG59KCkpO1xuIg==\"}"
+            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set per level shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"level\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdsZXZlbCcgKyBsZXZlbCArICdWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzZXQgYXQgZWFjaCBsZXZlbCBvZiB0aGUgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIHNldC4nKTsKfSgpKTsK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/41c24257-d7fc-4654-8b46-c2666dc5b56d"
         },
         "response": {
-          "bodySize": 777,
+          "bodySize": 765,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 777,
-            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"name\":\"level\",\"description\":\"set per level shared state variable\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnbGV2ZWwnICsgbGV2ZWwgKyAnVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2V0IGF0IGVhY2ggbGV2ZWwgb2YgdGhlIG5lc3RlZCBqb3VybmV5cy4gSXQgY29udGFpbnMgYW4gaW5kaWNhdG9yIGluIHdoaWNoIGxldmVsIGl0IHdhcyBzZXQuJyk7XG59KCkpO1xuIg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574398979,\"evaluatorVersion\":\"1.0\"}"
+            "size": 765,
+            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"name\":\"level\",\"description\":\"set per level shared state variable\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdsZXZlbCcgKyBsZXZlbCArICdWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzZXQgYXQgZWFjaCBsZXZlbCBvZiB0aGUgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIHNldC4nKTsKfSgpKTsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329894818,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -15242,15 +15242,15 @@
             },
             {
               "name": "content-length",
-              "value": "777"
+              "value": "765"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -15275,8 +15275,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:18.930Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:34.750Z",
+        "time": 89,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15284,15 +15284,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 89
         }
       },
       {
-        "_id": "9f6c4ef1a2f56dd677351662221cc6bf",
+        "_id": "d367dbb7190523aee15f268dccbe87af",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2016,
+          "bodySize": 1960,
           "cookies": [],
           "headers": [
             {
@@ -15305,11 +15305,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -15321,7 +15321,7 @@
             },
             {
               "name": "content-length",
-              "value": "2016"
+              "value": "1960"
             },
             {
               "name": "accept-encoding",
@@ -15338,17 +15338,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if mode has already been set.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"mode\",\"script\":\"Ii8qIG1vZGVcbiAqXG4gKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tXG4gKiBcbiAqIENvbGxlY3QgbW9kZSBpZiBub3QgYWxyZWFkeSBzZXQgYW5kIHNldCBvdXRjb21lIHRvIG1vZGUuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gJ3NoYXJlZCBhbmQgbGV2ZWwnXG4gKiAtICdzaGFyZWQgb25seSdcbiAqIC0gJ2xldmVsIG9ubHknXG4gKiAtICdub25lJ1xuICovXG4oZnVuY3Rpb24gKCkge1xuICB2YXIgbW9kZSA9IG5vZGVTdGF0ZS5nZXQoJ21vZGUnKTtcbiAgaWYgKG1vZGUpIHtcbiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpO1xuICAgIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCkgKyAxO1xuICAgIGxvZ2dlci5lcnJvcignbW9kZTogbW9kZT0nICsgbW9kZS5hc1N0cmluZygpICsgJywgbGV2ZWw9JyArIGxldmVsKTtcbiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpO1xuICB9XG4gIGVsc2Uge1xuICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddO1xuICBcbiAgICB2YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbixcbiAgICAgIGphdmF4LnNlY3VyaXR5LmF1dGguY2FsbGJhY2suQ2hvaWNlQ2FsbGJhY2tcbiAgICApXG5cbiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQoW1xuICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSlcbiAgICAgIF0pLmJ1aWxkKCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTtcbiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ21vZGUnLCBjaG9pY2VzW2Nob2ljZV0pO1xuICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbGV2ZWwnLCAwKTtcbiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTtcbiAgICB9XG4gIH1cbn0oKSk7XG4i\"}"
+            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if mode has already been set.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"mode\",\"script\":\"LyogbW9kZQogKgogKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tCiAqIAogKiBDb2xsZWN0IG1vZGUgaWYgbm90IGFscmVhZHkgc2V0IGFuZCBzZXQgb3V0Y29tZSB0byBtb2RlLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSAnc2hhcmVkIGFuZCBsZXZlbCcKICogLSAnc2hhcmVkIG9ubHknCiAqIC0gJ2xldmVsIG9ubHknCiAqIC0gJ25vbmUnCiAqLwooZnVuY3Rpb24gKCkgewogIHZhciBtb2RlID0gbm9kZVN0YXRlLmdldCgnbW9kZScpOwogIGlmIChtb2RlKSB7CiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpOwogICAgdmFyIGxldmVsID0gbm9kZVN0YXRlLmdldCgnbGV2ZWwnKS5hc0ludGVnZXIoKSArIDE7CiAgICBsb2dnZXIuZXJyb3IoJ21vZGU6IG1vZGU9JyArIG1vZGUuYXNTdHJpbmcoKSArICcsIGxldmVsPScgKyBsZXZlbCk7CiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpOwogIH0KICBlbHNlIHsKICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddOwogIAogICAgdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbiwKICAgICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5DaG9pY2VDYWxsYmFjawogICAgKQoKICAgIGlmIChjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFsKICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSkKICAgICAgXSkuYnVpbGQoKTsKICAgIH0gZWxzZSB7CiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTsKICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbW9kZScsIGNob2ljZXNbY2hvaWNlXSk7CiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ2xldmVsJywgMCk7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTsKICAgIH0KICB9Cn0oKSk7Cg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/5bbdaeff-ddee-44b9-b608-8d413d7d65a6"
         },
         "response": {
-          "bodySize": 2084,
+          "bodySize": 2028,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 2084,
-            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"name\":\"mode\",\"description\":\"Check if mode has already been set.\",\"script\":\"Ii8qIG1vZGVcbiAqXG4gKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tXG4gKiBcbiAqIENvbGxlY3QgbW9kZSBpZiBub3QgYWxyZWFkeSBzZXQgYW5kIHNldCBvdXRjb21lIHRvIG1vZGUuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gJ3NoYXJlZCBhbmQgbGV2ZWwnXG4gKiAtICdzaGFyZWQgb25seSdcbiAqIC0gJ2xldmVsIG9ubHknXG4gKiAtICdub25lJ1xuICovXG4oZnVuY3Rpb24gKCkge1xuICB2YXIgbW9kZSA9IG5vZGVTdGF0ZS5nZXQoJ21vZGUnKTtcbiAgaWYgKG1vZGUpIHtcbiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpO1xuICAgIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCkgKyAxO1xuICAgIGxvZ2dlci5lcnJvcignbW9kZTogbW9kZT0nICsgbW9kZS5hc1N0cmluZygpICsgJywgbGV2ZWw9JyArIGxldmVsKTtcbiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpO1xuICB9XG4gIGVsc2Uge1xuICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddO1xuICBcbiAgICB2YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbixcbiAgICAgIGphdmF4LnNlY3VyaXR5LmF1dGguY2FsbGJhY2suQ2hvaWNlQ2FsbGJhY2tcbiAgICApXG5cbiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQoW1xuICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSlcbiAgICAgIF0pLmJ1aWxkKCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTtcbiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ21vZGUnLCBjaG9pY2VzW2Nob2ljZV0pO1xuICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbGV2ZWwnLCAwKTtcbiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTtcbiAgICB9XG4gIH1cbn0oKSk7XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574399051,\"evaluatorVersion\":\"1.0\"}"
+            "size": 2028,
+            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"name\":\"mode\",\"description\":\"Check if mode has already been set.\",\"script\":\"LyogbW9kZQogKgogKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tCiAqIAogKiBDb2xsZWN0IG1vZGUgaWYgbm90IGFscmVhZHkgc2V0IGFuZCBzZXQgb3V0Y29tZSB0byBtb2RlLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSAnc2hhcmVkIGFuZCBsZXZlbCcKICogLSAnc2hhcmVkIG9ubHknCiAqIC0gJ2xldmVsIG9ubHknCiAqIC0gJ25vbmUnCiAqLwooZnVuY3Rpb24gKCkgewogIHZhciBtb2RlID0gbm9kZVN0YXRlLmdldCgnbW9kZScpOwogIGlmIChtb2RlKSB7CiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpOwogICAgdmFyIGxldmVsID0gbm9kZVN0YXRlLmdldCgnbGV2ZWwnKS5hc0ludGVnZXIoKSArIDE7CiAgICBsb2dnZXIuZXJyb3IoJ21vZGU6IG1vZGU9JyArIG1vZGUuYXNTdHJpbmcoKSArICcsIGxldmVsPScgKyBsZXZlbCk7CiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpOwogIH0KICBlbHNlIHsKICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddOwogIAogICAgdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbiwKICAgICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5DaG9pY2VDYWxsYmFjawogICAgKQoKICAgIGlmIChjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFsKICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSkKICAgICAgXSkuYnVpbGQoKTsKICAgIH0gZWxzZSB7CiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTsKICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbW9kZScsIGNob2ljZXNbY2hvaWNlXSk7CiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ2xldmVsJywgMCk7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTsKICAgIH0KICB9Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329894911,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -15398,15 +15398,15 @@
             },
             {
               "name": "content-length",
-              "value": "2084"
+              "value": "2028"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:34 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -15431,8 +15431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.004Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:34.844Z",
+        "time": 91,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15440,7 +15440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 91
         }
       },
       {
@@ -15461,15 +15461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -15526,7 +15526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -15562,11 +15562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -15591,8 +15591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.073Z",
-        "time": 86,
+        "startedDateTime": "2024-12-04T16:31:34.939Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15600,7 +15600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 86
+          "wait": 88
         }
       },
       {
@@ -15621,15 +15621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -15686,7 +15686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -15722,11 +15722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -15751,8 +15751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.163Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:35.031Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15760,7 +15760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 78
         }
       },
       {
@@ -15781,15 +15781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -15846,7 +15846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -15882,11 +15882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -15911,8 +15911,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.234Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:31:35.118Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -15920,7 +15920,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 77
         }
       },
       {
@@ -15941,15 +15941,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16006,7 +16006,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16042,11 +16042,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -16071,8 +16071,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.322Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:35.199Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16080,7 +16080,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 77
         }
       },
       {
@@ -16101,15 +16101,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16166,7 +16166,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16202,11 +16202,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -16231,8 +16231,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.393Z",
-        "time": 63,
+        "startedDateTime": "2024-12-04T16:31:35.282Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16240,7 +16240,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 63
+          "wait": 79
         }
       },
       {
@@ -16261,15 +16261,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16326,7 +16326,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16362,11 +16362,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -16391,8 +16391,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.461Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:35.365Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16400,7 +16400,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 78
         }
       },
       {
@@ -16421,15 +16421,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16486,7 +16486,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16522,11 +16522,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:18 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -16551,8 +16551,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.530Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:31:35.450Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16560,7 +16560,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 86
         }
       },
       {
@@ -16581,15 +16581,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16646,7 +16646,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16682,11 +16682,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -16711,8 +16711,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.819Z",
-        "time": 77,
+        "startedDateTime": "2024-12-04T16:31:35.786Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16720,7 +16720,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 77
+          "wait": 84
         }
       },
       {
@@ -16741,15 +16741,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16806,7 +16806,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -16842,11 +16842,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:35 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -16871,8 +16871,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.901Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:35.875Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -16880,7 +16880,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 76
         }
       },
       {
@@ -16901,15 +16901,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -16966,7 +16966,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17002,11 +17002,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -17031,8 +17031,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:19.969Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:35.955Z",
+        "time": 91,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17040,7 +17040,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 91
         }
       },
       {
@@ -17061,15 +17061,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17126,7 +17126,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17162,11 +17162,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -17191,8 +17191,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.042Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:31:36.050Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17200,7 +17200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 80
         }
       },
       {
@@ -17221,15 +17221,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17286,7 +17286,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17322,11 +17322,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -17351,8 +17351,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.118Z",
-        "time": 60,
+        "startedDateTime": "2024-12-04T16:31:36.135Z",
+        "time": 97,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17360,7 +17360,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 60
+          "wait": 97
         }
       },
       {
@@ -17381,15 +17381,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17446,7 +17446,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17482,11 +17482,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -17511,8 +17511,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.183Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:36.236Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17520,7 +17520,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 78
         }
       },
       {
@@ -17541,15 +17541,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17606,7 +17606,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17642,11 +17642,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -17671,8 +17671,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.259Z",
-        "time": 60,
+        "startedDateTime": "2024-12-04T16:31:36.318Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17680,7 +17680,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 60
+          "wait": 85
         }
       },
       {
@@ -17701,15 +17701,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17766,7 +17766,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17802,11 +17802,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:19 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -17831,8 +17831,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.547Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:36.651Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -17840,7 +17840,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 86
         }
       },
       {
@@ -17861,15 +17861,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -17926,7 +17926,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -17962,11 +17962,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -17991,8 +17991,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.620Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:36.743Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18000,7 +18000,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 79
         }
       },
       {
@@ -18021,15 +18021,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18086,7 +18086,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18122,11 +18122,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -18151,8 +18151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.688Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:36.826Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18160,7 +18160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 75
         }
       },
       {
@@ -18181,15 +18181,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18246,7 +18246,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18282,11 +18282,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:36 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -18311,8 +18311,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.757Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:36.907Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18320,7 +18320,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 77
         }
       },
       {
@@ -18341,15 +18341,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18406,7 +18406,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18442,11 +18442,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -18471,8 +18471,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.830Z",
-        "time": 73,
+        "startedDateTime": "2024-12-04T16:31:36.988Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18480,7 +18480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 73
+          "wait": 79
         }
       },
       {
@@ -18501,15 +18501,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18566,7 +18566,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18602,11 +18602,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -18631,8 +18631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.908Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:37.071Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18640,7 +18640,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 77
         }
       },
       {
@@ -18661,15 +18661,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18726,7 +18726,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18762,11 +18762,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -18791,8 +18791,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:20.979Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:37.154Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18800,7 +18800,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 93
         }
       },
       {
@@ -18821,15 +18821,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -18886,7 +18886,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -18922,11 +18922,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -18951,8 +18951,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.284Z",
-        "time": 63,
+        "startedDateTime": "2024-12-04T16:31:37.510Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -18960,7 +18960,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 63
+          "wait": 80
         }
       },
       {
@@ -18981,15 +18981,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19046,7 +19046,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19082,11 +19082,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -19111,8 +19111,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.352Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:37.595Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19120,7 +19120,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 78
         }
       },
       {
@@ -19141,15 +19141,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19206,7 +19206,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19242,11 +19242,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -19271,8 +19271,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.421Z",
-        "time": 62,
+        "startedDateTime": "2024-12-04T16:31:37.678Z",
+        "time": 87,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19280,7 +19280,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 62
+          "wait": 87
         }
       },
       {
@@ -19301,15 +19301,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19366,7 +19366,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19402,11 +19402,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -19431,8 +19431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.487Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:37.773Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19440,7 +19440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 80
         }
       },
       {
@@ -19461,15 +19461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19526,7 +19526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19562,11 +19562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:20 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:37 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -19591,8 +19591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.562Z",
-        "time": 61,
+        "startedDateTime": "2024-12-04T16:31:37.857Z",
+        "time": 95,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19600,7 +19600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 61
+          "wait": 95
         }
       },
       {
@@ -19621,15 +19621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19686,7 +19686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19722,11 +19722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -19751,8 +19751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.628Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:37.956Z",
+        "time": 95,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19760,7 +19760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 95
         }
       },
       {
@@ -19781,15 +19781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -19846,7 +19846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -19882,11 +19882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -19911,8 +19911,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.697Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:38.056Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -19920,7 +19920,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 80
         }
       },
       {
@@ -19941,15 +19941,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20006,7 +20006,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20042,11 +20042,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -20071,8 +20071,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:21.972Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:38.382Z",
+        "time": 96,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20080,7 +20080,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 96
         }
       },
       {
@@ -20101,15 +20101,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20166,7 +20166,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20202,11 +20202,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -20231,8 +20231,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.045Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:31:38.482Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20240,7 +20240,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 88
         }
       },
       {
@@ -20261,15 +20261,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20326,7 +20326,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20362,11 +20362,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -20391,8 +20391,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.121Z",
-        "time": 60,
+        "startedDateTime": "2024-12-04T16:31:38.575Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20400,7 +20400,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 60
+          "wait": 76
         }
       },
       {
@@ -20421,15 +20421,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20486,7 +20486,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20522,11 +20522,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -20551,8 +20551,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.185Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:38.656Z",
+        "time": 88,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20560,7 +20560,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 88
         }
       },
       {
@@ -20581,15 +20581,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20646,7 +20646,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20682,11 +20682,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -20711,8 +20711,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.254Z",
-        "time": 75,
+        "startedDateTime": "2024-12-04T16:31:38.749Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20720,7 +20720,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 75
+          "wait": 83
         }
       },
       {
@@ -20741,15 +20741,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20806,7 +20806,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -20842,11 +20842,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -20871,8 +20871,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.333Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:38.836Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -20880,7 +20880,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 79
         }
       },
       {
@@ -20901,15 +20901,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -20966,7 +20966,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21002,11 +21002,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:21 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:38 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -21031,8 +21031,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.403Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:38.918Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21040,7 +21040,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 86
         }
       },
       {
@@ -21061,15 +21061,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21126,7 +21126,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21162,11 +21162,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:39 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -21191,8 +21191,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.674Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:39.248Z",
+        "time": 92,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21200,7 +21200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 92
         }
       },
       {
@@ -21221,15 +21221,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21286,7 +21286,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21322,11 +21322,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:39 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -21351,8 +21351,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.747Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:39.344Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21360,7 +21360,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 80
         }
       },
       {
@@ -21381,15 +21381,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21446,7 +21446,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21482,11 +21482,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:39 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -21511,8 +21511,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.819Z",
-        "time": 62,
+        "startedDateTime": "2024-12-04T16:31:39.428Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21520,7 +21520,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 62
+          "wait": 83
         }
       },
       {
@@ -21541,15 +21541,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21606,7 +21606,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21642,11 +21642,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:39 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -21671,8 +21671,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.885Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:39.515Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21680,7 +21680,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 72
         }
       },
       {
@@ -21701,15 +21701,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21766,7 +21766,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21802,11 +21802,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:39 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -21831,8 +21831,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:22.957Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:39.592Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -21840,7 +21840,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 70
         }
       },
       {
@@ -21861,15 +21861,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -21926,7 +21926,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -21962,11 +21962,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:39 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -21991,8 +21991,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.028Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:39.667Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22000,7 +22000,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 72
         }
       },
       {
@@ -22021,15 +22021,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22086,7 +22086,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22122,11 +22122,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:39 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -22151,8 +22151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.103Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:39.743Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22160,7 +22160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 66
         }
       },
       {
@@ -22181,15 +22181,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22246,7 +22246,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22282,11 +22282,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -22311,8 +22311,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.374Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:40.047Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22320,7 +22320,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 78
         }
       },
       {
@@ -22341,15 +22341,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22406,7 +22406,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22442,11 +22442,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -22471,8 +22471,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.449Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:40.130Z",
+        "time": 86,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22480,7 +22480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 86
         }
       },
       {
@@ -22501,15 +22501,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22566,7 +22566,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22602,11 +22602,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -22631,8 +22631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.520Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:40.221Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22640,7 +22640,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 85
         }
       },
       {
@@ -22661,15 +22661,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22726,7 +22726,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22762,11 +22762,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:22 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -22791,8 +22791,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.595Z",
-        "time": 59,
+        "startedDateTime": "2024-12-04T16:31:40.310Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22800,7 +22800,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 59
+          "wait": 68
         }
       },
       {
@@ -22821,15 +22821,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -22886,7 +22886,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -22922,11 +22922,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -22951,8 +22951,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.659Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:31:40.383Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -22960,7 +22960,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 82
         }
       },
       {
@@ -22981,15 +22981,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23046,7 +23046,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23082,11 +23082,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -23111,8 +23111,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.736Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:40.468Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23120,7 +23120,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 69
         }
       },
       {
@@ -23141,15 +23141,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23206,7 +23206,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23242,11 +23242,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -23271,7 +23271,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:23.811Z",
+        "startedDateTime": "2024-12-04T16:31:40.541Z",
         "time": 66,
         "timings": {
           "blocked": -1,
@@ -23301,15 +23301,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23366,7 +23366,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23402,11 +23402,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -23431,7 +23431,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.097Z",
+        "startedDateTime": "2024-12-04T16:31:40.842Z",
         "time": 69,
         "timings": {
           "blocked": -1,
@@ -23461,15 +23461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23526,7 +23526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23562,11 +23562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:40 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -23591,8 +23591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.171Z",
-        "time": 88,
+        "startedDateTime": "2024-12-04T16:31:40.915Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23600,7 +23600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 88
+          "wait": 83
         }
       },
       {
@@ -23621,15 +23621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23686,7 +23686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23722,11 +23722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -23751,8 +23751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.263Z",
-        "time": 72,
+        "startedDateTime": "2024-12-04T16:31:41.002Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23760,7 +23760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 72
+          "wait": 69
         }
       },
       {
@@ -23781,15 +23781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -23846,7 +23846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -23882,11 +23882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -23911,8 +23911,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.341Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:41.076Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -23920,7 +23920,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 73
         }
       },
       {
@@ -23941,15 +23941,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24006,7 +24006,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24042,11 +24042,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -24071,8 +24071,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.416Z",
-        "time": 79,
+        "startedDateTime": "2024-12-04T16:31:41.153Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24080,7 +24080,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 79
+          "wait": 78
         }
       },
       {
@@ -24101,15 +24101,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24166,7 +24166,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24202,11 +24202,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -24231,8 +24231,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.500Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:41.235Z",
+        "time": 71,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24240,7 +24240,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 71
         }
       },
       {
@@ -24261,15 +24261,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24326,7 +24326,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24362,11 +24362,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:23 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -24391,8 +24391,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.574Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:41.310Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24400,7 +24400,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 74
         }
       },
       {
@@ -24421,15 +24421,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24486,7 +24486,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24522,11 +24522,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -24551,8 +24551,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.864Z",
-        "time": 128,
+        "startedDateTime": "2024-12-04T16:31:41.609Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24560,7 +24560,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 128
+          "wait": 66
         }
       },
       {
@@ -24581,15 +24581,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24646,7 +24646,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24682,11 +24682,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -24711,8 +24711,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:24.997Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:41.681Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24720,7 +24720,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 85
         }
       },
       {
@@ -24741,15 +24741,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24806,7 +24806,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -24842,11 +24842,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -24871,8 +24871,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.075Z",
-        "time": 63,
+        "startedDateTime": "2024-12-04T16:31:41.771Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -24880,7 +24880,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 63
+          "wait": 80
         }
       },
       {
@@ -24901,15 +24901,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -24966,7 +24966,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25002,11 +25002,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -25031,8 +25031,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.143Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:41.855Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25040,7 +25040,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 70
         }
       },
       {
@@ -25061,15 +25061,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25126,7 +25126,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25162,11 +25162,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:41 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -25191,8 +25191,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.215Z",
-        "time": 62,
+        "startedDateTime": "2024-12-04T16:31:41.931Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25200,7 +25200,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 62
+          "wait": 77
         }
       },
       {
@@ -25221,15 +25221,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25286,7 +25286,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25322,11 +25322,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -25351,8 +25351,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.282Z",
-        "time": 82,
+        "startedDateTime": "2024-12-04T16:31:42.012Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25360,7 +25360,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 82
+          "wait": 72
         }
       },
       {
@@ -25381,15 +25381,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25446,7 +25446,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25482,11 +25482,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -25511,8 +25511,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.368Z",
-        "time": 80,
+        "startedDateTime": "2024-12-04T16:31:42.088Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25520,7 +25520,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 80
+          "wait": 75
         }
       },
       {
@@ -25541,15 +25541,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25606,7 +25606,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25642,11 +25642,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:24 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -25671,8 +25671,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.664Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:42.411Z",
+        "time": 94,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25680,7 +25680,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 94
         }
       },
       {
@@ -25701,15 +25701,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25766,7 +25766,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25802,11 +25802,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -25831,8 +25831,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.741Z",
-        "time": 63,
+        "startedDateTime": "2024-12-04T16:31:42.509Z",
+        "time": 94,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -25840,7 +25840,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 63
+          "wait": 94
         }
       },
       {
@@ -25861,15 +25861,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -25926,7 +25926,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -25962,11 +25962,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -25991,8 +25991,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.809Z",
-        "time": 78,
+        "startedDateTime": "2024-12-04T16:31:42.608Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26000,7 +26000,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 78
+          "wait": 93
         }
       },
       {
@@ -26021,15 +26021,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26086,7 +26086,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26122,11 +26122,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -26151,8 +26151,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.891Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:42.706Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26160,7 +26160,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 73
         }
       },
       {
@@ -26181,15 +26181,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26246,7 +26246,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26282,11 +26282,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -26311,8 +26311,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:25.961Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:42.784Z",
+        "time": 66,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26320,7 +26320,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 66
         }
       },
       {
@@ -26341,15 +26341,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26406,7 +26406,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26442,11 +26442,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -26471,8 +26471,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.034Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:42.856Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26480,7 +26480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 76
         }
       },
       {
@@ -26501,15 +26501,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26566,7 +26566,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26602,11 +26602,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:42 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -26631,8 +26631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.108Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:42.937Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26640,7 +26640,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 74
         }
       },
       {
@@ -26661,15 +26661,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26726,7 +26726,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26762,11 +26762,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -26791,8 +26791,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.392Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:43.239Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26800,7 +26800,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 93
         }
       },
       {
@@ -26821,15 +26821,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -26886,7 +26886,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -26922,11 +26922,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -26951,8 +26951,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.466Z",
-        "time": 65,
+        "startedDateTime": "2024-12-04T16:31:43.337Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -26960,7 +26960,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 65
+          "wait": 70
         }
       },
       {
@@ -26981,15 +26981,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27046,7 +27046,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27082,11 +27082,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -27111,8 +27111,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.536Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:43.411Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27120,7 +27120,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 69
         }
       },
       {
@@ -27141,15 +27141,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27206,7 +27206,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27242,11 +27242,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -27271,8 +27271,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.610Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:43.484Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27280,7 +27280,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 73
         }
       },
       {
@@ -27301,15 +27301,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27366,7 +27366,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27402,11 +27402,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:25 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -27431,8 +27431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.685Z",
-        "time": 70,
+        "startedDateTime": "2024-12-04T16:31:43.561Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27440,7 +27440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 70
+          "wait": 73
         }
       },
       {
@@ -27461,15 +27461,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27526,7 +27526,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27562,11 +27562,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -27591,8 +27591,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.759Z",
-        "time": 82,
+        "startedDateTime": "2024-12-04T16:31:43.639Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27600,7 +27600,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 82
+          "wait": 69
         }
       },
       {
@@ -27621,15 +27621,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27686,7 +27686,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27722,11 +27722,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -27751,8 +27751,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.846Z",
-        "time": 74,
+        "startedDateTime": "2024-12-04T16:31:43.712Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27760,7 +27760,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 74
+          "wait": 68
         }
       },
       {
@@ -27781,15 +27781,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -27846,7 +27846,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -27882,11 +27882,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:26 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:43 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -27911,8 +27911,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:26.926Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:43.785Z",
+        "time": 68,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -27920,7 +27920,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 68
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_af_D_262722764/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_af_D_262722764/oauth2_393036114/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "accept-api-version",
@@ -98,11 +98,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:24 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -127,8 +127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.300Z",
-        "time": 89,
+        "startedDateTime": "2024-12-04T16:31:24.536Z",
+        "time": 93,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -136,7 +136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 89
+          "wait": 93
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_af_D_262722764/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_af_D_262722764/openidm_3290118515/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -66,7 +66,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:24 GMT"
             },
             {
               "name": "cache-control",
@@ -114,7 +114,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -139,8 +139,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.427Z",
-        "time": 122,
+        "startedDateTime": "2024-12-04T16:31:24.666Z",
+        "time": 109,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 122
+          "wait": 109
         }
       },
       {
@@ -169,11 +169,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -210,7 +210,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:24 GMT"
             },
             {
               "name": "cache-control",
@@ -258,7 +258,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -283,8 +283,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.462Z",
-        "time": 71,
+        "startedDateTime": "2024-12-04T16:31:24.715Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -292,7 +292,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 71
+          "wait": 70
         }
       },
       {
@@ -313,11 +313,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -362,7 +362,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:09 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:24 GMT"
             },
             {
               "name": "cache-control",
@@ -406,7 +406,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -431,8 +431,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:09.634Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:24.884Z",
+        "time": 74,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -440,7 +440,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 74
         }
       },
       {
@@ -461,11 +461,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -510,7 +510,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "cache-control",
@@ -554,7 +554,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -579,8 +579,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.234Z",
-        "time": 60,
+        "startedDateTime": "2024-12-04T16:31:26.518Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -588,7 +588,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 60
+          "wait": 69
         }
       },
       {
@@ -609,11 +609,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -645,7 +645,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "cache-control",
@@ -689,7 +689,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -718,8 +718,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.299Z",
-        "time": 89,
+        "startedDateTime": "2024-12-04T16:31:26.592Z",
+        "time": 75,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -727,7 +727,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 89
+          "wait": 75
         }
       },
       {
@@ -748,11 +748,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -793,7 +793,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:11 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:26 GMT"
             },
             {
               "name": "cache-control",
@@ -837,7 +837,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -866,8 +866,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:11.400Z",
-        "time": 84,
+        "startedDateTime": "2024-12-04T16:31:26.680Z",
+        "time": 99,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -875,7 +875,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 99
         }
       },
       {
@@ -896,11 +896,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -945,7 +945,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:16 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:31 GMT"
             },
             {
               "name": "cache-control",
@@ -989,7 +989,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1014,8 +1014,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:16.440Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:31.722Z",
+        "time": 70,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1023,7 +1023,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 70
         }
       },
       {
@@ -1044,11 +1044,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -1093,7 +1093,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:32 GMT"
             },
             {
               "name": "cache-control",
@@ -1137,7 +1137,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1162,8 +1162,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.265Z",
-        "time": 85,
+        "startedDateTime": "2024-12-04T16:31:32.703Z",
+        "time": 69,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1171,7 +1171,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 69
         }
       },
       {
@@ -1192,11 +1192,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "authorization",
@@ -1241,7 +1241,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:33:17 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:33 GMT"
             },
             {
               "name": "cache-control",
@@ -1285,7 +1285,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-f6fac699-8d61-466d-bfe8-08d133555266"
+              "value": "frodo-121ac065-7ad4-4015-a455-b2c31a95462a"
             },
             {
               "name": "strict-transport-security",
@@ -1310,8 +1310,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:33:17.943Z",
-        "time": 47,
+        "startedDateTime": "2024-12-04T16:31:33.562Z",
+        "time": 60,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1319,7 +1319,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 47
+          "wait": 60
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_i_f_D_135597397/am_1076162899/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_i_f_D_135597397/am_1076162899/recording.har
@@ -25,15 +25,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.1"
             },
             {
               "name": "accept-encoding",
@@ -51,11 +51,11 @@
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
         },
         "response": {
-          "bodySize": 538,
+          "bodySize": 553,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 538,
-            "text": "{\"_id\":\"*\",\"_rev\":\"36966512\",\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
+            "size": 553,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1874515102\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[]}"
           },
           "cookies": [],
           "headers": [
@@ -77,7 +77,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.1"
             },
             {
               "name": "content-security-policy",
@@ -93,7 +93,7 @@
             },
             {
               "name": "etag",
-              "value": "\"36966512\""
+              "value": "\"1874515102\""
             },
             {
               "name": "expires",
@@ -109,15 +109,15 @@
             },
             {
               "name": "content-length",
-              "value": "538"
+              "value": "553"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -136,14 +136,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 785,
+          "headersSize": 787,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:02.624Z",
-        "time": 108,
+        "startedDateTime": "2024-12-04T16:31:08.204Z",
+        "time": 174,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -151,7 +151,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 108
+          "wait": 174
         }
       },
       {
@@ -172,11 +172,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
@@ -206,7 +206,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 282,
-            "text": "{\"_id\":\"version\",\"_rev\":\"355151460\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 493165657bbb9390016bd43ca767a46f23d8d24a (2024-September-23 14:30)\",\"revision\":\"493165657bbb9390016bd43ca767a46f23d8d24a\",\"date\":\"2024-September-23 14:30\"}"
+            "text": "{\"_id\":\"version\",\"_rev\":\"-1964495080\",\"version\":\"7.6.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 7.6.0-SNAPSHOT Build 7cab9c08465b06ed66fff4b458eef61d6b6825da (2024-November-15 10:51)\",\"revision\":\"7cab9c08465b06ed66fff4b458eef61d6b6825da\",\"date\":\"2024-November-15 10:51\"}"
           },
           "cookies": [],
           "headers": [
@@ -244,7 +244,7 @@
             },
             {
               "name": "etag",
-              "value": "\"355151460\""
+              "value": "\"-1964495080\""
             },
             {
               "name": "expires",
@@ -264,11 +264,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -287,14 +287,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 786,
+          "headersSize": 788,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:02.843Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:08.511Z",
+        "time": 77,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -302,7 +302,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 77
         }
       },
       {
@@ -323,15 +323,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -362,7 +362,7 @@
           "content": {
             "mimeType": "application/json;charset=UTF-8",
             "size": 31869,
-            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-501795106\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"description\":\"Reset Password Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"OrphanedTest\",\"_rev\":\"-764260244\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"343e745f-923a-43c4-8675-649a490fd0a3\",\"innerTreeOnly\":false,\"nodes\":{\"343e745f-923a-43c4-8675-649a490fd0a3\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":407.046875,\"y\":190.015625}},\"description\":\"Test orphaned nodes\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":704,\"y\":129},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":707,\"y\":381},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"test\",\"_rev\":\"279923916\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{},\"entryNodeId\":\"d26176be-ea6f-4f2a-81cd-3d41dd6cee4d\",\"innerTreeOnly\":false,\"nodes\":{},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":50,\"y\":117},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":152,\"y\":25},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ForgottenUsername\",\"_rev\":\"1703131230\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":0,\"y\":0},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":0,\"y\":0},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":0,\"y\":0}},\"description\":\"Forgotten Username Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j10\",\"_rev\":\"751431822\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"c91d626e-1156-41bd-b1fb-d292f640fba6\",\"innerTreeOnly\":false,\"nodes\":{\"300feda0-3248-49a9-b60f-01df802b2229\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"40afb384-e9b6-4dcb-acde-04de109474c8\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"8d7d64ee-da20-461f-a2ca-206b7479dd67\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\":{\"connections\":{\"true\":\"8d7d64ee-da20-461f-a2ca-206b7479dd67\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"c91d626e-1156-41bd-b1fb-d292f640fba6\":{\"connections\":{\"level only\":\"300feda0-3248-49a9-b60f-01df802b2229\",\"none\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\",\"shared and level\":\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\",\"shared only\":\"40afb384-e9b6-4dcb-acde-04de109474c8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j01\",\"_rev\":\"-523887030\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"f129f0df-b49e-453b-97fb-db508e3893ce\",\"innerTreeOnly\":false,\"nodes\":{\"6674b4ac-dd89-4e13-9440-6f81194e3a22\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\":{\"connections\":{\"true\":\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"f129f0df-b49e-453b-97fb-db508e3893ce\":{\"connections\":{\"level only\":\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\",\"none\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\",\"shared and level\":\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\",\"shared only\":\"6674b4ac-dd89-4e13-9440-6f81194e3a22\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"UpdatePassword\",\"_rev\":\"-1067190791\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"description\":\"Update password using active session\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j00\",\"_rev\":\"214130857\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\",\"innerTreeOnly\":false,\"nodes\":{\"01d3785f-7fb4-44a7-9458-72c380a9818f\":{\"connections\":{\"true\":\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":348,\"y\":61},\"39b48197-f4be-42b9-800a-866587b4b9b5\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":365,\"y\":252},\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":567,\"y\":64},\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\":{\"connections\":{\"level only\":\"39b48197-f4be-42b9-800a-866587b4b9b5\",\"none\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\",\"shared and level\":\"01d3785f-7fb4-44a7-9458-72c380a9818f\",\"shared only\":\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":117,\"y\":117},\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\":{\"connections\":{\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":760,\"y\":137},\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":338,\"y\":156}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":132,\"y\":364},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":137},\"startNode\":{\"x\":0,\"y\":0}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Login\",\"_rev\":\"-453684268\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"nodes\":{\"2119f332-0f69-4088-a7a1-6582bf0f2001\":{\"connections\":{\"Reject\":\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\",\"Retry\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\"},\"displayName\":\"Retry Limit Decision\",\"nodeType\":\"RetryLimitDecisionNode\",\"x\":612,\"y\":105.015625},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":827,\"y\":13},\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Account Lockout\",\"nodeType\":\"AccountLockoutNode\",\"x\":836,\"y\":184.015625},\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\":{\"connections\":{\"CANCELLED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EXPIRED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"FALSE\":\"2119f332-0f69-4088-a7a1-6582bf0f2001\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":352,\"y\":40.015625},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":579,\"y\":34}},\"description\":\"Platform Login Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1073,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":761,\"y\":401},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j03\",\"_rev\":\"-1352811052\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\",\"innerTreeOnly\":false,\"nodes\":{\"35a4f94b-c895-46b9-bc0a-93cf59233759\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"3a92300d-6d64-451d-8156-30cb51781026\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"6f9de973-9ed4-41f5-b43d-4036041e2b96\":{\"connections\":{\"true\":\"3a92300d-6d64-451d-8156-30cb51781026\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\":{\"connections\":{\"level only\":\"35a4f94b-c895-46b9-bc0a-93cf59233759\",\"none\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\",\"shared and level\":\"6f9de973-9ed4-41f5-b43d-4036041e2b96\",\"shared only\":\"fae7424e-13c9-45bd-b3a2-045773671a3f\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"fae7424e-13c9-45bd-b3a2-045773671a3f\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j02\",\"_rev\":\"2029292005\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"59b06306-a886-443d-92df-7a27a60c394e\",\"innerTreeOnly\":false,\"nodes\":{\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"56899fef-92a1-4f2a-ade3-973c81eb3af1\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"59b06306-a886-443d-92df-7a27a60c394e\":{\"connections\":{\"level only\":\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\",\"none\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\",\"shared and level\":\"e0983ead-4918-48f6-858d-9aff0f03759c\",\"shared only\":\"cbb3d506-b267-4b99-9edd-363e90aac997\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"cbb3d506-b267-4b99-9edd-363e90aac997\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e0983ead-4918-48f6-858d-9aff0f03759c\":{\"connections\":{\"true\":\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j05\",\"_rev\":\"1652057497\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"622179cb-98f1-484a-820d-9a0df6e45e95\",\"innerTreeOnly\":false,\"nodes\":{\"11f1c31c-50a9-4717-8213-420f6932481f\":{\"connections\":{\"true\":\"e90ae257-c279-46e0-9b43-5ecd89784d77\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"3c106772-ace7-4808-8f3a-9840de8f67f0\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"622179cb-98f1-484a-820d-9a0df6e45e95\":{\"connections\":{\"level only\":\"3c106772-ace7-4808-8f3a-9840de8f67f0\",\"none\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\",\"shared and level\":\"11f1c31c-50a9-4717-8213-420f6932481f\",\"shared only\":\"a0782616-84b7-4bf5-87ed-a01fb3018563\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"a0782616-84b7-4bf5-87ed-a01fb3018563\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e90ae257-c279-46e0-9b43-5ecd89784d77\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j04\",\"_rev\":\"-1089876293\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"040b6c89-313b-4664-92e0-6732017384b8\",\"innerTreeOnly\":false,\"nodes\":{\"00e75aa0-2f9b-4895-9257-d515286fd64b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"040b6c89-313b-4664-92e0-6732017384b8\":{\"connections\":{\"level only\":\"d10104e9-1f8d-4da6-a110-28d879d13959\",\"none\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\",\"shared and level\":\"f5c317ce-fabd-4a10-9907-c71cea037844\",\"shared only\":\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"69ae8ec1-de43-44ac-98e5-733db80ac176\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d10104e9-1f8d-4da6-a110-28d879d13959\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"f5c317ce-fabd-4a10-9907-c71cea037844\":{\"connections\":{\"true\":\"69ae8ec1-de43-44ac-98e5-733db80ac176\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j07\",\"_rev\":\"-937100459\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\",\"innerTreeOnly\":false,\"nodes\":{\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\":{\"connections\":{\"level only\":\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\",\"none\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\",\"shared and level\":\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\",\"shared only\":\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\":{\"connections\":{\"true\":\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j06\",\"_rev\":\"605160891\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\",\"innerTreeOnly\":false,\"nodes\":{\"1d59caff-243c-45bd-b7d0-6dcc563989c5\":{\"connections\":{\"true\":\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"409c251f-c23b-411d-9009-d3b3d26d1b90\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\":{\"connections\":{\"level only\":\"fe8f27df-8a27-4d88-9196-834ce398b2b7\",\"none\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\",\"shared and level\":\"1d59caff-243c-45bd-b7d0-6dcc563989c5\",\"shared only\":\"da878771-421c-463f-aad7-4d5f2ad5e59a\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"da878771-421c-463f-aad7-4d5f2ad5e59a\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"fe8f27df-8a27-4d88-9196-834ce398b2b7\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j09\",\"_rev\":\"-1358707527\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"251f35c3-1a32-4520-be10-1f4af9600935\",\"innerTreeOnly\":false,\"nodes\":{\"251f35c3-1a32-4520-be10-1f4af9600935\":{\"connections\":{\"level only\":\"56b82371-0c61-4dc3-8d06-c1158415b8f9\",\"none\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\",\"shared and level\":\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\",\"shared only\":\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"56b82371-0c61-4dc3-8d06-c1158415b8f9\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"6df24fdd-0b6c-4def-bf42-77af998f28b8\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\":{\"connections\":{\"true\":\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j08\",\"_rev\":\"-1997695217\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"d429b2b5-b215-46a5-b239-4994df65cb8b\",\"innerTreeOnly\":false,\"nodes\":{\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\":{\"connections\":{\"true\":\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"8096649e-973e-4209-88ce-e1d87ae2bb96\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"948e21f4-c512-450a-9d42-e0d629217834\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d429b2b5-b215-46a5-b239-4994df65cb8b\":{\"connections\":{\"level only\":\"8096649e-973e-4209-88ce-e1d87ae2bb96\",\"none\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\",\"shared and level\":\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\",\"shared only\":\"948e21f4-c512-450a-9d42-e0d629217834\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Registration\",\"_rev\":\"-340494482\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"466f8b54-07fb-4e31-a11d-a6842618cc37\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"466f8b54-07fb-4e31-a11d-a6842618cc37\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":484,\"y\":267.015625},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":861,\"y\":221},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":717,\"y\":283}},\"description\":\"Platform Registration Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1085,\"y\":248},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":921,\"y\":370},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"512701181\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"description\":\"Prompt for missing preferences on 3rd login\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"FrodoTest\",\"_rev\":\"1975823900\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"e2c39477-847a-4df2-9c5d-b449a752638b\",\"innerTreeOnly\":false,\"nodes\":{\"278bf084-9eea-46fe-8ce9-2600dde3b046\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":444,\"y\":273.015625},\"64157fca-bd5b-4405-a4c8-64ffd98a5461\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"SAML2 Authentication\",\"nodeType\":\"product-Saml2Node\",\"x\":1196,\"y\":188.015625},\"731c5810-020b-45c8-a7fc-3c21903ae2b3\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":443,\"y\":26.015625},\"bf153f37-83dd-4f39-aa0c-74135430242e\":{\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"64157fca-bd5b-4405-a4c8-64ffd98a5461\"},\"displayName\":\"Email Template Node\",\"nodeType\":\"EmailTemplateNode\",\"x\":967,\"y\":222.015625},\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"bf153f37-83dd-4f39-aa0c-74135430242e\"},\"displayName\":\"Social Login\",\"nodeType\":\"SocialProviderHandlerNode\",\"x\":702,\"y\":116.015625},\"e2c39477-847a-4df2-9c5d-b449a752638b\":{\"connections\":{\"known\":\"731c5810-020b-45c8-a7fc-3c21903ae2b3\",\"unknown\":\"278bf084-9eea-46fe-8ce9-2600dde3b046\"},\"displayName\":\"Check Username\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":200,\"y\":235.015625},\"fc7e47cd-c679-4211-8e05-a36654f23c67\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Validate Creds\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":702,\"y\":292.015625}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1434,\"y\":60},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1433,\"y\":459},\"startNode\":{\"x\":63,\"y\":252}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"RadioChoice\",\"_rev\":\"947126104\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"5d6cd20e-5074-43de-8832-fddd95fb078e\",\"innerTreeOnly\":false,\"nodes\":{\"5d6cd20e-5074-43de-8832-fddd95fb078e\":{\"connections\":{\"one\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"three\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"two\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":260,\"y\":409.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":50},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":744,\"y\":327},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true}],\"resultCount\":21,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-501795106\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"description\":\"Reset Password Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"OrphanedTest\",\"_rev\":\"-764260244\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"343e745f-923a-43c4-8675-649a490fd0a3\",\"innerTreeOnly\":false,\"nodes\":{\"343e745f-923a-43c4-8675-649a490fd0a3\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":407.046875,\"y\":190.015625}},\"description\":\"Test orphaned nodes\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":704,\"y\":129},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":707,\"y\":381},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"test\",\"_rev\":\"279923916\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{},\"entryNodeId\":\"d26176be-ea6f-4f2a-81cd-3d41dd6cee4d\",\"innerTreeOnly\":false,\"nodes\":{},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":50,\"y\":117},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":152,\"y\":25},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ForgottenUsername\",\"_rev\":\"1703131230\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":0,\"y\":0},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":0,\"y\":0},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":0,\"y\":0}},\"description\":\"Forgotten Username Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j10\",\"_rev\":\"751431822\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"c91d626e-1156-41bd-b1fb-d292f640fba6\",\"innerTreeOnly\":false,\"nodes\":{\"300feda0-3248-49a9-b60f-01df802b2229\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"40afb384-e9b6-4dcb-acde-04de109474c8\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"8d7d64ee-da20-461f-a2ca-206b7479dd67\":{\"connections\":{\"true\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\":{\"connections\":{\"true\":\"8d7d64ee-da20-461f-a2ca-206b7479dd67\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"c91d626e-1156-41bd-b1fb-d292f640fba6\":{\"connections\":{\"level only\":\"300feda0-3248-49a9-b60f-01df802b2229\",\"none\":\"c7fcf7ae-1ab5-474b-b5b0-272e10468fbd\",\"shared and level\":\"97ef9d96-99e7-4d2d-b6c6-4177b5397ead\",\"shared only\":\"40afb384-e9b6-4dcb-acde-04de109474c8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j01\",\"_rev\":\"-523887030\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"f129f0df-b49e-453b-97fb-db508e3893ce\",\"innerTreeOnly\":false,\"nodes\":{\"6674b4ac-dd89-4e13-9440-6f81194e3a22\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\":{\"connections\":{\"true\":\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":0,\"y\":0},\"bdfbe97c-1ff4-4162-85bc-47f6f14b2c66\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\":{\"connections\":{\"true\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0},\"f129f0df-b49e-453b-97fb-db508e3893ce\":{\"connections\":{\"level only\":\"e92d5139-b8a6-43dc-9b13-95ba1d0dc53c\",\"none\":\"bb1e96af-f316-4eb0-b1c6-36b3f1af9e35\",\"shared and level\":\"89ce5d57-82fa-4d58-8d15-0329f7dbd7e7\",\"shared only\":\"6674b4ac-dd89-4e13-9440-6f81194e3a22\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":0,\"y\":0}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"UpdatePassword\",\"_rev\":\"-1067190791\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"description\":\"Update password using active session\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Login\",\"_rev\":\"-453684268\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"nodes\":{\"2119f332-0f69-4088-a7a1-6582bf0f2001\":{\"connections\":{\"Reject\":\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\",\"Retry\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\"},\"displayName\":\"Retry Limit Decision\",\"nodeType\":\"RetryLimitDecisionNode\",\"x\":612,\"y\":105.015625},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":827,\"y\":13},\"51e8c4c1-3509-4635-90e6-d2cc31c4a6a5\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Account Lockout\",\"nodeType\":\"AccountLockoutNode\",\"x\":836,\"y\":184.015625},\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\":{\"connections\":{\"CANCELLED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EXPIRED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"FALSE\":\"2119f332-0f69-4088-a7a1-6582bf0f2001\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Identity Store Decision\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":352,\"y\":40.015625},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"7f0c2aee-8c74-4d02-82a6-9d4ed9d11708\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":579,\"y\":34}},\"description\":\"Platform Login Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1073,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":761,\"y\":401},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j00\",\"_rev\":\"214130857\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\",\"innerTreeOnly\":false,\"nodes\":{\"01d3785f-7fb4-44a7-9458-72c380a9818f\":{\"connections\":{\"true\":\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":348,\"y\":61},\"39b48197-f4be-42b9-800a-866587b4b9b5\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":365,\"y\":252},\"3c1e8d61-0c48-44ba-86dc-52e9555b6aeb\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":567,\"y\":64},\"513a2ab4-f0b8-4f94-b840-6fe14796cc84\":{\"connections\":{\"level only\":\"39b48197-f4be-42b9-800a-866587b4b9b5\",\"none\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\",\"shared and level\":\"01d3785f-7fb4-44a7-9458-72c380a9818f\",\"shared only\":\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":117,\"y\":117},\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\":{\"connections\":{\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":760,\"y\":137},\"d17ffaa1-2c61-4abd-9bb1-2559160d0a5c\":{\"connections\":{\"true\":\"ba503a1e-633e-4d0d-ba18-c9a9b1105b5b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":338,\"y\":156}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":132,\"y\":364},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":137},\"startNode\":{\"x\":0,\"y\":0}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j03\",\"_rev\":\"-1352811052\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\",\"innerTreeOnly\":false,\"nodes\":{\"35a4f94b-c895-46b9-bc0a-93cf59233759\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"3a92300d-6d64-451d-8156-30cb51781026\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"6f9de973-9ed4-41f5-b43d-4036041e2b96\":{\"connections\":{\"true\":\"3a92300d-6d64-451d-8156-30cb51781026\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"e0cfbd13-6f1e-4924-9d2d-0f7c23507172\":{\"connections\":{\"level only\":\"35a4f94b-c895-46b9-bc0a-93cf59233759\",\"none\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\",\"shared and level\":\"6f9de973-9ed4-41f5-b43d-4036041e2b96\",\"shared only\":\"fae7424e-13c9-45bd-b3a2-045773671a3f\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"fae7424e-13c9-45bd-b3a2-045773671a3f\":{\"connections\":{\"true\":\"bcb8c535-5ecd-4d3d-b970-26816de96bf2\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j02\",\"_rev\":\"2029292005\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"59b06306-a886-443d-92df-7a27a60c394e\",\"innerTreeOnly\":false,\"nodes\":{\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"56899fef-92a1-4f2a-ade3-973c81eb3af1\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"59b06306-a886-443d-92df-7a27a60c394e\":{\"connections\":{\"level only\":\"4416aff7-3ebd-47e6-9831-c2f6bbe3ae24\",\"none\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\",\"shared and level\":\"e0983ead-4918-48f6-858d-9aff0f03759c\",\"shared only\":\"cbb3d506-b267-4b99-9edd-363e90aac997\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"cbb3d506-b267-4b99-9edd-363e90aac997\":{\"connections\":{\"true\":\"56899fef-92a1-4f2a-ade3-973c81eb3af1\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e0983ead-4918-48f6-858d-9aff0f03759c\":{\"connections\":{\"true\":\"2dbd2d37-c659-48cf-8357-c9fc1166e3a7\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j05\",\"_rev\":\"1652057497\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"622179cb-98f1-484a-820d-9a0df6e45e95\",\"innerTreeOnly\":false,\"nodes\":{\"11f1c31c-50a9-4717-8213-420f6932481f\":{\"connections\":{\"true\":\"e90ae257-c279-46e0-9b43-5ecd89784d77\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"3c106772-ace7-4808-8f3a-9840de8f67f0\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"622179cb-98f1-484a-820d-9a0df6e45e95\":{\"connections\":{\"level only\":\"3c106772-ace7-4808-8f3a-9840de8f67f0\",\"none\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\",\"shared and level\":\"11f1c31c-50a9-4717-8213-420f6932481f\",\"shared only\":\"a0782616-84b7-4bf5-87ed-a01fb3018563\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"a0782616-84b7-4bf5-87ed-a01fb3018563\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"e90ae257-c279-46e0-9b43-5ecd89784d77\":{\"connections\":{\"true\":\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f17ecb7c-abc3-4523-9943-4cbdd90305cb\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j04\",\"_rev\":\"-1089876293\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"040b6c89-313b-4664-92e0-6732017384b8\",\"innerTreeOnly\":false,\"nodes\":{\"00e75aa0-2f9b-4895-9257-d515286fd64b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"040b6c89-313b-4664-92e0-6732017384b8\":{\"connections\":{\"level only\":\"d10104e9-1f8d-4da6-a110-28d879d13959\",\"none\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\",\"shared and level\":\"f5c317ce-fabd-4a10-9907-c71cea037844\",\"shared only\":\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"69ae8ec1-de43-44ac-98e5-733db80ac176\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"9603ef52-30f0-4ddc-b3c0-28dac83c7bdb\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d10104e9-1f8d-4da6-a110-28d879d13959\":{\"connections\":{\"true\":\"00e75aa0-2f9b-4895-9257-d515286fd64b\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"f5c317ce-fabd-4a10-9907-c71cea037844\":{\"connections\":{\"true\":\"69ae8ec1-de43-44ac-98e5-733db80ac176\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j07\",\"_rev\":\"-937100459\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\",\"innerTreeOnly\":false,\"nodes\":{\"13b12fe6-cf53-46a4-a83d-0a3c1fda814f\":{\"connections\":{\"level only\":\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\",\"none\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\",\"shared and level\":\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\",\"shared only\":\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d90dd9f8-8b12-4e90-abaf-228ecc0174a7\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"d9a06d3a-7e3f-4244-9a32-63ffa0d26e00\":{\"connections\":{\"true\":\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"f2fe740c-cd75-460a-8baa-fe4b52ecc947\":{\"connections\":{\"true\":\"e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j06\",\"_rev\":\"605160891\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\",\"innerTreeOnly\":false,\"nodes\":{\"1d59caff-243c-45bd-b7d0-6dcc563989c5\":{\"connections\":{\"true\":\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"409c251f-c23b-411d-9009-d3b3d26d1b90\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"44b8651c-7c1e-41f1-b9a6-2e441b0ce05a\":{\"connections\":{\"level only\":\"fe8f27df-8a27-4d88-9196-834ce398b2b7\",\"none\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\",\"shared and level\":\"1d59caff-243c-45bd-b7d0-6dcc563989c5\",\"shared only\":\"da878771-421c-463f-aad7-4d5f2ad5e59a\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"da878771-421c-463f-aad7-4d5f2ad5e59a\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"fe8f27df-8a27-4d88-9196-834ce398b2b7\":{\"connections\":{\"true\":\"409c251f-c23b-411d-9009-d3b3d26d1b90\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j09\",\"_rev\":\"-1358707527\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"251f35c3-1a32-4520-be10-1f4af9600935\",\"innerTreeOnly\":false,\"nodes\":{\"251f35c3-1a32-4520-be10-1f4af9600935\":{\"connections\":{\"level only\":\"56b82371-0c61-4dc3-8d06-c1158415b8f9\",\"none\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\",\"shared and level\":\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\",\"shared only\":\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625},\"56b82371-0c61-4dc3-8d06-c1158415b8f9\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"6df24fdd-0b6c-4def-bf42-77af998f28b8\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":233.015625},\"8c5e9cb5-471b-4dd6-b150-ecaaeda98195\":{\"connections\":{\"true\":\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"bb294e05-6b6b-4478-b46f-b8d9e7711c66\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"f57cf53c-b4c6-48f7-84e8-91f535a2e8f8\":{\"connections\":{\"true\":\"6df24fdd-0b6c-4def-bf42-77af998f28b8\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"j08\",\"_rev\":\"-1997695217\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"d429b2b5-b215-46a5-b239-4994df65cb8b\",\"innerTreeOnly\":false,\"nodes\":{\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\":{\"connections\":{\"true\":\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":392,\"y\":173.015625},\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"nest\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":816,\"y\":232.015625},\"8096649e-973e-4209-88ce-e1d87ae2bb96\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":395,\"y\":345.015625},\"87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"level\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":598,\"y\":173.015625},\"948e21f4-c512-450a-9d42-e0d629217834\":{\"connections\":{\"true\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\"},\"displayName\":\"shared\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":393,\"y\":259.015625},\"d429b2b5-b215-46a5-b239-4994df65cb8b\":{\"connections\":{\"level only\":\"8096649e-973e-4209-88ce-e1d87ae2bb96\",\"none\":\"66026170-5088-4fcd-a6c8-ed89d7a5c79d\",\"shared and level\":\"042b600b-71cb-45a8-93ae-a6f57b16a6e5\",\"shared only\":\"948e21f4-c512-450a-9d42-e0d629217834\"},\"displayName\":\"mode\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":167,\"y\":210.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1236,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1236,\"y\":253},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"Registration\",\"_rev\":\"-340494482\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"466f8b54-07fb-4e31-a11d-a6842618cc37\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"466f8b54-07fb-4e31-a11d-a6842618cc37\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":484,\"y\":267.015625},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":861,\"y\":221},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":717,\"y\":283}},\"description\":\"Platform Registration Tree\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1085,\"y\":248},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":921,\"y\":370},\"startNode\":{\"x\":50,\"y\":25}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"512701181\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"description\":\"Prompt for missing preferences on 3rd login\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"FrodoTest\",\"_rev\":\"1975823900\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[\\\"Frodo\\\",\\\"Prototype\\\"]\"},\"entryNodeId\":\"e2c39477-847a-4df2-9c5d-b449a752638b\",\"innerTreeOnly\":false,\"nodes\":{\"278bf084-9eea-46fe-8ce9-2600dde3b046\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":444,\"y\":273.015625},\"64157fca-bd5b-4405-a4c8-64ffd98a5461\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"SAML2 Authentication\",\"nodeType\":\"product-Saml2Node\",\"x\":1196,\"y\":188.015625},\"731c5810-020b-45c8-a7fc-3c21903ae2b3\":{\"connections\":{\"localAuthentication\":\"fc7e47cd-c679-4211-8e05-a36654f23c67\",\"socialAuthentication\":\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\"},\"displayName\":\"Login Page\",\"nodeType\":\"PageNode\",\"x\":443,\"y\":26.015625},\"bf153f37-83dd-4f39-aa0c-74135430242e\":{\"connections\":{\"EMAIL_NOT_SENT\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"EMAIL_SENT\":\"64157fca-bd5b-4405-a4c8-64ffd98a5461\"},\"displayName\":\"Email Template Node\",\"nodeType\":\"EmailTemplateNode\",\"x\":967,\"y\":222.015625},\"d5cc2d52-6ce4-452d-85ea-3a5b50218b67\":{\"connections\":{\"ACCOUNT_EXISTS\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"NO_ACCOUNT\":\"bf153f37-83dd-4f39-aa0c-74135430242e\"},\"displayName\":\"Social Login\",\"nodeType\":\"SocialProviderHandlerNode\",\"x\":702,\"y\":116.015625},\"e2c39477-847a-4df2-9c5d-b449a752638b\":{\"connections\":{\"known\":\"731c5810-020b-45c8-a7fc-3c21903ae2b3\",\"unknown\":\"278bf084-9eea-46fe-8ce9-2600dde3b046\"},\"displayName\":\"Check Username\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":200,\"y\":235.015625},\"fc7e47cd-c679-4211-8e05-a36654f23c67\":{\"connections\":{\"CANCELLED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"EXPIRED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"FALSE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"LOCKED\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"TRUE\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Validate Creds\",\"nodeType\":\"IdentityStoreDecisionNode\",\"x\":702,\"y\":292.015625}},\"description\":\"Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.\",\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1434,\"y\":60},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1433,\"y\":459},\"startNode\":{\"x\":63,\"y\":252}},\"mustRun\":false,\"enabled\":true},{\"_id\":\"RadioChoice\",\"_rev\":\"947126104\",\"identityResource\":\"managed/alpha_user\",\"uiConfig\":{\"categories\":\"[]\"},\"entryNodeId\":\"5d6cd20e-5074-43de-8832-fddd95fb078e\",\"innerTreeOnly\":false,\"nodes\":{\"5d6cd20e-5074-43de-8832-fddd95fb078e\":{\"connections\":{\"one\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"three\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"two\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":260,\"y\":409.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":50},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":744,\"y\":327},\"startNode\":{\"x\":50,\"y\":250}},\"mustRun\":false,\"enabled\":true}],\"resultCount\":21,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
           },
           "cookies": [],
           "headers": [
@@ -384,7 +384,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "protocol=2.1,resource=2.0, resource=2.0"
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -412,11 +412,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -445,7 +445,319 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:02.985Z",
+        "startedDateTime": "2024-12-04T16:31:08.666Z",
+        "time": 90,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 90
+        }
+      },
+      {
+        "_id": "ecc5b4f2eb12840cf634a5faa3ca5784",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 681,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "681"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2021,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set the same shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"shared\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdzaGFyZWRWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzaGFyZWQgYWNyb3NzIGFsbCBuZXN0ZWQgam91cm5leXMuIEl0IGNvbnRhaW5zIGFuIGluZGljYXRvciBpbiB3aGljaCBsZXZlbCBpdCB3YXMgbGFzdCBzZXQuJyk7Cn0oKSk7Cg==\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/1b52a7e0-4019-40fa-958a-15a49870e901"
+        },
+        "response": {
+          "bodySize": 749,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 749,
+            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"name\":\"shared\",\"description\":\"set the same shared state variable\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdzaGFyZWRWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzaGFyZWQgYWNyb3NzIGFsbCBuZXN0ZWQgam91cm5leXMuIEl0IGNvbnRhaW5zIGFuIGluZGljYXRvciBpbiB3aGljaCBsZXZlbCBpdCB3YXMgbGFzdCBzZXQuJyk7Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329868824,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "749"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-12-04T16:31:08.763Z",
+        "time": 83,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 83
+        }
+      },
+      {
+        "_id": "124e3260c3d3bd1d675f6cb1e5813068",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 3171,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "3171"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2022,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Display sharedState, transientState, and headers.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"debug\",\"script\":\"LyogZGVidWcKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogRGlzcGxheSBzaGFyZWRTdGF0ZSwgdHJhbnNpZW50U3RhdGUsIGFuZCBoZWFkZXJzLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSB0cnVlCiAqLwp2YXIgYW5jaG9yID0gImFuY2hvci0iLmNvbmNhdChnZW5lcmF0ZU51bWVyaWNUb2tlbigneHh4JykpOwp2YXIgaGFsaWduID0gImxlZnQiOwp2YXIgbWVzc2FnZSA9ICI8cD48Yj5TaGFyZWQgU3RhdGU8L2I+Ojxici8+Ii5jb25jYXQoCiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdCgiPC9wPiIpLmNvbmNhdCgKICAgICI8cD48Yj5UcmFuc2llbnQgU3RhdGU8L2I+Ojxici8+IikuY29uY2F0KAogICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoIjwvcD4iKS5jb25jYXQoCiAgICAiPHA+PGI+UmVxdWVzdCBIZWFkZXJzPC9iPjo8YnIvPiIpLmNvbmNhdCgKICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KCI8L3A+IikKdmFyIHNjcmlwdCA9ICJBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbChcbiIuY29uY2F0KAogICJkb2N1bWVudC5nZXRFbGVtZW50c0J5Q2xhc3NOYW1lKCdjYWxsYmFjay1jb21wb25lbnQnKSkuZm9yRWFjaChcbiIpLmNvbmNhdCgKICAiZnVuY3Rpb24gKGUpIHtcbiIpLmNvbmNhdCgKICAiICB2YXIgbWVzc2FnZSA9IGUuZmlyc3RFbGVtZW50Q2hpbGQ7XG4iKS5jb25jYXQoCiAgIiAgaWYgKG1lc3NhZ2UuZmlyc3RDaGlsZCAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZU5hbWUgPT0gJyN0ZXh0JyAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZVZhbHVlLnRyaW0oKSA9PSAnIikuY29uY2F0KGFuY2hvcikuY29uY2F0KCInKSB7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmNsYXNzTmFtZSA9IFwidGV4dC1sZWZ0XCI7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmFsaWduID0gXCIiKS5jb25jYXQoaGFsaWduKS5jb25jYXQoIlwiO1xuIikuY29uY2F0KAogICIgICAgbWVzc2FnZS5pbm5lckhUTUwgPSAnIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdCgiJztcbiIpLmNvbmNhdCgKICAiICB9XG4iKS5jb25jYXQoCiAgIn0pIikKdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKICAgIGNvbS5zdW4uaWRlbnRpdHkuYXV0aGVudGljYXRpb24uY2FsbGJhY2tzLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjawopCmlmIChtZXNzYWdlLmxlbmd0aCAmJiBjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICBhY3Rpb24gPSBmci5BY3Rpb24uc2VuZCgKICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKAogICAgICAgICAgICBmci5UZXh0T3V0cHV0Q2FsbGJhY2suSU5GT1JNQVRJT04sCiAgICAgICAgICAgIGFuY2hvcgogICAgICAgICksCiAgICAgICAgbmV3IGZyLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjayhzY3JpcHQpCiAgICApLmJ1aWxkKCkKfQplbHNlIHsKICBhY3Rpb24gPSBmci5BY3Rpb24uZ29UbygidHJ1ZSIpLmJ1aWxkKCk7Cn0KCiAvKgogICogR2VuZXJhdGUgYSB0b2tlbiBpbiB0aGUgZGVzaXJlZCBmb3JtYXQuIEFsbCAneCcgY2hhcmFjdGVycyB3aWxsIGJlIHJlcGxhY2VkIHdpdGggYSByYW5kb20gbnVtYmVyIDAtOS4KICAqIAogICogRXhhbXBsZToKICAqICd4eHh4eCcgcHJvZHVjZXMgJzI4NTM1JwogICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJwogICovCmZ1bmN0aW9uIGdlbmVyYXRlTnVtZXJpY1Rva2VuKGZvcm1hdCkgewogICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykgewogICAgICAgIHZhciByID0gTWF0aC5yYW5kb20oKSoxMHwwOwogICAgICAgIHZhciB2ID0gcjsKICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7CiAgICB9KTsKfQo=\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/3cb43516-ae69-433a-8787-501d45db14e9"
+        },
+        "response": {
+          "bodySize": 3239,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3239,
+            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"name\":\"debug\",\"description\":\"Display sharedState, transientState, and headers.\",\"script\":\"LyogZGVidWcKICoKICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbQogKiAKICogRGlzcGxheSBzaGFyZWRTdGF0ZSwgdHJhbnNpZW50U3RhdGUsIGFuZCBoZWFkZXJzLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSB0cnVlCiAqLwp2YXIgYW5jaG9yID0gImFuY2hvci0iLmNvbmNhdChnZW5lcmF0ZU51bWVyaWNUb2tlbigneHh4JykpOwp2YXIgaGFsaWduID0gImxlZnQiOwp2YXIgbWVzc2FnZSA9ICI8cD48Yj5TaGFyZWQgU3RhdGU8L2I+Ojxici8+Ii5jb25jYXQoCiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdCgiPC9wPiIpLmNvbmNhdCgKICAgICI8cD48Yj5UcmFuc2llbnQgU3RhdGU8L2I+Ojxici8+IikuY29uY2F0KAogICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoIjwvcD4iKS5jb25jYXQoCiAgICAiPHA+PGI+UmVxdWVzdCBIZWFkZXJzPC9iPjo8YnIvPiIpLmNvbmNhdCgKICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KCI8L3A+IikKdmFyIHNjcmlwdCA9ICJBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbChcbiIuY29uY2F0KAogICJkb2N1bWVudC5nZXRFbGVtZW50c0J5Q2xhc3NOYW1lKCdjYWxsYmFjay1jb21wb25lbnQnKSkuZm9yRWFjaChcbiIpLmNvbmNhdCgKICAiZnVuY3Rpb24gKGUpIHtcbiIpLmNvbmNhdCgKICAiICB2YXIgbWVzc2FnZSA9IGUuZmlyc3RFbGVtZW50Q2hpbGQ7XG4iKS5jb25jYXQoCiAgIiAgaWYgKG1lc3NhZ2UuZmlyc3RDaGlsZCAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZU5hbWUgPT0gJyN0ZXh0JyAmJiBtZXNzYWdlLmZpcnN0Q2hpbGQubm9kZVZhbHVlLnRyaW0oKSA9PSAnIikuY29uY2F0KGFuY2hvcikuY29uY2F0KCInKSB7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmNsYXNzTmFtZSA9IFwidGV4dC1sZWZ0XCI7XG4iKS5jb25jYXQoCiAgIiAgICBtZXNzYWdlLmFsaWduID0gXCIiKS5jb25jYXQoaGFsaWduKS5jb25jYXQoIlwiO1xuIikuY29uY2F0KAogICIgICAgbWVzc2FnZS5pbm5lckhUTUwgPSAnIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdCgiJztcbiIpLmNvbmNhdCgKICAiICB9XG4iKS5jb25jYXQoCiAgIn0pIikKdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKICAgIGNvbS5zdW4uaWRlbnRpdHkuYXV0aGVudGljYXRpb24uY2FsbGJhY2tzLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjawopCmlmIChtZXNzYWdlLmxlbmd0aCAmJiBjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICBhY3Rpb24gPSBmci5BY3Rpb24uc2VuZCgKICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKAogICAgICAgICAgICBmci5UZXh0T3V0cHV0Q2FsbGJhY2suSU5GT1JNQVRJT04sCiAgICAgICAgICAgIGFuY2hvcgogICAgICAgICksCiAgICAgICAgbmV3IGZyLlNjcmlwdFRleHRPdXRwdXRDYWxsYmFjayhzY3JpcHQpCiAgICApLmJ1aWxkKCkKfQplbHNlIHsKICBhY3Rpb24gPSBmci5BY3Rpb24uZ29UbygidHJ1ZSIpLmJ1aWxkKCk7Cn0KCiAvKgogICogR2VuZXJhdGUgYSB0b2tlbiBpbiB0aGUgZGVzaXJlZCBmb3JtYXQuIEFsbCAneCcgY2hhcmFjdGVycyB3aWxsIGJlIHJlcGxhY2VkIHdpdGggYSByYW5kb20gbnVtYmVyIDAtOS4KICAqIAogICogRXhhbXBsZToKICAqICd4eHh4eCcgcHJvZHVjZXMgJzI4NTM1JwogICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJwogICovCmZ1bmN0aW9uIGdlbmVyYXRlTnVtZXJpY1Rva2VuKGZvcm1hdCkgewogICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykgewogICAgICAgIHZhciByID0gTWF0aC5yYW5kb20oKSoxMHwwOwogICAgICAgIHZhciB2ID0gcjsKICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7CiAgICB9KTsKfQo=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329868909,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "3239"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 767,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-12-04T16:31:08.852Z",
         "time": 77,
         "timings": {
           "blocked": -1,
@@ -458,11 +770,11 @@
         }
       },
       {
-        "_id": "9cf0243aa28aad2f8450fabb17eae4a7",
+        "_id": "ea15b364abb396f2b5708090ab733b71",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 689,
+          "bodySize": 697,
           "cookies": [],
           "headers": [
             {
@@ -475,11 +787,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
@@ -491,7 +803,7 @@
             },
             {
               "name": "content-length",
-              "value": "689"
+              "value": "697"
             },
             {
               "name": "accept-encoding",
@@ -508,329 +820,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set the same shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"shared\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnc2hhcmVkVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2hhcmVkIGFjcm9zcyBhbGwgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIGxhc3Qgc2V0LicpO1xufSgpKTtcbiI=\"}"
-          },
-          "queryString": [],
-          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/1b52a7e0-4019-40fa-958a-15a49870e901"
-        },
-        "response": {
-          "bodySize": 757,
-          "content": {
-            "mimeType": "application/json;charset=UTF-8",
-            "size": 757,
-            "text": "{\"_id\":\"1b52a7e0-4019-40fa-958a-15a49870e901\",\"name\":\"shared\",\"description\":\"set the same shared state variable\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnc2hhcmVkVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2hhcmVkIGFjcm9zcyBhbGwgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIGxhc3Qgc2V0LicpO1xufSgpKTtcbiI=\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574263116,\"evaluatorVersion\":\"1.0\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "x-frame-options",
-              "value": "SAMEORIGIN"
-            },
-            {
-              "name": "content-security-policy-report-only",
-              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "cache-control",
-              "value": "private"
-            },
-            {
-              "name": "content-api-version",
-              "value": "resource=1.1"
-            },
-            {
-              "name": "content-security-policy",
-              "value": "default-src 'none';frame-ancestors 'none';sandbox"
-            },
-            {
-              "name": "cross-origin-opener-policy",
-              "value": "same-origin"
-            },
-            {
-              "name": "cross-origin-resource-policy",
-              "value": "same-origin"
-            },
-            {
-              "name": "expires",
-              "value": "0"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json;charset=UTF-8"
-            },
-            {
-              "name": "content-length",
-              "value": "757"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
-            },
-            {
-              "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload;"
-            },
-            {
-              "name": "x-robots-tag",
-              "value": "none"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google"
-            },
-            {
-              "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
-            }
-          ],
-          "headersSize": 766,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-10-10T15:31:03.068Z",
-        "time": 153,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 153
-        }
-      },
-      {
-        "_id": "589bc3213af463279e35284f3ac342ba",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 3335,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "accept",
-              "value": "application/json, text/plain, */*"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
-            },
-            {
-              "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
-            },
-            {
-              "name": "accept-api-version",
-              "value": "protocol=2.0,resource=1.0"
-            },
-            {
-              "name": "authorization",
-              "value": "Bearer <bearer token>"
-            },
-            {
-              "name": "content-length",
-              "value": "3335"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "gzip, compress, deflate, br"
-            },
-            {
-              "name": "host",
-              "value": "openam-frodo-dev.forgeblocks.com"
-            }
-          ],
-          "headersSize": 2022,
-          "httpVersion": "HTTP/1.1",
-          "method": "PUT",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Display sharedState, transientState, and headers.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"debug\",\"script\":\"Ii8qIGRlYnVnXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBEaXNwbGF5IHNoYXJlZFN0YXRlLCB0cmFuc2llbnRTdGF0ZSwgYW5kIGhlYWRlcnMuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gdHJ1ZVxuICovXG52YXIgYW5jaG9yID0gXCJhbmNob3ItXCIuY29uY2F0KGdlbmVyYXRlTnVtZXJpY1Rva2VuKCd4eHgnKSk7XG52YXIgaGFsaWduID0gXCJsZWZ0XCI7XG52YXIgbWVzc2FnZSA9IFwiPHA+PGI+U2hhcmVkIFN0YXRlPC9iPjo8YnIvPlwiLmNvbmNhdChcbiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdChcIjwvcD5cIikuY29uY2F0KFxuICAgIFwiPHA+PGI+VHJhbnNpZW50IFN0YXRlPC9iPjo8YnIvPlwiKS5jb25jYXQoXG4gICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoXCI8L3A+XCIpLmNvbmNhdChcbiAgICBcIjxwPjxiPlJlcXVlc3QgSGVhZGVyczwvYj46PGJyLz5cIikuY29uY2F0KFxuICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KFwiPC9wPlwiKVxudmFyIHNjcmlwdCA9IFwiQXJyYXkucHJvdG90eXBlLnNsaWNlLmNhbGwoXFxuXCIuY29uY2F0KFxuICBcImRvY3VtZW50LmdldEVsZW1lbnRzQnlDbGFzc05hbWUoJ2NhbGxiYWNrLWNvbXBvbmVudCcpKS5mb3JFYWNoKFxcblwiKS5jb25jYXQoXG4gIFwiZnVuY3Rpb24gKGUpIHtcXG5cIikuY29uY2F0KFxuICBcIiAgdmFyIG1lc3NhZ2UgPSBlLmZpcnN0RWxlbWVudENoaWxkO1xcblwiKS5jb25jYXQoXG4gIFwiICBpZiAobWVzc2FnZS5maXJzdENoaWxkICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlTmFtZSA9PSAnI3RleHQnICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlVmFsdWUudHJpbSgpID09ICdcIikuY29uY2F0KGFuY2hvcikuY29uY2F0KFwiJykge1xcblwiKS5jb25jYXQoXG4gIFwiICAgIG1lc3NhZ2UuY2xhc3NOYW1lID0gXFxcInRleHQtbGVmdFxcXCI7XFxuXCIpLmNvbmNhdChcbiAgXCIgICAgbWVzc2FnZS5hbGlnbiA9IFxcXCJcIikuY29uY2F0KGhhbGlnbikuY29uY2F0KFwiXFxcIjtcXG5cIikuY29uY2F0KFxuICBcIiAgICBtZXNzYWdlLmlubmVySFRNTCA9ICdcIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdChcIic7XFxuXCIpLmNvbmNhdChcbiAgXCIgIH1cXG5cIikuY29uY2F0KFxuICBcIn0pXCIpXG52YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sXG4gICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5UZXh0T3V0cHV0Q2FsbGJhY2ssXG4gICAgY29tLnN1bi5pZGVudGl0eS5hdXRoZW50aWNhdGlvbi5jYWxsYmFja3MuU2NyaXB0VGV4dE91dHB1dENhbGxiYWNrXG4pXG5pZiAobWVzc2FnZS5sZW5ndGggJiYgY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFxuICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKFxuICAgICAgICAgICAgZnIuVGV4dE91dHB1dENhbGxiYWNrLklORk9STUFUSU9OLFxuICAgICAgICAgICAgYW5jaG9yXG4gICAgICAgICksXG4gICAgICAgIG5ldyBmci5TY3JpcHRUZXh0T3V0cHV0Q2FsbGJhY2soc2NyaXB0KVxuICAgICkuYnVpbGQoKVxufVxuZWxzZSB7XG4gIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKFwidHJ1ZVwiKS5idWlsZCgpO1xufVxuXG4gLypcbiAgKiBHZW5lcmF0ZSBhIHRva2VuIGluIHRoZSBkZXNpcmVkIGZvcm1hdC4gQWxsICd4JyBjaGFyYWN0ZXJzIHdpbGwgYmUgcmVwbGFjZWQgd2l0aCBhIHJhbmRvbSBudW1iZXIgMC05LlxuICAqIFxuICAqIEV4YW1wbGU6XG4gICogJ3h4eHh4JyBwcm9kdWNlcyAnMjg1MzUnXG4gICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJ1xuICAqL1xuZnVuY3Rpb24gZ2VuZXJhdGVOdW1lcmljVG9rZW4oZm9ybWF0KSB7XG4gICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykge1xuICAgICAgICB2YXIgciA9IE1hdGgucmFuZG9tKCkqMTB8MDtcbiAgICAgICAgdmFyIHYgPSByO1xuICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7XG4gICAgfSk7XG59XG4i\"}"
-          },
-          "queryString": [],
-          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/3cb43516-ae69-433a-8787-501d45db14e9"
-        },
-        "response": {
-          "bodySize": 3403,
-          "content": {
-            "mimeType": "application/json;charset=UTF-8",
-            "size": 3403,
-            "text": "{\"_id\":\"3cb43516-ae69-433a-8787-501d45db14e9\",\"name\":\"debug\",\"description\":\"Display sharedState, transientState, and headers.\",\"script\":\"Ii8qIGRlYnVnXG4gKlxuICogQXV0aG9yOiB2b2xrZXIuc2NoZXViZXJAZm9yZ2Vyb2NrLmNvbVxuICogXG4gKiBEaXNwbGF5IHNoYXJlZFN0YXRlLCB0cmFuc2llbnRTdGF0ZSwgYW5kIGhlYWRlcnMuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gdHJ1ZVxuICovXG52YXIgYW5jaG9yID0gXCJhbmNob3ItXCIuY29uY2F0KGdlbmVyYXRlTnVtZXJpY1Rva2VuKCd4eHgnKSk7XG52YXIgaGFsaWduID0gXCJsZWZ0XCI7XG52YXIgbWVzc2FnZSA9IFwiPHA+PGI+U2hhcmVkIFN0YXRlPC9iPjo8YnIvPlwiLmNvbmNhdChcbiAgICAgIHNoYXJlZFN0YXRlLnRvU3RyaW5nKCkpLmNvbmNhdChcIjwvcD5cIikuY29uY2F0KFxuICAgIFwiPHA+PGI+VHJhbnNpZW50IFN0YXRlPC9iPjo8YnIvPlwiKS5jb25jYXQoXG4gICAgICB0cmFuc2llbnRTdGF0ZS50b1N0cmluZygpKS5jb25jYXQoXCI8L3A+XCIpLmNvbmNhdChcbiAgICBcIjxwPjxiPlJlcXVlc3QgSGVhZGVyczwvYj46PGJyLz5cIikuY29uY2F0KFxuICAgICAgcmVxdWVzdEhlYWRlcnMudG9TdHJpbmcoKSkuY29uY2F0KFwiPC9wPlwiKVxudmFyIHNjcmlwdCA9IFwiQXJyYXkucHJvdG90eXBlLnNsaWNlLmNhbGwoXFxuXCIuY29uY2F0KFxuICBcImRvY3VtZW50LmdldEVsZW1lbnRzQnlDbGFzc05hbWUoJ2NhbGxiYWNrLWNvbXBvbmVudCcpKS5mb3JFYWNoKFxcblwiKS5jb25jYXQoXG4gIFwiZnVuY3Rpb24gKGUpIHtcXG5cIikuY29uY2F0KFxuICBcIiAgdmFyIG1lc3NhZ2UgPSBlLmZpcnN0RWxlbWVudENoaWxkO1xcblwiKS5jb25jYXQoXG4gIFwiICBpZiAobWVzc2FnZS5maXJzdENoaWxkICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlTmFtZSA9PSAnI3RleHQnICYmIG1lc3NhZ2UuZmlyc3RDaGlsZC5ub2RlVmFsdWUudHJpbSgpID09ICdcIikuY29uY2F0KGFuY2hvcikuY29uY2F0KFwiJykge1xcblwiKS5jb25jYXQoXG4gIFwiICAgIG1lc3NhZ2UuY2xhc3NOYW1lID0gXFxcInRleHQtbGVmdFxcXCI7XFxuXCIpLmNvbmNhdChcbiAgXCIgICAgbWVzc2FnZS5hbGlnbiA9IFxcXCJcIikuY29uY2F0KGhhbGlnbikuY29uY2F0KFwiXFxcIjtcXG5cIikuY29uY2F0KFxuICBcIiAgICBtZXNzYWdlLmlubmVySFRNTCA9ICdcIikuY29uY2F0KG1lc3NhZ2UpLmNvbmNhdChcIic7XFxuXCIpLmNvbmNhdChcbiAgXCIgIH1cXG5cIikuY29uY2F0KFxuICBcIn0pXCIpXG52YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sXG4gICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5UZXh0T3V0cHV0Q2FsbGJhY2ssXG4gICAgY29tLnN1bi5pZGVudGl0eS5hdXRoZW50aWNhdGlvbi5jYWxsYmFja3MuU2NyaXB0VGV4dE91dHB1dENhbGxiYWNrXG4pXG5pZiAobWVzc2FnZS5sZW5ndGggJiYgY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFxuICAgICAgICBuZXcgZnIuVGV4dE91dHB1dENhbGxiYWNrKFxuICAgICAgICAgICAgZnIuVGV4dE91dHB1dENhbGxiYWNrLklORk9STUFUSU9OLFxuICAgICAgICAgICAgYW5jaG9yXG4gICAgICAgICksXG4gICAgICAgIG5ldyBmci5TY3JpcHRUZXh0T3V0cHV0Q2FsbGJhY2soc2NyaXB0KVxuICAgICkuYnVpbGQoKVxufVxuZWxzZSB7XG4gIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKFwidHJ1ZVwiKS5idWlsZCgpO1xufVxuXG4gLypcbiAgKiBHZW5lcmF0ZSBhIHRva2VuIGluIHRoZSBkZXNpcmVkIGZvcm1hdC4gQWxsICd4JyBjaGFyYWN0ZXJzIHdpbGwgYmUgcmVwbGFjZWQgd2l0aCBhIHJhbmRvbSBudW1iZXIgMC05LlxuICAqIFxuICAqIEV4YW1wbGU6XG4gICogJ3h4eHh4JyBwcm9kdWNlcyAnMjg1MzUnXG4gICogJ3h4eC14eHgnIHByb2R1Y2VzICc0MzItNTIxJ1xuICAqL1xuZnVuY3Rpb24gZ2VuZXJhdGVOdW1lcmljVG9rZW4oZm9ybWF0KSB7XG4gICAgcmV0dXJuIGZvcm1hdC5yZXBsYWNlKC9beF0vZywgZnVuY3Rpb24oYykge1xuICAgICAgICB2YXIgciA9IE1hdGgucmFuZG9tKCkqMTB8MDtcbiAgICAgICAgdmFyIHYgPSByO1xuICAgICAgICByZXR1cm4gdi50b1N0cmluZygxMCk7XG4gICAgfSk7XG59XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574263276,\"evaluatorVersion\":\"1.0\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "x-frame-options",
-              "value": "SAMEORIGIN"
-            },
-            {
-              "name": "content-security-policy-report-only",
-              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "cache-control",
-              "value": "private"
-            },
-            {
-              "name": "content-api-version",
-              "value": "resource=1.1"
-            },
-            {
-              "name": "content-security-policy",
-              "value": "default-src 'none';frame-ancestors 'none';sandbox"
-            },
-            {
-              "name": "cross-origin-opener-policy",
-              "value": "same-origin"
-            },
-            {
-              "name": "cross-origin-resource-policy",
-              "value": "same-origin"
-            },
-            {
-              "name": "expires",
-              "value": "0"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json;charset=UTF-8"
-            },
-            {
-              "name": "content-length",
-              "value": "3403"
-            },
-            {
-              "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
-            },
-            {
-              "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload;"
-            },
-            {
-              "name": "x-robots-tag",
-              "value": "none"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google"
-            },
-            {
-              "name": "alt-svc",
-              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
-            }
-          ],
-          "headersSize": 767,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-10-10T15:31:03.226Z",
-        "time": 70,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 70
-        }
-      },
-      {
-        "_id": "9d93ce8c0cada398e926fde6717de656",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 709,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "accept",
-              "value": "application/json, text/plain, */*"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
-            },
-            {
-              "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
-            },
-            {
-              "name": "accept-api-version",
-              "value": "protocol=2.0,resource=1.0"
-            },
-            {
-              "name": "authorization",
-              "value": "Bearer <bearer token>"
-            },
-            {
-              "name": "content-length",
-              "value": "709"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "gzip, compress, deflate, br"
-            },
-            {
-              "name": "host",
-              "value": "openam-frodo-dev.forgeblocks.com"
-            }
-          ],
-          "headersSize": 2021,
-          "httpVersion": "HTTP/1.1",
-          "method": "PUT",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set per level shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"level\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnbGV2ZWwnICsgbGV2ZWwgKyAnVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2V0IGF0IGVhY2ggbGV2ZWwgb2YgdGhlIG5lc3RlZCBqb3VybmV5cy4gSXQgY29udGFpbnMgYW4gaW5kaWNhdG9yIGluIHdoaWNoIGxldmVsIGl0IHdhcyBzZXQuJyk7XG59KCkpO1xuIg==\"}"
+            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"set per level shared state variable\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"level\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdsZXZlbCcgKyBsZXZlbCArICdWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzZXQgYXQgZWFjaCBsZXZlbCBvZiB0aGUgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIHNldC4nKTsKfSgpKTsK\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/41c24257-d7fc-4654-8b46-c2666dc5b56d"
         },
         "response": {
-          "bodySize": 777,
+          "bodySize": 765,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 777,
-            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"name\":\"level\",\"description\":\"set per level shared state variable\",\"script\":\"IihmdW5jdGlvbiAoKSB7XG4gIG91dGNvbWUgPSAndHJ1ZSc7XG4gIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7XG4gIHNoYXJlZFN0YXRlLnB1dCgnbGV2ZWwnICsgbGV2ZWwgKyAnVmFsdWUnLCAnTGV2ZWwgJyArIGxldmVsICsgJzogVGhpcyBpcyBhIGxvbmdlciBzdHJpbmcgdmFsdWUgc2V0IGF0IGVhY2ggbGV2ZWwgb2YgdGhlIG5lc3RlZCBqb3VybmV5cy4gSXQgY29udGFpbnMgYW4gaW5kaWNhdG9yIGluIHdoaWNoIGxldmVsIGl0IHdhcyBzZXQuJyk7XG59KCkpO1xuIg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574263347,\"evaluatorVersion\":\"1.0\"}"
+            "size": 765,
+            "text": "{\"_id\":\"41c24257-d7fc-4654-8b46-c2666dc5b56d\",\"name\":\"level\",\"description\":\"set per level shared state variable\",\"script\":\"KGZ1bmN0aW9uICgpIHsKICBvdXRjb21lID0gJ3RydWUnOwogIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCk7CiAgc2hhcmVkU3RhdGUucHV0KCdsZXZlbCcgKyBsZXZlbCArICdWYWx1ZScsICdMZXZlbCAnICsgbGV2ZWwgKyAnOiBUaGlzIGlzIGEgbG9uZ2VyIHN0cmluZyB2YWx1ZSBzZXQgYXQgZWFjaCBsZXZlbCBvZiB0aGUgbmVzdGVkIGpvdXJuZXlzLiBJdCBjb250YWlucyBhbiBpbmRpY2F0b3IgaW4gd2hpY2ggbGV2ZWwgaXQgd2FzIHNldC4nKTsKfSgpKTsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329868996,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -880,15 +880,15 @@
             },
             {
               "name": "content-length",
-              "value": "777"
+              "value": "765"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -913,8 +913,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:03.301Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:08.935Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -922,15 +922,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 83
         }
       },
       {
-        "_id": "9f6c4ef1a2f56dd677351662221cc6bf",
+        "_id": "d367dbb7190523aee15f268dccbe87af",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2016,
+          "bodySize": 1960,
           "cookies": [],
           "headers": [
             {
@@ -943,11 +943,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
@@ -959,7 +959,7 @@
             },
             {
               "name": "content-length",
-              "value": "2016"
+              "value": "1960"
             },
             {
               "name": "accept-encoding",
@@ -976,17 +976,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if mode has already been set.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"mode\",\"script\":\"Ii8qIG1vZGVcbiAqXG4gKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tXG4gKiBcbiAqIENvbGxlY3QgbW9kZSBpZiBub3QgYWxyZWFkeSBzZXQgYW5kIHNldCBvdXRjb21lIHRvIG1vZGUuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gJ3NoYXJlZCBhbmQgbGV2ZWwnXG4gKiAtICdzaGFyZWQgb25seSdcbiAqIC0gJ2xldmVsIG9ubHknXG4gKiAtICdub25lJ1xuICovXG4oZnVuY3Rpb24gKCkge1xuICB2YXIgbW9kZSA9IG5vZGVTdGF0ZS5nZXQoJ21vZGUnKTtcbiAgaWYgKG1vZGUpIHtcbiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpO1xuICAgIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCkgKyAxO1xuICAgIGxvZ2dlci5lcnJvcignbW9kZTogbW9kZT0nICsgbW9kZS5hc1N0cmluZygpICsgJywgbGV2ZWw9JyArIGxldmVsKTtcbiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpO1xuICB9XG4gIGVsc2Uge1xuICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddO1xuICBcbiAgICB2YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbixcbiAgICAgIGphdmF4LnNlY3VyaXR5LmF1dGguY2FsbGJhY2suQ2hvaWNlQ2FsbGJhY2tcbiAgICApXG5cbiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQoW1xuICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSlcbiAgICAgIF0pLmJ1aWxkKCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTtcbiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ21vZGUnLCBjaG9pY2VzW2Nob2ljZV0pO1xuICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbGV2ZWwnLCAwKTtcbiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTtcbiAgICB9XG4gIH1cbn0oKSk7XG4i\"}"
+            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"default\":false,\"description\":\"Check if mode has already been set.\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"null\",\"lastModifiedDate\":0,\"name\":\"mode\",\"script\":\"LyogbW9kZQogKgogKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tCiAqIAogKiBDb2xsZWN0IG1vZGUgaWYgbm90IGFscmVhZHkgc2V0IGFuZCBzZXQgb3V0Y29tZSB0byBtb2RlLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSAnc2hhcmVkIGFuZCBsZXZlbCcKICogLSAnc2hhcmVkIG9ubHknCiAqIC0gJ2xldmVsIG9ubHknCiAqIC0gJ25vbmUnCiAqLwooZnVuY3Rpb24gKCkgewogIHZhciBtb2RlID0gbm9kZVN0YXRlLmdldCgnbW9kZScpOwogIGlmIChtb2RlKSB7CiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpOwogICAgdmFyIGxldmVsID0gbm9kZVN0YXRlLmdldCgnbGV2ZWwnKS5hc0ludGVnZXIoKSArIDE7CiAgICBsb2dnZXIuZXJyb3IoJ21vZGU6IG1vZGU9JyArIG1vZGUuYXNTdHJpbmcoKSArICcsIGxldmVsPScgKyBsZXZlbCk7CiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpOwogIH0KICBlbHNlIHsKICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddOwogIAogICAgdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbiwKICAgICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5DaG9pY2VDYWxsYmFjawogICAgKQoKICAgIGlmIChjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFsKICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSkKICAgICAgXSkuYnVpbGQoKTsKICAgIH0gZWxzZSB7CiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTsKICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbW9kZScsIGNob2ljZXNbY2hvaWNlXSk7CiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ2xldmVsJywgMCk7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTsKICAgIH0KICB9Cn0oKSk7Cg==\"}"
           },
           "queryString": [],
           "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/scripts/5bbdaeff-ddee-44b9-b608-8d413d7d65a6"
         },
         "response": {
-          "bodySize": 2084,
+          "bodySize": 2028,
           "content": {
             "mimeType": "application/json;charset=UTF-8",
-            "size": 2084,
-            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"name\":\"mode\",\"description\":\"Check if mode has already been set.\",\"script\":\"Ii8qIG1vZGVcbiAqXG4gKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tXG4gKiBcbiAqIENvbGxlY3QgbW9kZSBpZiBub3QgYWxyZWFkeSBzZXQgYW5kIHNldCBvdXRjb21lIHRvIG1vZGUuXG4gKiBcbiAqIFRoaXMgc2NyaXB0IGRvZXMgbm90IG5lZWQgdG8gYmUgcGFyYW1ldHJpemVkLiBJdCB3aWxsIHdvcmsgcHJvcGVybHkgYXMgaXMuXG4gKiBcbiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDpcbiAqIC0gJ3NoYXJlZCBhbmQgbGV2ZWwnXG4gKiAtICdzaGFyZWQgb25seSdcbiAqIC0gJ2xldmVsIG9ubHknXG4gKiAtICdub25lJ1xuICovXG4oZnVuY3Rpb24gKCkge1xuICB2YXIgbW9kZSA9IG5vZGVTdGF0ZS5nZXQoJ21vZGUnKTtcbiAgaWYgKG1vZGUpIHtcbiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpO1xuICAgIHZhciBsZXZlbCA9IG5vZGVTdGF0ZS5nZXQoJ2xldmVsJykuYXNJbnRlZ2VyKCkgKyAxO1xuICAgIGxvZ2dlci5lcnJvcignbW9kZTogbW9kZT0nICsgbW9kZS5hc1N0cmluZygpICsgJywgbGV2ZWw9JyArIGxldmVsKTtcbiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpO1xuICB9XG4gIGVsc2Uge1xuICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddO1xuICBcbiAgICB2YXIgZnIgPSBKYXZhSW1wb3J0ZXIoXG4gICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbixcbiAgICAgIGphdmF4LnNlY3VyaXR5LmF1dGguY2FsbGJhY2suQ2hvaWNlQ2FsbGJhY2tcbiAgICApXG5cbiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkge1xuICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQoW1xuICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSlcbiAgICAgIF0pLmJ1aWxkKCk7XG4gICAgfSBlbHNlIHtcbiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTtcbiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ21vZGUnLCBjaG9pY2VzW2Nob2ljZV0pO1xuICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbGV2ZWwnLCAwKTtcbiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTtcbiAgICB9XG4gIH1cbn0oKSk7XG4i\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1728574263419,\"evaluatorVersion\":\"1.0\"}"
+            "size": 2028,
+            "text": "{\"_id\":\"5bbdaeff-ddee-44b9-b608-8d413d7d65a6\",\"name\":\"mode\",\"description\":\"Check if mode has already been set.\",\"script\":\"LyogbW9kZQogKgogKiBBdXRob3I6IHZvbGtlci5zY2hldWJlckBmb3JnZXJvY2suY29tCiAqIAogKiBDb2xsZWN0IG1vZGUgaWYgbm90IGFscmVhZHkgc2V0IGFuZCBzZXQgb3V0Y29tZSB0byBtb2RlLgogKiAKICogVGhpcyBzY3JpcHQgZG9lcyBub3QgbmVlZCB0byBiZSBwYXJhbWV0cml6ZWQuIEl0IHdpbGwgd29yayBwcm9wZXJseSBhcyBpcy4KICogCiAqIFRoZSBTY3JpcHRlZCBEZWNpc2lvbiBOb2RlIG5lZWRzIHRoZSBmb2xsb3dpbmcgb3V0Y29tZXMgZGVmaW5lZDoKICogLSAnc2hhcmVkIGFuZCBsZXZlbCcKICogLSAnc2hhcmVkIG9ubHknCiAqIC0gJ2xldmVsIG9ubHknCiAqIC0gJ25vbmUnCiAqLwooZnVuY3Rpb24gKCkgewogIHZhciBtb2RlID0gbm9kZVN0YXRlLmdldCgnbW9kZScpOwogIGlmIChtb2RlKSB7CiAgICBvdXRjb21lID0gbW9kZS5hc1N0cmluZygpOwogICAgdmFyIGxldmVsID0gbm9kZVN0YXRlLmdldCgnbGV2ZWwnKS5hc0ludGVnZXIoKSArIDE7CiAgICBsb2dnZXIuZXJyb3IoJ21vZGU6IG1vZGU9JyArIG1vZGUuYXNTdHJpbmcoKSArICcsIGxldmVsPScgKyBsZXZlbCk7CiAgICBzaGFyZWRTdGF0ZS5wdXQoJ2xldmVsJywgbGV2ZWwpOwogIH0KICBlbHNlIHsKICAgIHZhciBjaG9pY2VzID0gWydzaGFyZWQgYW5kIGxldmVsJywgJ3NoYXJlZCBvbmx5JywgJ2xldmVsIG9ubHknLCAnbm9uZSddOwogIAogICAgdmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgICBvcmcuZm9yZ2Vyb2NrLm9wZW5hbS5hdXRoLm5vZGUuYXBpLkFjdGlvbiwKICAgICAgamF2YXguc2VjdXJpdHkuYXV0aC5jYWxsYmFjay5DaG9pY2VDYWxsYmFjawogICAgKQoKICAgIGlmIChjYWxsYmFja3MuaXNFbXB0eSgpKSB7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5zZW5kKFsKICAgICAgICBuZXcgZnIuQ2hvaWNlQ2FsbGJhY2soJ0Nob29zZSB0ZXN0IG1vZGUnLCBjaG9pY2VzLCAwLCBmYWxzZSkKICAgICAgXSkuYnVpbGQoKTsKICAgIH0gZWxzZSB7CiAgICAgIHZhciBjaG9pY2UgPSBwYXJzZUludChjYWxsYmFja3MuZ2V0KDApLmdldFNlbGVjdGVkSW5kZXhlcygpWzBdKTsKICAgICAgbm9kZVN0YXRlLnB1dFNoYXJlZCgnbW9kZScsIGNob2ljZXNbY2hvaWNlXSk7CiAgICAgIG5vZGVTdGF0ZS5wdXRTaGFyZWQoJ2xldmVsJywgMCk7CiAgICAgIGFjdGlvbiA9IGZyLkFjdGlvbi5nb1RvKGNob2ljZXNbY2hvaWNlXSkuYnVpbGQoKTsKICAgIH0KICB9Cn0oKSk7Cg==\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"null\",\"creationDate\":0,\"lastModifiedBy\":\"id=7a031a92-f70d-4b30-9d70-da7cfb1d9c93,ou=user,ou=am-config\",\"lastModifiedDate\":1733329869074,\"evaluatorVersion\":\"1.0\"}"
           },
           "cookies": [],
           "headers": [
@@ -1036,15 +1036,15 @@
             },
             {
               "name": "content-length",
-              "value": "2084"
+              "value": "2028"
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -1069,8 +1069,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:03.371Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:09.022Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1078,7 +1078,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 72
         }
       },
       {
@@ -1099,15 +1099,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1164,7 +1164,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1200,11 +1200,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:04 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -1229,8 +1229,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:03.442Z",
-        "time": 650,
+        "startedDateTime": "2024-12-04T16:31:09.099Z",
+        "time": 284,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1238,7 +1238,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 650
+          "wait": 284
         }
       },
       {
@@ -1259,15 +1259,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1324,7 +1324,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1360,11 +1360,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:04 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -1389,8 +1389,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:04.097Z",
-        "time": 66,
+        "startedDateTime": "2024-12-04T16:31:09.389Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1398,7 +1398,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 66
+          "wait": 78
         }
       },
       {
@@ -1419,15 +1419,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1484,7 +1484,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1520,11 +1520,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:04 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -1549,8 +1549,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:04.168Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:09.472Z",
+        "time": 73,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1558,7 +1558,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 73
         }
       },
       {
@@ -1579,15 +1579,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1644,7 +1644,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1680,11 +1680,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:04 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -1709,8 +1709,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:04.242Z",
-        "time": 67,
+        "startedDateTime": "2024-12-04T16:31:09.549Z",
+        "time": 72,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1718,7 +1718,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 67
+          "wait": 72
         }
       },
       {
@@ -1739,15 +1739,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1804,7 +1804,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -1840,11 +1840,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:04 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -1869,8 +1869,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:04.313Z",
-        "time": 68,
+        "startedDateTime": "2024-12-04T16:31:09.626Z",
+        "time": 76,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1878,7 +1878,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 68
+          "wait": 76
         }
       },
       {
@@ -1899,15 +1899,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -1964,7 +1964,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2000,11 +2000,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:04 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -2029,8 +2029,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:04.386Z",
-        "time": 64,
+        "startedDateTime": "2024-12-04T16:31:09.707Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2038,7 +2038,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 64
+          "wait": 78
         }
       },
       {
@@ -2059,15 +2059,15 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
-              "value": "protocol=2.1,resource=2.0"
+              "value": "protocol=2.1,resource=1.0"
             },
             {
               "name": "authorization",
@@ -2124,7 +2124,7 @@
             },
             {
               "name": "content-api-version",
-              "value": "resource=2.0"
+              "value": "resource=1.0"
             },
             {
               "name": "content-security-policy",
@@ -2160,11 +2160,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:04 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:09 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -2189,8 +2189,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:04.455Z",
-        "time": 69,
+        "startedDateTime": "2024-12-04T16:31:09.790Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2198,7 +2198,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 69
+          "wait": 79
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_i_f_D_135597397/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_i_f_D_135597397/oauth2_393036114/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "accept-api-version",
@@ -98,11 +98,11 @@
             },
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -127,8 +127,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:02.746Z",
-        "time": 90,
+        "startedDateTime": "2024-12-04T16:31:08.391Z",
+        "time": 113,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -136,7 +136,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 90
+          "wait": 113
         }
       }
     ],

--- a/test/e2e/mocks/journey_3464291987/import_288002260/0_i_f_D_135597397/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/journey_3464291987/import_288002260/0_i_f_D_135597397/openidm_3290118515/recording.har
@@ -25,11 +25,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "authorization",
@@ -66,7 +66,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
             },
             {
               "name": "cache-control",
@@ -114,7 +114,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -139,8 +139,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:02.874Z",
-        "time": 117,
+        "startedDateTime": "2024-12-04T16:31:08.541Z",
+        "time": 112,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 117
+          "wait": 112
         }
       },
       {
@@ -169,11 +169,11 @@
             },
             {
               "name": "user-agent",
-              "value": "@rockcarver/frodo-lib/2.1.2-0"
+              "value": "@rockcarver/frodo-lib/3.0.1-0"
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "authorization",
@@ -210,7 +210,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 10 Oct 2024 15:31:02 GMT"
+              "value": "Wed, 04 Dec 2024 16:31:08 GMT"
             },
             {
               "name": "cache-control",
@@ -258,7 +258,7 @@
             },
             {
               "name": "x-forgerock-transactionid",
-              "value": "frodo-7d9cd466-e910-4f02-b8ca-c1463dcf668c"
+              "value": "frodo-5ed00cf6-5364-4f69-b4aa-0c97e48e6110"
             },
             {
               "name": "strict-transport-security",
@@ -283,8 +283,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-10-10T15:31:02.916Z",
-        "time": 62,
+        "startedDateTime": "2024-12-04T16:31:08.595Z",
+        "time": 64,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -292,7 +292,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 62
+          "wait": 64
         }
       }
     ],


### PR DESCRIPTION
An update was made to frodo-lib (in this PR: https://github.com/rockcarver/frodo-lib/pull/475) to fix the bug mentioned in this issue: https://github.com/rockcarver/frodo-cli/issues/457

As a result of the change, journey import mock recordings needed to be updated for the tests to pass, so this PR updates those mocks.