### PR TITLE
Added new CLI option to support better control over managed object names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rockcarver/frodo-cli",
-  "version": "2.1.1-alpha",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rockcarver/frodo-cli",
-      "version": "2.1.1-alpha",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.4.24"
@@ -15,7 +15,7 @@
         "frodo": "dist/launch.cjs"
       },
       "devDependencies": {
-        "@rockcarver/frodo-lib": "file:../frodo-lib",
+        "@rockcarver/frodo-lib": "2.4.0",
         "@types/colors": "^1.2.1",
         "@types/fs-extra": "^11.0.1",
         "@types/jest": "^29.2.3",
@@ -66,7 +66,7 @@
     },
     "../frodo-lib": {
       "name": "@rockcarver/frodo-lib",
-      "version": "2.3.1-alpha",
+      "version": "2.4.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "@rockcarver/frodo-cli",
-  "version": "2.1.0",
+  "version": "2.1.1-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rockcarver/frodo-cli",
-      "version": "2.1.0",
+      "version": "2.1.1-alpha",
       "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.4.24"
+      },
       "bin": {
         "frodo": "dist/launch.cjs"
       },
       "devDependencies": {
-        "@rockcarver/frodo-lib": "2.2.0",
+        "@rockcarver/frodo-lib": "file:../frodo-lib",
         "@types/colors": "^1.2.1",
         "@types/fs-extra": "^11.0.1",
         "@types/jest": "^29.2.3",
@@ -56,6 +59,69 @@
         "typescript": "^5.2.2",
         "uuid": "^9.0.0",
         "yesno": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "../frodo-lib": {
+      "name": "@rockcarver/frodo-lib",
+      "version": "2.3.1-alpha",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@jest/globals": "^29.0.1",
+        "@pollyjs/adapter-node-http": "^6.0.5",
+        "@pollyjs/core": "^6.0.5",
+        "@pollyjs/persister-fs": "^6.0.5",
+        "@types/esprima": "^4.0.3",
+        "@types/fs-extra": "^11.0.1",
+        "@types/jest": "^29.5.12",
+        "@types/lodash": "^4.14.189",
+        "@types/mock-fs": "^4.13.1",
+        "@types/node": "^20.5.8",
+        "@types/node-forge": "^1.3.11",
+        "@types/properties-reader": "^2.1.1",
+        "@types/uuid": "^9.0.0",
+        "@typescript-eslint/eslint-plugin": "^7.12.0",
+        "@typescript-eslint/parser": "^7.12.0",
+        "agentkeepalive": "^4.2.1",
+        "axios": "^1.7.4",
+        "axios-mock-adapter": "^1.21.2",
+        "axios-retry": "^4.4.0",
+        "colors": "^1.4.0",
+        "copyfiles": "^2.4.1",
+        "del": "^7.1.0",
+        "eslint": "^8.57.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-deprecation": "^3.0.0",
+        "eslint-plugin-import": "^2.28.0",
+        "eslint-plugin-jest": "^28.5.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
+        "esprima": "^4.0.1",
+        "fs-extra": "^11.1.1",
+        "https-proxy-agent": "^7.0.4",
+        "jest": "^29.3.1",
+        "jest-jasmine2": "^29.7.0",
+        "loglevel": "^1.9.1",
+        "map-stream": "^0.0.7",
+        "mock-fs": "^5.2.0",
+        "node-forge": "^1.3.1",
+        "node-jose": "^2.2.0",
+        "prettier": "^3.2.5",
+        "properties-reader": "^2.2.0",
+        "qs": "^6.10.3",
+        "replaceall": "^0.1.6",
+        "rimraf": "^5.0.1",
+        "setup-polly-jest": "^0.11.0",
+        "slugify": "^1.6.5",
+        "ts-jest": "^29.1.2",
+        "tsup": "^8.0.2",
+        "typedoc": "^0.25.0",
+        "typedoc-plugin-missing-exports": "^2.0.0",
+        "typescript": "^5.2.2",
+        "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -2108,14 +2174,8 @@
       }
     },
     "node_modules/@rockcarver/frodo-lib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rockcarver/frodo-lib/-/frodo-lib-2.2.0.tgz",
-      "integrity": "sha512-zgKVYi3cFkk+cTQHnZXFzlHWfDeq4SaWCFCZVdj/kYwkdM6wAii4uS3D8QA3feeM0JU1xfb9J/YrHI4FUL9p7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17.0"
-      }
+      "resolved": "../frodo-lib",
+      "link": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.24.0",
@@ -5930,7 +5990,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -9142,7 +9201,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rockcarver/frodo-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "description": "A command line interface to manage ForgeRock Identity Cloud tenants, ForgeOps deployments, and classic deployments.",
   "keywords": [
@@ -114,7 +114,7 @@
     ]
   },
   "devDependencies": {
-    "@rockcarver/frodo-lib": "2.2.0",
+    "@rockcarver/frodo-lib": "2.4.0",
     "@types/colors": "^1.2.1",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.2.3",
@@ -158,5 +158,8 @@
     "typescript": "^5.2.2",
     "uuid": "^9.0.0",
     "yesno": "^0.4.0"
+  },
+  "dependencies": {
+    "iconv-lite": "^0.4.24"
   }
 }

--- a/src/cli/FrodoCommand.ts
+++ b/src/cli/FrodoCommand.ts
@@ -103,6 +103,14 @@ const noCacheOption = new Option(
   'Disable token cache for this operation.'
 );
 
+const useRealmPrefixOnManagedObjects = new Option(
+  '--use-realm-prefix-on-managed-objects', 
+  'Set to true if you want to use the realm name as a prefix on managed object configuration, e.g. managed/alpha_user,\
+  managed/alpha_application or managed/bravo_organization. When false, the default behaviour of using managed/user \
+  etc. is retained. \
+  This option is ignored when the deployment type is "cloud".'
+);
+
 const flushCacheOption = new Option('--flush-cache', 'Flush token cache.');
 
 const defaultArgs = [
@@ -126,6 +134,7 @@ const defaultOpts = [
   curlirizeOption,
   noCacheOption,
   flushCacheOption,
+  useRealmPrefixOnManagedObjects,
 ];
 
 const stateMap = {
@@ -166,6 +175,8 @@ const stateMap = {
     state.setCurlirize(curlirize),
   [noCacheOption.attributeName()]: (cache: boolean) =>
     state.setUseTokenCache(cache),
+  [useRealmPrefixOnManagedObjects.attributeName()]: () =>
+    state.setUseRealmPrefixOnManagedObjects(true),
   [flushCacheOption.attributeName()]: (flush: boolean) => {
     if (flush) frodo.cache.flush();
   },


### PR DESCRIPTION
Related to #480 - adds the CLI option `--use-realm-prefix-on-managed-objects` to support enabling this feature in the Lib.