### PR TITLE
Fixed issue with data structure for all journey import

### DIFF
--- a/src/ops/JourneyOps.ts
+++ b/src/ops/JourneyOps.ts
@@ -530,10 +530,8 @@ export async function importJourneysFromFiles(
       .map((name) => getFilePath(name));
     const allJourneysData = { trees: {} };
     for (const file of jsonFiles) {
-      const fileObj = JSON.parse(fs.readFileSync(file, 'utf8'));
-      for (const [id, obj] of Object.entries(fileObj.trees)) {
-        allJourneysData.trees[id] = obj;
-      }
+      const journeyData = JSON.parse(fs.readFileSync(file, 'utf8'));
+      allJourneysData.trees[journeyData.tree._id] = journeyData;
     }
     await importJourneys(allJourneysData as MultiTreeExportInterface, options);
     return true;


### PR DESCRIPTION
The data structure for the all journey import from seperate files feature is broken in the new version.

The lib expects a map like: 
```json 
{
  "TreeID1": { //tree content },
  "TreeID2": { //tree content }
}
```

But this version is providing it in a different shape.

This breaks importing journeys exported using the versions frodo-cli v3.0.0 and lib 3.0.1.

Command:
`frodo journey import --directory alpha/journey https://<LOCAL_DEPLOYMENT>/am alpha --all-separate`