### PR TITLE
Fix Journey Export Format

### DIFF
--- a/src/ops/JourneyOps.ts
+++ b/src/ops/JourneyOps.ts
@@ -189,9 +189,10 @@ export async function exportJourneyToFile(
       journeyId,
       options
     );
+    delete fileData.meta;
     if (verbose)
       spinnerId = createProgressIndicator('indeterminate', 0, `${journeyId}`);
-    saveJsonToFile(fileData, filePath, includeMeta);
+    saveJsonToFile({ trees: { [fileData.tree._id]: fileData } }, filePath, includeMeta);
     stopProgressIndicator(
       spinnerId,
       `Exported ${journeyId['brightCyan']} to ${filePath['brightCyan']}.`,
@@ -264,10 +265,9 @@ export async function exportJourneysToFiles(
         `Saving ${treeId}...`
       );
       const file = getFilePath(getTypedFilename(`${treeId}`, 'journey'), true);
-      treeValue['meta'] = journeysExport.meta;
       try {
         updateProgressIndicator(indicatorId, `Saving ${treeId} to ${file}`);
-        saveJsonToFile(treeValue, file, includeMeta);
+        saveJsonToFile({ trees: { [treeValue.tree._id]: treeValue } }, file, includeMeta);
         stopProgressIndicator(indicatorId, `${treeId} saved to ${file}`);
       } catch (error) {
         stopProgressIndicator(indicatorId, `Error saving ${treeId} to ${file}`);

--- a/test/e2e/__snapshots__/journey-export.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/journey-export.e2e.test.js.snap
@@ -3254,170 +3254,174 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: ForgottenUsername.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "a0cbf6f1-37a1-4e95-bdb2-ddb14a1e8773": {
-      "_id": "a0cbf6f1-37a1-4e95-bdb2-ddb14a1e8773",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
-      },
-      "attributesToCollect": [
-        "mail",
-      ],
-      "identityAttribute": "mail",
-      "required": true,
-      "validateInputs": false,
-    },
-  },
   "meta": Any<Object>,
-  "nodes": {
-    "28ecb51a-6495-436e-a0b2-f11888072075": {
-      "_id": "28ecb51a-6495-436e-a0b2-f11888072075",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+  "trees": {
+    "ForgottenUsername": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "a0cbf6f1-37a1-4e95-bdb2-ddb14a1e8773": {
           "_id": "a0cbf6f1-37a1-4e95-bdb2-ddb14a1e8773",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "mail",
+          ],
+          "identityAttribute": "mail",
+          "required": true,
+          "validateInputs": false,
         },
-      ],
-      "pageDescription": {
-        "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
       },
-      "pageHeader": {
-        "en": "Forgotten Username",
-      },
-    },
-    "40cd436a-6090-416c-b523-932e82a38619": {
-      "_id": "40cd436a-6090-416c-b523-932e82a38619",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+      "nodes": {
+        "28ecb51a-6495-436e-a0b2-f11888072075": {
+          "_id": "28ecb51a-6495-436e-a0b2-f11888072075",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "a0cbf6f1-37a1-4e95-bdb2-ddb14a1e8773",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
+          },
+          "pageHeader": {
+            "en": "Forgotten Username",
+          },
         },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
-      },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "forgottenUsername",
-      "identityAttribute": "mail",
-      "objectLookup": true,
-    },
-    "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f": {
-      "_id": "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+        "40cd436a-6090-416c-b523-932e82a38619": {
+          "_id": "40cd436a-6090-416c-b523-932e82a38619",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "forgottenUsername",
+          "identityAttribute": "mail",
+          "objectLookup": true,
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f": {
+          "_id": "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "Login",
         },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
+        "d82415c8-66bd-41f8-9224-15a1e724f1c6": {
+          "_id": "d82415c8-66bd-41f8-9224-15a1e724f1c6",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "IdentifyExistingUserNode",
+            "collection": true,
+            "name": "Identify Existing User",
+          },
+          "identifier": "userName",
+          "identityAttribute": "mail",
+        },
       },
-      "tree": "Login",
-    },
-    "d82415c8-66bd-41f8-9224-15a1e724f1c6": {
-      "_id": "d82415c8-66bd-41f8-9224-15a1e724f1c6",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "ForgottenUsername",
+        "description": "Forgotten Username Tree",
+        "enabled": true,
+        "entryNodeId": "28ecb51a-6495-436e-a0b2-f11888072075",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "28ecb51a-6495-436e-a0b2-f11888072075": {
+            "connections": {
+              "outcome": "d82415c8-66bd-41f8-9224-15a1e724f1c6",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "40cd436a-6090-416c-b523-932e82a38619": {
+            "connections": {
+              "outcome": "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+          },
+          "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Inner Tree Evaluator",
+            "nodeType": "InnerTreeEvaluatorNode",
+          },
+          "d82415c8-66bd-41f8-9224-15a1e724f1c6": {
+            "connections": {
+              "false": "40cd436a-6090-416c-b523-932e82a38619",
+              "true": "40cd436a-6090-416c-b523-932e82a38619",
+            },
+            "displayName": "Identify Existing User",
+            "nodeType": "IdentifyExistingUserNode",
+          },
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-      ],
-      "_type": {
-        "_id": "IdentifyExistingUserNode",
-        "collection": true,
-        "name": "Identify Existing User",
+        "uiConfig": {
+          "categories": "["Username Reset"]",
+        },
       },
-      "identifier": "userName",
-      "identityAttribute": "mail",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "ForgottenUsername",
-    "description": "Forgotten Username Tree",
-    "enabled": true,
-    "entryNodeId": "28ecb51a-6495-436e-a0b2-f11888072075",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "28ecb51a-6495-436e-a0b2-f11888072075": {
-        "connections": {
-          "outcome": "d82415c8-66bd-41f8-9224-15a1e724f1c6",
-        },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-      },
-      "40cd436a-6090-416c-b523-932e82a38619": {
-        "connections": {
-          "outcome": "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f",
-        },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-      },
-      "aae774bb-dd4a-4d60-b80d-c3481b4cdb6f": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-        },
-        "displayName": "Inner Tree Evaluator",
-        "nodeType": "InnerTreeEvaluatorNode",
-      },
-      "d82415c8-66bd-41f8-9224-15a1e724f1c6": {
-        "connections": {
-          "false": "40cd436a-6090-416c-b523-932e82a38619",
-          "true": "40cd436a-6090-416c-b523-932e82a38619",
-        },
-        "displayName": "Identify Existing User",
-        "nodeType": "IdentifyExistingUserNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "["Username Reset"]",
     },
   },
 }
@@ -3425,388 +3429,392 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: FrodoTest.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "051c1939-7dd5-4cf1-866e-48f57541b6ac": {
-      "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "28595125-e97a-40e7-aa3c-bebdb6821949": {
-      "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4": {
-      "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "ac343c95-8873-410e-823b-0931a71fc0c7": {
-      "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "fe762924-bc07-4f50-9234-17ab245efff1": {
-      "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": false,
-    },
-  },
   "meta": Any<Object>,
-  "nodes": {
-    "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
-      "_id": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "SocialProviderHandlerNode",
-        "collection": true,
-        "name": "Social Provider Handler Node",
-      },
-      "clientType": "BROWSER",
-      "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
-      "usernameAttribute": "userName",
-    },
-    "4951364c-59be-42cd-9cd7-79c9392214db": {
-      "_id": "4951364c-59be-42cd-9cd7-79c9392214db",
-      "_outcomes": [
-        {
-          "displayName": "known",
-          "id": "known",
-        },
-        {
-          "displayName": "unknown",
-          "id": "unknown",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "known",
-        "unknown",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "739bdc48-fd24-4c52-b353-88706d75558a",
-    },
-    "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
-      "_id": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "TRUE",
-        },
-        {
-          "displayName": "False",
-          "id": "FALSE",
-        },
-        {
-          "displayName": "Locked",
-          "id": "LOCKED",
-        },
-        {
-          "displayName": "Cancelled",
-          "id": "CANCELLED",
-        },
-        {
-          "displayName": "Expired",
-          "id": "EXPIRED",
-        },
-      ],
-      "_type": {
-        "_id": "IdentityStoreDecisionNode",
-        "collection": true,
-        "name": "Identity Store Decision",
-      },
-      "minimumPasswordLength": 8,
-      "mixedCaseForPasswordChangeMessages": false,
-      "useUniversalIdForUsername": true,
-    },
-    "650203c3-47f7-439d-a554-669cb7b08c57": {
-      "_id": "650203c3-47f7-439d-a554-669cb7b08c57",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "product-Saml2Node",
-        "collection": true,
-        "name": "SAML2 Authentication",
-      },
-      "allowCreate": true,
-      "authComparison": "MINIMUM",
-      "authnContextClassRef": [],
-      "authnContextDeclRef": [],
-      "binding": "HTTP_ARTIFACT",
-      "forceAuthn": false,
-      "idpEntityId": "urn:federation:MicrosoftOnline",
-      "isPassive": false,
-      "metaAlias": "/alpha/iSPAzure",
-      "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-      "requestBinding": "HTTP_REDIRECT",
-    },
-    "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
-      "_id": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
-          "displayName": "Username",
-          "nodeType": "ValidatedUsernameNode",
-        },
-        {
+  "trees": {
+    "FrodoTest": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "051c1939-7dd5-4cf1-866e-48f57541b6ac": {
           "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-        {
+        "28595125-e97a-40e7-aa3c-bebdb6821949": {
           "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
-      "_id": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
-        },
-        {
+        "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4": {
           "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "c859d258-79c1-4448-bd52-12e4e414af92": {
-      "_id": "c859d258-79c1-4448-bd52-12e4e414af92",
-      "_outcomes": [
-        {
-          "displayName": "Email Sent",
-          "id": "EMAIL_SENT",
+        "ac343c95-8873-410e-823b-0931a71fc0c7": {
+          "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-        {
-          "displayName": "Email Not Sent",
-          "id": "EMAIL_NOT_SENT",
+        "fe762924-bc07-4f50-9234-17ab245efff1": {
+          "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": false,
         },
-      ],
-      "_type": {
-        "_id": "EmailTemplateNode",
-        "collection": true,
-        "name": "Email Template Node",
       },
-      "emailAttribute": "mail",
-      "emailTemplateName": "welcome",
-      "identityAttribute": "userName",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "FrodoTest",
-    "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
-    "enabled": true,
-    "entryNodeId": "4951364c-59be-42cd-9cd7-79c9392214db",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "c859d258-79c1-4448-bd52-12e4e414af92",
+      "nodes": {
+        "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
+          "_id": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "SocialProviderHandlerNode",
+            "collection": true,
+            "name": "Social Provider Handler Node",
+          },
+          "clientType": "BROWSER",
+          "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
+          "usernameAttribute": "userName",
         },
-        "displayName": "Social Login",
-        "nodeType": "SocialProviderHandlerNode",
-      },
-      "4951364c-59be-42cd-9cd7-79c9392214db": {
-        "connections": {
-          "known": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
-          "unknown": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+        "4951364c-59be-42cd-9cd7-79c9392214db": {
+          "_id": "4951364c-59be-42cd-9cd7-79c9392214db",
+          "_outcomes": [
+            {
+              "displayName": "known",
+              "id": "known",
+            },
+            {
+              "displayName": "unknown",
+              "id": "unknown",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "known",
+            "unknown",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "739bdc48-fd24-4c52-b353-88706d75558a",
         },
-        "displayName": "Check Username",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
-        "connections": {
-          "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
+          "_id": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "TRUE",
+            },
+            {
+              "displayName": "False",
+              "id": "FALSE",
+            },
+            {
+              "displayName": "Locked",
+              "id": "LOCKED",
+            },
+            {
+              "displayName": "Cancelled",
+              "id": "CANCELLED",
+            },
+            {
+              "displayName": "Expired",
+              "id": "EXPIRED",
+            },
+          ],
+          "_type": {
+            "_id": "IdentityStoreDecisionNode",
+            "collection": true,
+            "name": "Identity Store Decision",
+          },
+          "minimumPasswordLength": 8,
+          "mixedCaseForPasswordChangeMessages": false,
+          "useUniversalIdForUsername": true,
         },
-        "displayName": "Validate Creds",
-        "nodeType": "IdentityStoreDecisionNode",
-      },
-      "650203c3-47f7-439d-a554-669cb7b08c57": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "650203c3-47f7-439d-a554-669cb7b08c57": {
+          "_id": "650203c3-47f7-439d-a554-669cb7b08c57",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "product-Saml2Node",
+            "collection": true,
+            "name": "SAML2 Authentication",
+          },
+          "allowCreate": true,
+          "authComparison": "MINIMUM",
+          "authnContextClassRef": [],
+          "authnContextDeclRef": [],
+          "binding": "HTTP_ARTIFACT",
+          "forceAuthn": false,
+          "idpEntityId": "urn:federation:MicrosoftOnline",
+          "isPassive": false,
+          "metaAlias": "/alpha/iSPAzure",
+          "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+          "requestBinding": "HTTP_REDIRECT",
         },
-        "displayName": "SAML2 Authentication",
-        "nodeType": "product-Saml2Node",
-      },
-      "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
-        "connections": {
-          "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-          "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+        "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
+          "_id": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
+              "displayName": "Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
         },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-      },
-      "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
-        "connections": {
-          "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-          "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+        "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
+          "_id": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
         },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-      },
-      "c859d258-79c1-4448-bd52-12e4e414af92": {
-        "connections": {
-          "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "EMAIL_SENT": "650203c3-47f7-439d-a554-669cb7b08c57",
+        "c859d258-79c1-4448-bd52-12e4e414af92": {
+          "_id": "c859d258-79c1-4448-bd52-12e4e414af92",
+          "_outcomes": [
+            {
+              "displayName": "Email Sent",
+              "id": "EMAIL_SENT",
+            },
+            {
+              "displayName": "Email Not Sent",
+              "id": "EMAIL_NOT_SENT",
+            },
+          ],
+          "_type": {
+            "_id": "EmailTemplateNode",
+            "collection": true,
+            "name": "Email Template Node",
+          },
+          "emailAttribute": "mail",
+          "emailTemplateName": "welcome",
+          "identityAttribute": "userName",
         },
-        "displayName": "Email Template Node",
-        "nodeType": "EmailTemplateNode",
       },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "["Frodo","Prototype"]",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "FrodoTest",
+        "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
+        "enabled": true,
+        "entryNodeId": "4951364c-59be-42cd-9cd7-79c9392214db",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "c859d258-79c1-4448-bd52-12e4e414af92",
+            },
+            "displayName": "Social Login",
+            "nodeType": "SocialProviderHandlerNode",
+          },
+          "4951364c-59be-42cd-9cd7-79c9392214db": {
+            "connections": {
+              "known": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
+              "unknown": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+            },
+            "displayName": "Check Username",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
+            "connections": {
+              "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Validate Creds",
+            "nodeType": "IdentityStoreDecisionNode",
+          },
+          "650203c3-47f7-439d-a554-669cb7b08c57": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "SAML2 Authentication",
+            "nodeType": "product-Saml2Node",
+          },
+          "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
+            "connections": {
+              "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+              "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+          },
+          "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
+            "connections": {
+              "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+              "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+          },
+          "c859d258-79c1-4448-bd52-12e4e414af92": {
+            "connections": {
+              "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "EMAIL_SENT": "650203c3-47f7-439d-a554-669cb7b08c57",
+            },
+            "displayName": "Email Template Node",
+            "nodeType": "EmailTemplateNode",
+          },
+        },
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
+        },
+        "uiConfig": {
+          "categories": "["Frodo","Prototype"]",
+        },
+      },
     },
   },
 }
@@ -3814,247 +3822,251 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: Login.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "16067406-e49b-46da-8dc6-fcc021481e48": {
-      "_id": "16067406-e49b-46da-8dc6-fcc021481e48",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": false,
-    },
-    "b39425a1-f892-414f-b2fc-c7007bbdf5b2": {
-      "_id": "b39425a1-f892-414f-b2fc-c7007bbdf5b2",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-  },
   "meta": Any<Object>,
-  "nodes": {
-    "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f": {
-      "_id": "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f",
-      "_outcomes": [
-        {
-          "displayName": "Retry",
-          "id": "Retry",
-        },
-        {
-          "displayName": "Reject",
-          "id": "Reject",
-        },
-      ],
-      "_type": {
-        "_id": "RetryLimitDecisionNode",
-        "collection": true,
-        "name": "Retry Limit Decision",
-      },
-      "incrementUserAttributeOnFailure": true,
-      "retryLimit": 5,
-    },
-    "346011d9-42c1-46db-aa54-9f63b3467fae": {
-      "_id": "346011d9-42c1-46db-aa54-9f63b3467fae",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
-      },
-      "tree": "ProgressiveProfile",
-    },
-    "72e84f65-3708-4a81-8921-5c0fc8ddb1a7": {
-      "_id": "72e84f65-3708-4a81-8921-5c0fc8ddb1a7",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+  "trees": {
+    "Login": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "16067406-e49b-46da-8dc6-fcc021481e48": {
           "_id": "16067406-e49b-46da-8dc6-fcc021481e48",
-          "displayName": "Platform Username",
-          "nodeType": "ValidatedUsernameNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": false,
         },
-        {
+        "b39425a1-f892-414f-b2fc-c7007bbdf5b2": {
           "_id": "b39425a1-f892-414f-b2fc-c7007bbdf5b2",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-      ],
-      "pageDescription": {
-        "en": "New here? <a href="#/service/Registration">Create an account</a><br><a href="#/service/ForgottenUsername">Forgot username?</a><a href="#/service/ResetPassword"> Forgot password?</a>",
       },
-      "pageHeader": {
-        "en": "Sign In",
+      "nodes": {
+        "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f": {
+          "_id": "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f",
+          "_outcomes": [
+            {
+              "displayName": "Retry",
+              "id": "Retry",
+            },
+            {
+              "displayName": "Reject",
+              "id": "Reject",
+            },
+          ],
+          "_type": {
+            "_id": "RetryLimitDecisionNode",
+            "collection": true,
+            "name": "Retry Limit Decision",
+          },
+          "incrementUserAttributeOnFailure": true,
+          "retryLimit": 5,
+        },
+        "346011d9-42c1-46db-aa54-9f63b3467fae": {
+          "_id": "346011d9-42c1-46db-aa54-9f63b3467fae",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "ProgressiveProfile",
+        },
+        "72e84f65-3708-4a81-8921-5c0fc8ddb1a7": {
+          "_id": "72e84f65-3708-4a81-8921-5c0fc8ddb1a7",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "16067406-e49b-46da-8dc6-fcc021481e48",
+              "displayName": "Platform Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "b39425a1-f892-414f-b2fc-c7007bbdf5b2",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "New here? <a href="#/service/Registration">Create an account</a><br><a href="#/service/ForgottenUsername">Forgot username?</a><a href="#/service/ResetPassword"> Forgot password?</a>",
+          },
+          "pageHeader": {
+            "en": "Sign In",
+          },
+        },
+        "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3": {
+          "_id": "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AccountLockoutNode",
+            "collection": true,
+            "name": "Account Lockout",
+          },
+          "lockAction": "LOCK",
+        },
+        "9f12b80b-914f-43a8-9b77-3b5efc997394": {
+          "_id": "9f12b80b-914f-43a8-9b77-3b5efc997394",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "IncrementLoginCountNode",
+            "collection": true,
+            "name": "Increment Login Count",
+          },
+          "identityAttribute": "userName",
+        },
+        "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0": {
+          "_id": "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "TRUE",
+            },
+            {
+              "displayName": "False",
+              "id": "FALSE",
+            },
+            {
+              "displayName": "Locked",
+              "id": "LOCKED",
+            },
+            {
+              "displayName": "Cancelled",
+              "id": "CANCELLED",
+            },
+            {
+              "displayName": "Expired",
+              "id": "EXPIRED",
+            },
+          ],
+          "_type": {
+            "_id": "IdentityStoreDecisionNode",
+            "collection": true,
+            "name": "Identity Store Decision",
+          },
+          "minimumPasswordLength": 8,
+          "mixedCaseForPasswordChangeMessages": false,
+          "useUniversalIdForUsername": false,
+        },
       },
-    },
-    "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3": {
-      "_id": "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "Login",
+        "description": "Platform Login Tree",
+        "enabled": true,
+        "entryNodeId": "72e84f65-3708-4a81-8921-5c0fc8ddb1a7",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f": {
+            "connections": {
+              "Reject": "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3",
+              "Retry": "72e84f65-3708-4a81-8921-5c0fc8ddb1a7",
+            },
+            "displayName": "Retry Limit Decision",
+            "nodeType": "RetryLimitDecisionNode",
+          },
+          "346011d9-42c1-46db-aa54-9f63b3467fae": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Inner Tree Evaluator",
+            "nodeType": "InnerTreeEvaluatorNode",
+          },
+          "72e84f65-3708-4a81-8921-5c0fc8ddb1a7": {
+            "connections": {
+              "outcome": "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3": {
+            "connections": {
+              "outcome": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "Account Lockout",
+            "nodeType": "AccountLockoutNode",
+          },
+          "9f12b80b-914f-43a8-9b77-3b5efc997394": {
+            "connections": {
+              "outcome": "346011d9-42c1-46db-aa54-9f63b3467fae",
+            },
+            "displayName": "Increment Login Count",
+            "nodeType": "IncrementLoginCountNode",
+          },
+          "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0": {
+            "connections": {
+              "CANCELLED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "EXPIRED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "FALSE": "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f",
+              "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "TRUE": "9f12b80b-914f-43a8-9b77-3b5efc997394",
+            },
+            "displayName": "Identity Store Decision",
+            "nodeType": "IdentityStoreDecisionNode",
+          },
         },
-      ],
-      "_type": {
-        "_id": "AccountLockoutNode",
-        "collection": true,
-        "name": "Account Lockout",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
+        },
+        "uiConfig": {
+          "categories": "["Authentication"]",
+        },
       },
-      "lockAction": "LOCK",
-    },
-    "9f12b80b-914f-43a8-9b77-3b5efc997394": {
-      "_id": "9f12b80b-914f-43a8-9b77-3b5efc997394",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "IncrementLoginCountNode",
-        "collection": true,
-        "name": "Increment Login Count",
-      },
-      "identityAttribute": "userName",
-    },
-    "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0": {
-      "_id": "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "TRUE",
-        },
-        {
-          "displayName": "False",
-          "id": "FALSE",
-        },
-        {
-          "displayName": "Locked",
-          "id": "LOCKED",
-        },
-        {
-          "displayName": "Cancelled",
-          "id": "CANCELLED",
-        },
-        {
-          "displayName": "Expired",
-          "id": "EXPIRED",
-        },
-      ],
-      "_type": {
-        "_id": "IdentityStoreDecisionNode",
-        "collection": true,
-        "name": "Identity Store Decision",
-      },
-      "minimumPasswordLength": 8,
-      "mixedCaseForPasswordChangeMessages": false,
-      "useUniversalIdForUsername": false,
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "Login",
-    "description": "Platform Login Tree",
-    "enabled": true,
-    "entryNodeId": "72e84f65-3708-4a81-8921-5c0fc8ddb1a7",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f": {
-        "connections": {
-          "Reject": "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3",
-          "Retry": "72e84f65-3708-4a81-8921-5c0fc8ddb1a7",
-        },
-        "displayName": "Retry Limit Decision",
-        "nodeType": "RetryLimitDecisionNode",
-      },
-      "346011d9-42c1-46db-aa54-9f63b3467fae": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-        },
-        "displayName": "Inner Tree Evaluator",
-        "nodeType": "InnerTreeEvaluatorNode",
-      },
-      "72e84f65-3708-4a81-8921-5c0fc8ddb1a7": {
-        "connections": {
-          "outcome": "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0",
-        },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-      },
-      "8ec2ec98-e450-4b4b-90cc-b6e31eb325b3": {
-        "connections": {
-          "outcome": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "Account Lockout",
-        "nodeType": "AccountLockoutNode",
-      },
-      "9f12b80b-914f-43a8-9b77-3b5efc997394": {
-        "connections": {
-          "outcome": "346011d9-42c1-46db-aa54-9f63b3467fae",
-        },
-        "displayName": "Increment Login Count",
-        "nodeType": "IncrementLoginCountNode",
-      },
-      "d2d89d77-da50-4d2e-acfc-f8ec2ce1d0e0": {
-        "connections": {
-          "CANCELLED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "EXPIRED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "FALSE": "0ba3e038-b9e7-4e2b-ae04-0ca559e04a1f",
-          "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "TRUE": "9f12b80b-914f-43a8-9b77-3b5efc997394",
-        },
-        "displayName": "Identity Store Decision",
-        "nodeType": "IdentityStoreDecisionNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "["Authentication"]",
     },
   },
 }
@@ -4062,173 +4074,177 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: ProgressiveProfile.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "e8bd5b15-2dba-46ec-b756-37a92f39bd3b": {
-      "_id": "e8bd5b15-2dba-46ec-b756-37a92f39bd3b",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
-      },
-      "attributesToCollect": [
-        "preferences/updates",
-        "preferences/marketing",
-      ],
-      "identityAttribute": "userName",
-      "required": false,
-      "validateInputs": false,
-    },
-  },
   "meta": Any<Object>,
-  "nodes": {
-    "1adb28dc-a657-4d15-83b3-2aa066e30f91": {
-      "_id": "1adb28dc-a657-4d15-83b3-2aa066e30f91",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+  "trees": {
+    "ProgressiveProfile": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "e8bd5b15-2dba-46ec-b756-37a92f39bd3b": {
           "_id": "e8bd5b15-2dba-46ec-b756-37a92f39bd3b",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "preferences/updates",
+            "preferences/marketing",
+          ],
+          "identityAttribute": "userName",
+          "required": false,
+          "validateInputs": false,
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {
-        "en": "Please select your preferences",
       },
-    },
-    "6208a8b5-3a96-43be-83dc-1d8ce7990d09": {
-      "_id": "6208a8b5-3a96-43be-83dc-1d8ce7990d09",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "nodes": {
+        "1adb28dc-a657-4d15-83b3-2aa066e30f91": {
+          "_id": "1adb28dc-a657-4d15-83b3-2aa066e30f91",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "e8bd5b15-2dba-46ec-b756-37a92f39bd3b",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {
+            "en": "Please select your preferences",
+          },
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "6208a8b5-3a96-43be-83dc-1d8ce7990d09": {
+          "_id": "6208a8b5-3a96-43be-83dc-1d8ce7990d09",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "LoginCountDecisionNode",
+            "collection": true,
+            "name": "Login Count Decision",
+          },
+          "amount": 3,
+          "identityAttribute": "userName",
+          "interval": "AT",
         },
-      ],
-      "_type": {
-        "_id": "LoginCountDecisionNode",
-        "collection": true,
-        "name": "Login Count Decision",
+        "7a2f3fed-f983-42be-ad43-b909ebf0615d": {
+          "_id": "7a2f3fed-f983-42be-ad43-b909ebf0615d",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "QueryFilterDecisionNode",
+            "collection": true,
+            "name": "Query Filter Decision",
+          },
+          "identityAttribute": "userName",
+          "queryFilter": "!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false",
+        },
+        "9352b4d1-9cb1-42c7-9d23-128695ec78e1": {
+          "_id": "9352b4d1-9cb1-42c7-9d23-128695ec78e1",
+          "_outcomes": [
+            {
+              "displayName": "Patched",
+              "id": "PATCHED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "PatchObjectNode",
+            "collection": true,
+            "name": "Patch Object",
+          },
+          "identityAttribute": "userName",
+          "identityResource": "managed/alpha_user",
+          "ignoredFields": [],
+          "patchAsObject": false,
+        },
       },
-      "amount": 3,
-      "identityAttribute": "userName",
-      "interval": "AT",
-    },
-    "7a2f3fed-f983-42be-ad43-b909ebf0615d": {
-      "_id": "7a2f3fed-f983-42be-ad43-b909ebf0615d",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "ProgressiveProfile",
+        "description": "Prompt for missing preferences on 3rd login",
+        "enabled": true,
+        "entryNodeId": "6208a8b5-3a96-43be-83dc-1d8ce7990d09",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "1adb28dc-a657-4d15-83b3-2aa066e30f91": {
+            "connections": {
+              "outcome": "9352b4d1-9cb1-42c7-9d23-128695ec78e1",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "6208a8b5-3a96-43be-83dc-1d8ce7990d09": {
+            "connections": {
+              "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "true": "7a2f3fed-f983-42be-ad43-b909ebf0615d",
+            },
+            "displayName": "Login Count Decision",
+            "nodeType": "LoginCountDecisionNode",
+          },
+          "7a2f3fed-f983-42be-ad43-b909ebf0615d": {
+            "connections": {
+              "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "true": "1adb28dc-a657-4d15-83b3-2aa066e30f91",
+            },
+            "displayName": "Query Filter Decision",
+            "nodeType": "QueryFilterDecisionNode",
+          },
+          "9352b4d1-9cb1-42c7-9d23-128695ec78e1": {
+            "connections": {
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Patch Object",
+            "nodeType": "PatchObjectNode",
+          },
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-      ],
-      "_type": {
-        "_id": "QueryFilterDecisionNode",
-        "collection": true,
-        "name": "Query Filter Decision",
+        "uiConfig": {
+          "categories": "["Progressive Profile"]",
+        },
       },
-      "identityAttribute": "userName",
-      "queryFilter": "!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false",
-    },
-    "9352b4d1-9cb1-42c7-9d23-128695ec78e1": {
-      "_id": "9352b4d1-9cb1-42c7-9d23-128695ec78e1",
-      "_outcomes": [
-        {
-          "displayName": "Patched",
-          "id": "PATCHED",
-        },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
-        },
-      ],
-      "_type": {
-        "_id": "PatchObjectNode",
-        "collection": true,
-        "name": "Patch Object",
-      },
-      "identityAttribute": "userName",
-      "identityResource": "managed/alpha_user",
-      "ignoredFields": [],
-      "patchAsObject": false,
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "ProgressiveProfile",
-    "description": "Prompt for missing preferences on 3rd login",
-    "enabled": true,
-    "entryNodeId": "6208a8b5-3a96-43be-83dc-1d8ce7990d09",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "1adb28dc-a657-4d15-83b3-2aa066e30f91": {
-        "connections": {
-          "outcome": "9352b4d1-9cb1-42c7-9d23-128695ec78e1",
-        },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-      },
-      "6208a8b5-3a96-43be-83dc-1d8ce7990d09": {
-        "connections": {
-          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "true": "7a2f3fed-f983-42be-ad43-b909ebf0615d",
-        },
-        "displayName": "Login Count Decision",
-        "nodeType": "LoginCountDecisionNode",
-      },
-      "7a2f3fed-f983-42be-ad43-b909ebf0615d": {
-        "connections": {
-          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "true": "1adb28dc-a657-4d15-83b3-2aa066e30f91",
-        },
-        "displayName": "Query Filter Decision",
-        "nodeType": "QueryFilterDecisionNode",
-      },
-      "9352b4d1-9cb1-42c7-9d23-128695ec78e1": {
-        "connections": {
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-        },
-        "displayName": "Patch Object",
-        "nodeType": "PatchObjectNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "["Progressive Profile"]",
     },
   },
 }
@@ -4236,252 +4252,256 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: Registration.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "2f377942-6879-412f-aa2e-b9210871ecf2": {
-      "_id": "2f377942-6879-412f-aa2e-b9210871ecf2",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
-      },
-      "attributesToCollect": [
-        "givenName",
-        "sn",
-        "mail",
-        "preferences/marketing",
-        "preferences/updates",
-      ],
-      "identityAttribute": "userName",
-      "required": true,
-      "validateInputs": true,
-    },
-    "624154da-55f1-4d8b-820a-39c9f8929e36": {
-      "_id": "624154da-55f1-4d8b-820a-39c9f8929e36",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": true,
-    },
-    "cfe07b10-2cf7-44a8-9257-9a2b741004f6": {
-      "_id": "cfe07b10-2cf7-44a8-9257-9a2b741004f6",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": true,
-    },
-    "d951f1f9-37ad-4138-af9d-1022946a6963": {
-      "_id": "d951f1f9-37ad-4138-af9d-1022946a6963",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AcceptTermsAndConditionsNode",
-        "collection": true,
-        "name": "Accept Terms and Conditions",
-      },
-    },
-    "ee52d2df-1f9f-4e9c-ab8a-e8703c97b81b": {
-      "_id": "ee52d2df-1f9f-4e9c-ab8a-e8703c97b81b",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "KbaCreateNode",
-        "collection": true,
-        "name": "KBA Definition",
-      },
-      "allowUserDefinedQuestions": true,
-      "message": {
-        "en": "Select a security question",
-      },
-    },
-  },
   "meta": Any<Object>,
-  "nodes": {
-    "7b52755d-3d09-4a89-9853-7c5bc82306d3": {
-      "_id": "7b52755d-3d09-4a89-9853-7c5bc82306d3",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
-      },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "registration",
-      "identityAttribute": "userName",
-      "objectLookup": false,
-    },
-    "91245e40-d579-4d99-8f0d-cfc8b9fda099": {
-      "_id": "91245e40-d579-4d99-8f0d-cfc8b9fda099",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "cfe07b10-2cf7-44a8-9257-9a2b741004f6",
-          "displayName": "Platform Username",
-          "nodeType": "ValidatedUsernameNode",
-        },
-        {
+  "trees": {
+    "Registration": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "2f377942-6879-412f-aa2e-b9210871ecf2": {
           "_id": "2f377942-6879-412f-aa2e-b9210871ecf2",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "givenName",
+            "sn",
+            "mail",
+            "preferences/marketing",
+            "preferences/updates",
+          ],
+          "identityAttribute": "userName",
+          "required": true,
+          "validateInputs": true,
         },
-        {
+        "624154da-55f1-4d8b-820a-39c9f8929e36": {
           "_id": "624154da-55f1-4d8b-820a-39c9f8929e36",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": true,
         },
-        {
-          "_id": "ee52d2df-1f9f-4e9c-ab8a-e8703c97b81b",
-          "displayName": "KBA Definition",
-          "nodeType": "KbaCreateNode",
+        "cfe07b10-2cf7-44a8-9257-9a2b741004f6": {
+          "_id": "cfe07b10-2cf7-44a8-9257-9a2b741004f6",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": true,
         },
-        {
+        "d951f1f9-37ad-4138-af9d-1022946a6963": {
           "_id": "d951f1f9-37ad-4138-af9d-1022946a6963",
-          "displayName": "Accept Terms and Conditions",
-          "nodeType": "AcceptTermsAndConditionsNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AcceptTermsAndConditionsNode",
+            "collection": true,
+            "name": "Accept Terms and Conditions",
+          },
         },
-      ],
-      "pageDescription": {
-        "en": "Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>",
-      },
-      "pageHeader": {
-        "en": "Sign Up",
-      },
-    },
-    "a150cf94-2d13-42c2-8b02-a1199bdc894d": {
-      "_id": "a150cf94-2d13-42c2-8b02-a1199bdc894d",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+        "ee52d2df-1f9f-4e9c-ab8a-e8703c97b81b": {
+          "_id": "ee52d2df-1f9f-4e9c-ab8a-e8703c97b81b",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "KbaCreateNode",
+            "collection": true,
+            "name": "KBA Definition",
+          },
+          "allowUserDefinedQuestions": true,
+          "message": {
+            "en": "Select a security question",
+          },
         },
-      ],
-      "_type": {
-        "_id": "IncrementLoginCountNode",
-        "collection": true,
-        "name": "Increment Login Count",
       },
-      "identityAttribute": "userName",
-    },
-    "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a": {
-      "_id": "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a",
-      "_outcomes": [
-        {
-          "displayName": "Created",
-          "id": "CREATED",
+      "nodes": {
+        "7b52755d-3d09-4a89-9853-7c5bc82306d3": {
+          "_id": "7b52755d-3d09-4a89-9853-7c5bc82306d3",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "registration",
+          "identityAttribute": "userName",
+          "objectLookup": false,
         },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
+        "91245e40-d579-4d99-8f0d-cfc8b9fda099": {
+          "_id": "91245e40-d579-4d99-8f0d-cfc8b9fda099",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "cfe07b10-2cf7-44a8-9257-9a2b741004f6",
+              "displayName": "Platform Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "2f377942-6879-412f-aa2e-b9210871ecf2",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+            {
+              "_id": "624154da-55f1-4d8b-820a-39c9f8929e36",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "ee52d2df-1f9f-4e9c-ab8a-e8703c97b81b",
+              "displayName": "KBA Definition",
+              "nodeType": "KbaCreateNode",
+            },
+            {
+              "_id": "d951f1f9-37ad-4138-af9d-1022946a6963",
+              "displayName": "Accept Terms and Conditions",
+              "nodeType": "AcceptTermsAndConditionsNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>",
+          },
+          "pageHeader": {
+            "en": "Sign Up",
+          },
         },
-      ],
-      "_type": {
-        "_id": "CreateObjectNode",
-        "collection": true,
-        "name": "Create Object",
+        "a150cf94-2d13-42c2-8b02-a1199bdc894d": {
+          "_id": "a150cf94-2d13-42c2-8b02-a1199bdc894d",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "IncrementLoginCountNode",
+            "collection": true,
+            "name": "Increment Login Count",
+          },
+          "identityAttribute": "userName",
+        },
+        "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a": {
+          "_id": "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a",
+          "_outcomes": [
+            {
+              "displayName": "Created",
+              "id": "CREATED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "CreateObjectNode",
+            "collection": true,
+            "name": "Create Object",
+          },
+          "identityResource": "managed/alpha_user",
+        },
       },
-      "identityResource": "managed/alpha_user",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "Registration",
-    "description": "Platform Registration Tree",
-    "enabled": true,
-    "entryNodeId": "91245e40-d579-4d99-8f0d-cfc8b9fda099",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "7b52755d-3d09-4a89-9853-7c5bc82306d3": {
-        "connections": {
-          "outcome": "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "Registration",
+        "description": "Platform Registration Tree",
+        "enabled": true,
+        "entryNodeId": "91245e40-d579-4d99-8f0d-cfc8b9fda099",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "7b52755d-3d09-4a89-9853-7c5bc82306d3": {
+            "connections": {
+              "outcome": "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+          },
+          "91245e40-d579-4d99-8f0d-cfc8b9fda099": {
+            "connections": {
+              "outcome": "7b52755d-3d09-4a89-9853-7c5bc82306d3",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "a150cf94-2d13-42c2-8b02-a1199bdc894d": {
+            "connections": {
+              "outcome": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Increment Login Count",
+            "nodeType": "IncrementLoginCountNode",
+          },
+          "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a": {
+            "connections": {
+              "CREATED": "a150cf94-2d13-42c2-8b02-a1199bdc894d",
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "Create Object",
+            "nodeType": "CreateObjectNode",
+          },
         },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-      },
-      "91245e40-d579-4d99-8f0d-cfc8b9fda099": {
-        "connections": {
-          "outcome": "7b52755d-3d09-4a89-9853-7c5bc82306d3",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-      },
-      "a150cf94-2d13-42c2-8b02-a1199bdc894d": {
-        "connections": {
-          "outcome": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "uiConfig": {
+          "categories": "["Registration"]",
         },
-        "displayName": "Increment Login Count",
-        "nodeType": "IncrementLoginCountNode",
       },
-      "aa59e383-ef71-4e9a-96be-c8d7f0c5f14a": {
-        "connections": {
-          "CREATED": "a150cf94-2d13-42c2-8b02-a1199bdc894d",
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "Create Object",
-        "nodeType": "CreateObjectNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "["Registration"]",
     },
   },
 }
@@ -4489,223 +4509,227 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: ResetPassword.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "854b3100-b527-4764-acad-d99ce357073b": {
-      "_id": "854b3100-b527-4764-acad-d99ce357073b",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": true,
-    },
-    "b0d66d01-f081-4e8f-833f-62ec8365275f": {
-      "_id": "b0d66d01-f081-4e8f-833f-62ec8365275f",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
-      },
-      "attributesToCollect": [
-        "mail",
-      ],
-      "identityAttribute": "mail",
-      "required": true,
-      "validateInputs": false,
-    },
-  },
   "meta": Any<Object>,
-  "nodes": {
-    "160b706c-266a-4f09-9edb-08308f95674c": {
-      "_id": "160b706c-266a-4f09-9edb-08308f95674c",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+  "trees": {
+    "ResetPassword": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "854b3100-b527-4764-acad-d99ce357073b": {
           "_id": "854b3100-b527-4764-acad-d99ce357073b",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": true,
         },
-      ],
-      "pageDescription": {
-        "en": "Change password",
-      },
-      "pageHeader": {
-        "en": "Reset Password",
-      },
-    },
-    "19e48430-f47b-4ef5-a8d7-42d09de63174": {
-      "_id": "19e48430-f47b-4ef5-a8d7-42d09de63174",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+        "b0d66d01-f081-4e8f-833f-62ec8365275f": {
           "_id": "b0d66d01-f081-4e8f-833f-62ec8365275f",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "mail",
+          ],
+          "identityAttribute": "mail",
+          "required": true,
+          "validateInputs": false,
         },
-      ],
-      "pageDescription": {
-        "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
       },
-      "pageHeader": {
-        "en": "Reset Password",
-      },
-    },
-    "a38fc3d5-4773-4172-b624-5b541965deab": {
-      "_id": "a38fc3d5-4773-4172-b624-5b541965deab",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "nodes": {
+        "160b706c-266a-4f09-9edb-08308f95674c": {
+          "_id": "160b706c-266a-4f09-9edb-08308f95674c",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "854b3100-b527-4764-acad-d99ce357073b",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Change password",
+          },
+          "pageHeader": {
+            "en": "Reset Password",
+          },
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "19e48430-f47b-4ef5-a8d7-42d09de63174": {
+          "_id": "19e48430-f47b-4ef5-a8d7-42d09de63174",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "b0d66d01-f081-4e8f-833f-62ec8365275f",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
+          },
+          "pageHeader": {
+            "en": "Reset Password",
+          },
         },
-      ],
-      "_type": {
-        "_id": "IdentifyExistingUserNode",
-        "collection": true,
-        "name": "Identify Existing User",
-      },
-      "identifier": "userName",
-      "identityAttribute": "mail",
-    },
-    "f1c4c6a1-b13d-4644-9d10-7f7a3c719414": {
-      "_id": "f1c4c6a1-b13d-4644-9d10-7f7a3c719414",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+        "a38fc3d5-4773-4172-b624-5b541965deab": {
+          "_id": "a38fc3d5-4773-4172-b624-5b541965deab",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "IdentifyExistingUserNode",
+            "collection": true,
+            "name": "Identify Existing User",
+          },
+          "identifier": "userName",
+          "identityAttribute": "mail",
         },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
-      },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "resetPassword",
-      "identityAttribute": "mail",
-      "objectLookup": true,
-    },
-    "f24d2e17-c523-4197-b137-90b027e9e711": {
-      "_id": "f24d2e17-c523-4197-b137-90b027e9e711",
-      "_outcomes": [
-        {
-          "displayName": "Patched",
-          "id": "PATCHED",
+        "f1c4c6a1-b13d-4644-9d10-7f7a3c719414": {
+          "_id": "f1c4c6a1-b13d-4644-9d10-7f7a3c719414",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "resetPassword",
+          "identityAttribute": "mail",
+          "objectLookup": true,
         },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
+        "f24d2e17-c523-4197-b137-90b027e9e711": {
+          "_id": "f24d2e17-c523-4197-b137-90b027e9e711",
+          "_outcomes": [
+            {
+              "displayName": "Patched",
+              "id": "PATCHED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "PatchObjectNode",
+            "collection": true,
+            "name": "Patch Object",
+          },
+          "identityAttribute": "mail",
+          "identityResource": "managed/alpha_user",
+          "ignoredFields": [],
+          "patchAsObject": false,
         },
-      ],
-      "_type": {
-        "_id": "PatchObjectNode",
-        "collection": true,
-        "name": "Patch Object",
       },
-      "identityAttribute": "mail",
-      "identityResource": "managed/alpha_user",
-      "ignoredFields": [],
-      "patchAsObject": false,
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "ResetPassword",
-    "description": "Reset Password Tree",
-    "enabled": true,
-    "entryNodeId": "19e48430-f47b-4ef5-a8d7-42d09de63174",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "160b706c-266a-4f09-9edb-08308f95674c": {
-        "connections": {
-          "outcome": "f24d2e17-c523-4197-b137-90b027e9e711",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "ResetPassword",
+        "description": "Reset Password Tree",
+        "enabled": true,
+        "entryNodeId": "19e48430-f47b-4ef5-a8d7-42d09de63174",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "160b706c-266a-4f09-9edb-08308f95674c": {
+            "connections": {
+              "outcome": "f24d2e17-c523-4197-b137-90b027e9e711",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "19e48430-f47b-4ef5-a8d7-42d09de63174": {
+            "connections": {
+              "outcome": "a38fc3d5-4773-4172-b624-5b541965deab",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "a38fc3d5-4773-4172-b624-5b541965deab": {
+            "connections": {
+              "false": "f1c4c6a1-b13d-4644-9d10-7f7a3c719414",
+              "true": "f1c4c6a1-b13d-4644-9d10-7f7a3c719414",
+            },
+            "displayName": "Identify Existing User",
+            "nodeType": "IdentifyExistingUserNode",
+          },
+          "f1c4c6a1-b13d-4644-9d10-7f7a3c719414": {
+            "connections": {
+              "outcome": "160b706c-266a-4f09-9edb-08308f95674c",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+          },
+          "f24d2e17-c523-4197-b137-90b027e9e711": {
+            "connections": {
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Patch Object",
+            "nodeType": "PatchObjectNode",
+          },
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-      },
-      "19e48430-f47b-4ef5-a8d7-42d09de63174": {
-        "connections": {
-          "outcome": "a38fc3d5-4773-4172-b624-5b541965deab",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-      },
-      "a38fc3d5-4773-4172-b624-5b541965deab": {
-        "connections": {
-          "false": "f1c4c6a1-b13d-4644-9d10-7f7a3c719414",
-          "true": "f1c4c6a1-b13d-4644-9d10-7f7a3c719414",
+        "uiConfig": {
+          "categories": "["Password Reset"]",
         },
-        "displayName": "Identify Existing User",
-        "nodeType": "IdentifyExistingUserNode",
       },
-      "f1c4c6a1-b13d-4644-9d10-7f7a3c719414": {
-        "connections": {
-          "outcome": "160b706c-266a-4f09-9edb-08308f95674c",
-        },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-      },
-      "f24d2e17-c523-4197-b137-90b027e9e711": {
-        "connections": {
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-        },
-        "displayName": "Patch Object",
-        "nodeType": "PatchObjectNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "["Password Reset"]",
     },
   },
 }
@@ -4713,270 +4737,274 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: UpdatePassword.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "10cfb382-40c6-4604-b4f5-76029850b927": {
-      "_id": "10cfb382-40c6-4604-b4f5-76029850b927",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "5d600377-4492-4b0e-8265-4fb5a3f5df1b": {
-      "_id": "5d600377-4492-4b0e-8265-4fb5a3f5df1b",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": true,
-    },
-  },
   "meta": Any<Object>,
-  "nodes": {
-    "285cd6cf-9abe-45d4-911c-5c983d50a3c8": {
-      "_id": "285cd6cf-9abe-45d4-911c-5c983d50a3c8",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "AttributePresentDecisionNode",
-        "collection": true,
-        "name": "Attribute Present Decision",
-      },
-      "identityAttribute": "userName",
-      "presentAttribute": "password",
-    },
-    "39fe97d3-83eb-42b0-b850-69522df26825": {
-      "_id": "39fe97d3-83eb-42b0-b850-69522df26825",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+  "trees": {
+    "UpdatePassword": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "10cfb382-40c6-4604-b4f5-76029850b927": {
           "_id": "10cfb382-40c6-4604-b4f5-76029850b927",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-      ],
-      "pageDescription": {
-        "en": "Enter current password",
-      },
-      "pageHeader": {
-        "en": "Verify Existing Password",
-      },
-    },
-    "5b07bb1d-ce48-48da-ac39-a35f2deb765e": {
-      "_id": "5b07bb1d-ce48-48da-ac39-a35f2deb765e",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
-      },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to your address, please verify your email address to update your password. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "updatePassword",
-      "identityAttribute": "userName",
-      "objectLookup": true,
-    },
-    "8a3872a2-e213-4a88-bc2a-9938a96de079": {
-      "_id": "8a3872a2-e213-4a88-bc2a-9938a96de079",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "DataStoreDecisionNode",
-        "collection": true,
-        "name": "Data Store Decision",
-      },
-    },
-    "8a4a788e-a640-4f36-8b2e-be22dea8e977": {
-      "_id": "8a4a788e-a640-4f36-8b2e-be22dea8e977",
-      "_outcomes": [
-        {
-          "displayName": "Patched",
-          "id": "PATCHED",
-        },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
-        },
-      ],
-      "_type": {
-        "_id": "PatchObjectNode",
-        "collection": true,
-        "name": "Patch Object",
-      },
-      "identityAttribute": "userName",
-      "identityResource": "managed/alpha_user",
-      "ignoredFields": [
-        "userName",
-      ],
-      "patchAsObject": false,
-    },
-    "c931f88f-5d02-4bfb-ab54-a114f7c44850": {
-      "_id": "c931f88f-5d02-4bfb-ab54-a114f7c44850",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+        "5d600377-4492-4b0e-8265-4fb5a3f5df1b": {
           "_id": "5d600377-4492-4b0e-8265-4fb5a3f5df1b",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": true,
         },
-      ],
-      "pageDescription": {
-        "en": "Enter new password",
       },
-      "pageHeader": {
-        "en": "Update Password",
-      },
-    },
-    "f80de248-16e5-439d-9fd0-ca73ce939563": {
-      "_id": "f80de248-16e5-439d-9fd0-ca73ce939563",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+      "nodes": {
+        "285cd6cf-9abe-45d4-911c-5c983d50a3c8": {
+          "_id": "285cd6cf-9abe-45d4-911c-5c983d50a3c8",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "AttributePresentDecisionNode",
+            "collection": true,
+            "name": "Attribute Present Decision",
+          },
+          "identityAttribute": "userName",
+          "presentAttribute": "password",
         },
-      ],
-      "_type": {
-        "_id": "SessionDataNode",
-        "collection": true,
-        "name": "Get Session Data",
-      },
-      "sessionDataKey": "UserToken",
-      "sharedStateKey": "userName",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "UpdatePassword",
-    "description": "Update password using active session",
-    "enabled": true,
-    "entryNodeId": "f80de248-16e5-439d-9fd0-ca73ce939563",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "285cd6cf-9abe-45d4-911c-5c983d50a3c8": {
-        "connections": {
-          "false": "5b07bb1d-ce48-48da-ac39-a35f2deb765e",
-          "true": "39fe97d3-83eb-42b0-b850-69522df26825",
+        "39fe97d3-83eb-42b0-b850-69522df26825": {
+          "_id": "39fe97d3-83eb-42b0-b850-69522df26825",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "10cfb382-40c6-4604-b4f5-76029850b927",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter current password",
+          },
+          "pageHeader": {
+            "en": "Verify Existing Password",
+          },
         },
-        "displayName": "Attribute Present Decision",
-        "nodeType": "AttributePresentDecisionNode",
-      },
-      "39fe97d3-83eb-42b0-b850-69522df26825": {
-        "connections": {
-          "outcome": "8a3872a2-e213-4a88-bc2a-9938a96de079",
+        "5b07bb1d-ce48-48da-ac39-a35f2deb765e": {
+          "_id": "5b07bb1d-ce48-48da-ac39-a35f2deb765e",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to your address, please verify your email address to update your password. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "updatePassword",
+          "identityAttribute": "userName",
+          "objectLookup": true,
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-      },
-      "5b07bb1d-ce48-48da-ac39-a35f2deb765e": {
-        "connections": {
-          "outcome": "c931f88f-5d02-4bfb-ab54-a114f7c44850",
+        "8a3872a2-e213-4a88-bc2a-9938a96de079": {
+          "_id": "8a3872a2-e213-4a88-bc2a-9938a96de079",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "DataStoreDecisionNode",
+            "collection": true,
+            "name": "Data Store Decision",
+          },
         },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-      },
-      "8a3872a2-e213-4a88-bc2a-9938a96de079": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "c931f88f-5d02-4bfb-ab54-a114f7c44850",
+        "8a4a788e-a640-4f36-8b2e-be22dea8e977": {
+          "_id": "8a4a788e-a640-4f36-8b2e-be22dea8e977",
+          "_outcomes": [
+            {
+              "displayName": "Patched",
+              "id": "PATCHED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "PatchObjectNode",
+            "collection": true,
+            "name": "Patch Object",
+          },
+          "identityAttribute": "userName",
+          "identityResource": "managed/alpha_user",
+          "ignoredFields": [
+            "userName",
+          ],
+          "patchAsObject": false,
         },
-        "displayName": "Data Store Decision",
-        "nodeType": "DataStoreDecisionNode",
-      },
-      "8a4a788e-a640-4f36-8b2e-be22dea8e977": {
-        "connections": {
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "c931f88f-5d02-4bfb-ab54-a114f7c44850": {
+          "_id": "c931f88f-5d02-4bfb-ab54-a114f7c44850",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "5d600377-4492-4b0e-8265-4fb5a3f5df1b",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter new password",
+          },
+          "pageHeader": {
+            "en": "Update Password",
+          },
         },
-        "displayName": "Patch Object",
-        "nodeType": "PatchObjectNode",
-      },
-      "c931f88f-5d02-4bfb-ab54-a114f7c44850": {
-        "connections": {
-          "outcome": "8a4a788e-a640-4f36-8b2e-be22dea8e977",
+        "f80de248-16e5-439d-9fd0-ca73ce939563": {
+          "_id": "f80de248-16e5-439d-9fd0-ca73ce939563",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "SessionDataNode",
+            "collection": true,
+            "name": "Get Session Data",
+          },
+          "sessionDataKey": "UserToken",
+          "sharedStateKey": "userName",
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
       },
-      "f80de248-16e5-439d-9fd0-ca73ce939563": {
-        "connections": {
-          "outcome": "285cd6cf-9abe-45d4-911c-5c983d50a3c8",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "UpdatePassword",
+        "description": "Update password using active session",
+        "enabled": true,
+        "entryNodeId": "f80de248-16e5-439d-9fd0-ca73ce939563",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "285cd6cf-9abe-45d4-911c-5c983d50a3c8": {
+            "connections": {
+              "false": "5b07bb1d-ce48-48da-ac39-a35f2deb765e",
+              "true": "39fe97d3-83eb-42b0-b850-69522df26825",
+            },
+            "displayName": "Attribute Present Decision",
+            "nodeType": "AttributePresentDecisionNode",
+          },
+          "39fe97d3-83eb-42b0-b850-69522df26825": {
+            "connections": {
+              "outcome": "8a3872a2-e213-4a88-bc2a-9938a96de079",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "5b07bb1d-ce48-48da-ac39-a35f2deb765e": {
+            "connections": {
+              "outcome": "c931f88f-5d02-4bfb-ab54-a114f7c44850",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+          },
+          "8a3872a2-e213-4a88-bc2a-9938a96de079": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "c931f88f-5d02-4bfb-ab54-a114f7c44850",
+            },
+            "displayName": "Data Store Decision",
+            "nodeType": "DataStoreDecisionNode",
+          },
+          "8a4a788e-a640-4f36-8b2e-be22dea8e977": {
+            "connections": {
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Patch Object",
+            "nodeType": "PatchObjectNode",
+          },
+          "c931f88f-5d02-4bfb-ab54-a114f7c44850": {
+            "connections": {
+              "outcome": "8a4a788e-a640-4f36-8b2e-be22dea8e977",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+          },
+          "f80de248-16e5-439d-9fd0-ca73ce939563": {
+            "connections": {
+              "outcome": "285cd6cf-9abe-45d4-911c-5c983d50a3c8",
+            },
+            "displayName": "Get Session Data",
+            "nodeType": "SessionDataNode",
+          },
         },
-        "displayName": "Get Session Data",
-        "nodeType": "SessionDataNode",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
+        },
+        "uiConfig": {
+          "categories": "["Password Reset"]",
+        },
       },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "["Password Reset"]",
     },
   },
 }
@@ -4984,239 +5012,243 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: j00.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
   "meta": Any<Object>,
-  "nodes": {
-    "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
-      "_id": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j00": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
+          "_id": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
+        "240d83a3-2268-4ae1-9c20-30b65be6adab": {
+          "_id": "240d83a3-2268-4ae1-9c20-30b65be6adab",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+        },
+        "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
+          "_id": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
+          "_id": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
+          "_id": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "3cb43516-ae69-433a-8787-501d45db14e9",
+        },
+        "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
+          "_id": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "240d83a3-2268-4ae1-9c20-30b65be6adab": {
-      "_id": "240d83a3-2268-4ae1-9c20-30b65be6adab",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j00",
+        "enabled": true,
+        "entryNodeId": "240d83a3-2268-4ae1-9c20-30b65be6adab",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
+            "connections": {
+              "true": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "240d83a3-2268-4ae1-9c20-30b65be6adab": {
+            "connections": {
+              "level only": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
+              "none": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+              "shared and level": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
+              "shared only": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
+            "connections": {
+              "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
+            "connections": {
+              "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
+            "connections": {
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "debug",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
+            "connections": {
+              "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
         },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-        {
-          "displayName": "level only",
-          "id": "level only",
+        "uiConfig": {
+          "categories": "[]",
         },
-        {
-          "displayName": "none",
-          "id": "none",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
-      "_id": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
-      "_id": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
-      "_id": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "3cb43516-ae69-433a-8787-501d45db14e9",
-    },
-    "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
-      "_id": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j00",
-    "enabled": true,
-    "entryNodeId": "240d83a3-2268-4ae1-9c20-30b65be6adab",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
-        "connections": {
-          "true": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "240d83a3-2268-4ae1-9c20-30b65be6adab": {
-        "connections": {
-          "level only": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
-          "none": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-          "shared and level": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
-          "shared only": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
-        },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
-        "connections": {
-          "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
-        "connections": {
-          "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
-        "connections": {
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "debug",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
-        "connections": {
-          "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }
@@ -5224,235 +5256,239 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: j01.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
   "meta": Any<Object>,
-  "nodes": {
-    "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
-      "_id": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j01": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
+          "_id": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
+        "aa97f870-d95e-4861-b756-64b6423dd7da": {
+          "_id": "aa97f870-d95e-4861-b756-64b6423dd7da",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "j00",
+        },
+        "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
+          "_id": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+        },
+        "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
+          "_id": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
+        "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
+          "_id": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "fa62ae77-1e86-4939-a773-e428259fac97": {
+          "_id": "fa62ae77-1e86-4939-a773-e428259fac97",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "aa97f870-d95e-4861-b756-64b6423dd7da": {
-      "_id": "aa97f870-d95e-4861-b756-64b6423dd7da",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j01",
+        "enabled": true,
+        "entryNodeId": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "aa97f870-d95e-4861-b756-64b6423dd7da": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "nest",
+            "nodeType": "InnerTreeEvaluatorNode",
+          },
+          "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
+            "connections": {
+              "level only": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
+              "none": "aa97f870-d95e-4861-b756-64b6423dd7da",
+              "shared and level": "fa62ae77-1e86-4939-a773-e428259fac97",
+              "shared only": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "fa62ae77-1e86-4939-a773-e428259fac97": {
+            "connections": {
+              "true": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
+        "uiConfig": {
+          "categories": "[]",
+        },
       },
-      "tree": "j00",
-    },
-    "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
-      "_id": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
-        },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
-        },
-        {
-          "displayName": "level only",
-          "id": "level only",
-        },
-        {
-          "displayName": "none",
-          "id": "none",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
-      "_id": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
-      "_id": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "fa62ae77-1e86-4939-a773-e428259fac97": {
-      "_id": "fa62ae77-1e86-4939-a773-e428259fac97",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j01",
-    "enabled": true,
-    "entryNodeId": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "aa97f870-d95e-4861-b756-64b6423dd7da": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "nest",
-        "nodeType": "InnerTreeEvaluatorNode",
-      },
-      "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
-        "connections": {
-          "level only": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
-          "none": "aa97f870-d95e-4861-b756-64b6423dd7da",
-          "shared and level": "fa62ae77-1e86-4939-a773-e428259fac97",
-          "shared only": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
-        },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "fa62ae77-1e86-4939-a773-e428259fac97": {
-        "connections": {
-          "true": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }
@@ -5460,235 +5496,239 @@ exports[`frodo journey export "frodo journey export --all-separate --no-deps --n
 
 exports[`frodo journey export "frodo journey export --all-separate --no-deps --no-coords --use-string-arrays": should export all journeys to separate files with no dependencies, no coordinates, and using string arrays: j02.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
   "meta": Any<Object>,
-  "nodes": {
-    "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
-      "_id": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j02": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
+          "_id": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
+        "33791a7d-d14a-460f-806b-5fc3113a1e13": {
+          "_id": "33791a7d-d14a-460f-806b-5fc3113a1e13",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+        },
+        "4ee0bb06-5335-403e-810b-72d574247dfe": {
+          "_id": "4ee0bb06-5335-403e-810b-72d574247dfe",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
+          "_id": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "a679285d-8718-4db3-ba08-e743ab7eb086": {
+          "_id": "a679285d-8718-4db3-ba08-e743ab7eb086",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
+        "f192e72d-aa85-447b-af66-592a60f0c6c0": {
+          "_id": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "j01",
+        },
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "33791a7d-d14a-460f-806b-5fc3113a1e13": {
-      "_id": "33791a7d-d14a-460f-806b-5fc3113a1e13",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j02",
+        "enabled": true,
+        "entryNodeId": "33791a7d-d14a-460f-806b-5fc3113a1e13",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "33791a7d-d14a-460f-806b-5fc3113a1e13": {
+            "connections": {
+              "level only": "4ee0bb06-5335-403e-810b-72d574247dfe",
+              "none": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+              "shared and level": "a679285d-8718-4db3-ba08-e743ab7eb086",
+              "shared only": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "4ee0bb06-5335-403e-810b-72d574247dfe": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "a679285d-8718-4db3-ba08-e743ab7eb086": {
+            "connections": {
+              "true": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "f192e72d-aa85-447b-af66-592a60f0c6c0": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "nest",
+            "nodeType": "InnerTreeEvaluatorNode",
+          },
         },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-        {
-          "displayName": "level only",
-          "id": "level only",
+        "uiConfig": {
+          "categories": "[]",
         },
-        {
-          "displayName": "none",
-          "id": "none",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "4ee0bb06-5335-403e-810b-72d574247dfe": {
-      "_id": "4ee0bb06-5335-403e-810b-72d574247dfe",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
-      "_id": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "a679285d-8718-4db3-ba08-e743ab7eb086": {
-      "_id": "a679285d-8718-4db3-ba08-e743ab7eb086",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "f192e72d-aa85-447b-af66-592a60f0c6c0": {
-      "_id": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
-      },
-      "tree": "j01",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j02",
-    "enabled": true,
-    "entryNodeId": "33791a7d-d14a-460f-806b-5fc3113a1e13",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "33791a7d-d14a-460f-806b-5fc3113a1e13": {
-        "connections": {
-          "level only": "4ee0bb06-5335-403e-810b-72d574247dfe",
-          "none": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-          "shared and level": "a679285d-8718-4db3-ba08-e743ab7eb086",
-          "shared only": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
-        },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "4ee0bb06-5335-403e-810b-72d574247dfe": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "a679285d-8718-4db3-ba08-e743ab7eb086": {
-        "connections": {
-          "true": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "f192e72d-aa85-447b-af66-592a60f0c6c0": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "nest",
-        "nodeType": "InnerTreeEvaluatorNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }
@@ -5698,234 +5738,238 @@ exports[`frodo journey export "frodo journey export --journey-id j02 --no-metada
 
 exports[`frodo journey export "frodo journey export --journey-id j02 --no-metadata --no-deps --no-coords --use-string-arrays -D journeyTestDirectory1": should export the journey with journey id "j02" to the folder named "journeyTestDirectory1", and the export should not contain dependencies or coordinates, and should use string arrays.: journeyTestDirectory1/j02.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
-  "nodes": {
-    "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
-      "_id": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j02": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
+          "_id": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
+        "33791a7d-d14a-460f-806b-5fc3113a1e13": {
+          "_id": "33791a7d-d14a-460f-806b-5fc3113a1e13",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+        },
+        "4ee0bb06-5335-403e-810b-72d574247dfe": {
+          "_id": "4ee0bb06-5335-403e-810b-72d574247dfe",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
+          "_id": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "a679285d-8718-4db3-ba08-e743ab7eb086": {
+          "_id": "a679285d-8718-4db3-ba08-e743ab7eb086",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
+        "f192e72d-aa85-447b-af66-592a60f0c6c0": {
+          "_id": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "j01",
+        },
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "33791a7d-d14a-460f-806b-5fc3113a1e13": {
-      "_id": "33791a7d-d14a-460f-806b-5fc3113a1e13",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j02",
+        "enabled": true,
+        "entryNodeId": "33791a7d-d14a-460f-806b-5fc3113a1e13",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "33791a7d-d14a-460f-806b-5fc3113a1e13": {
+            "connections": {
+              "level only": "4ee0bb06-5335-403e-810b-72d574247dfe",
+              "none": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+              "shared and level": "a679285d-8718-4db3-ba08-e743ab7eb086",
+              "shared only": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "4ee0bb06-5335-403e-810b-72d574247dfe": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "a679285d-8718-4db3-ba08-e743ab7eb086": {
+            "connections": {
+              "true": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+          },
+          "f192e72d-aa85-447b-af66-592a60f0c6c0": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "nest",
+            "nodeType": "InnerTreeEvaluatorNode",
+          },
         },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
+          "e301438c-0bd0-429c-ab0c-66126501069a": {},
+          "startNode": {},
         },
-        {
-          "displayName": "level only",
-          "id": "level only",
+        "uiConfig": {
+          "categories": "[]",
         },
-        {
-          "displayName": "none",
-          "id": "none",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "4ee0bb06-5335-403e-810b-72d574247dfe": {
-      "_id": "4ee0bb06-5335-403e-810b-72d574247dfe",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
-      "_id": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "a679285d-8718-4db3-ba08-e743ab7eb086": {
-      "_id": "a679285d-8718-4db3-ba08-e743ab7eb086",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "f192e72d-aa85-447b-af66-592a60f0c6c0": {
-      "_id": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
-      },
-      "tree": "j01",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j02",
-    "enabled": true,
-    "entryNodeId": "33791a7d-d14a-460f-806b-5fc3113a1e13",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "33791a7d-d14a-460f-806b-5fc3113a1e13": {
-        "connections": {
-          "level only": "4ee0bb06-5335-403e-810b-72d574247dfe",
-          "none": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-          "shared and level": "a679285d-8718-4db3-ba08-e743ab7eb086",
-          "shared only": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
-        },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "4ee0bb06-5335-403e-810b-72d574247dfe": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "a679285d-8718-4db3-ba08-e743ab7eb086": {
-        "connections": {
-          "true": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-      },
-      "f192e72d-aa85-447b-af66-592a60f0c6c0": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "nest",
-        "nodeType": "InnerTreeEvaluatorNode",
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {},
-      "e301438c-0bd0-429c-ab0c-66126501069a": {},
-      "startNode": {},
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }
@@ -5986,51 +6030,54 @@ Exporting journey...
 
 exports[`frodo journey export "frodo journey export --verbose -i FrodoTest": should export the journey with journey id "FrodoTest": FrodoTest.journey.json 1`] = `
 {
-  "circlesOfTrust": {
-    "2f04818d-561e-4f8a-82e8-af2426112138": {
-      "_id": "2f04818d-561e-4f8a-82e8-af2426112138",
-      "_type": {
-        "_id": "circlesoftrust",
-        "collection": true,
-        "name": "Circle of Trust",
+  "meta": Any<Object>,
+  "trees": {
+    "FrodoTest": {
+      "circlesOfTrust": {
+        "2f04818d-561e-4f8a-82e8-af2426112138": {
+          "_id": "2f04818d-561e-4f8a-82e8-af2426112138",
+          "_type": {
+            "_id": "circlesoftrust",
+            "collection": true,
+            "name": "Circle of Trust",
+          },
+          "status": "active",
+          "trustedProviders": [
+            "benefits-IDP|saml2",
+            "iSPAzure|saml2",
+          ],
+        },
+        "AzureCOT": {
+          "_id": "AzureCOT",
+          "_type": {
+            "_id": "circlesoftrust",
+            "collection": true,
+            "name": "Circle of Trust",
+          },
+          "status": "active",
+          "trustedProviders": [
+            "https://sts.windows.net/711ffa9c-5972-4713-ace3-688c9732614a/|saml2",
+            "SPAzure|saml2",
+            "iSPAzure|saml2",
+            "https://idc.scheuber.io/am/saml2/IDPAzure|saml2",
+          ],
+        },
       },
-      "status": "active",
-      "trustedProviders": [
-        "benefits-IDP|saml2",
-        "iSPAzure|saml2",
-      ],
-    },
-    "AzureCOT": {
-      "_id": "AzureCOT",
-      "_type": {
-        "_id": "circlesoftrust",
-        "collection": true,
-        "name": "Circle of Trust",
-      },
-      "status": "active",
-      "trustedProviders": [
-        "https://sts.windows.net/711ffa9c-5972-4713-ace3-688c9732614a/|saml2",
-        "SPAzure|saml2",
-        "iSPAzure|saml2",
-        "https://idc.scheuber.io/am/saml2/IDPAzure|saml2",
-      ],
-    },
-  },
-  "emailTemplates": {
-    "welcome": {
-      "_id": "emailTemplate/welcome",
-      "defaultLocale": "en",
-      "displayName": "Welcome",
-      "enabled": true,
-      "from": "saas@forgerock.com",
-      "html": {
-        "en": "<div class="content"><p>Welcome. Your username is '{{object.userName}}'.</p></div>",
-      },
-      "message": {
-        "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>Welcome. Your username is '{{object.userName}}'.</p></div></body></html>",
-      },
-      "mimeType": "text/html",
-      "styles": "body{
+      "emailTemplates": {
+        "welcome": {
+          "_id": "emailTemplate/welcome",
+          "defaultLocale": "en",
+          "displayName": "Welcome",
+          "enabled": true,
+          "from": "saas@forgerock.com",
+          "html": {
+            "en": "<div class="content"><p>Welcome. Your username is '{{object.userName}}'.</p></div>",
+          },
+          "message": {
+            "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>Welcome. Your username is '{{object.userName}}'.</p></div></body></html>",
+          },
+          "mimeType": "text/html",
+          "styles": "body{
  background-color:#324054;
  color:#5e6d82;
  padding:60px;
@@ -6048,1058 +6095,1059 @@ a{
  width:235px
 }
 ",
-      "subject": {
-        "en": "Your account has been created",
+          "subject": {
+            "en": "Your account has been created",
+          },
+        },
       },
-    },
-  },
-  "innerNodes": {
-    "038f9b2a-36b2-489b-9e03-386c9a62ea21": {
-      "_id": "038f9b2a-36b2-489b-9e03-386c9a62ea21",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "228a44d5-fd78-4278-8999-fdd470ea7ebf": {
-      "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "7a351800-fb7e-4145-903c-388554747556": {
-      "_id": "7a351800-fb7e-4145-903c-388554747556",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": false,
-    },
-    "804e6a68-1720-442b-926a-007e90f02782": {
-      "_id": "804e6a68-1720-442b-926a-007e90f02782",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "dd16c8d4-baca-4ae0-bcd8-fb98b9040524": {
-      "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-  },
-  "meta": Any<Object>,
-  "nodes": {
-    "278bf084-9eea-46fe-8ce9-2600dde3b046": {
-      "_id": "278bf084-9eea-46fe-8ce9-2600dde3b046",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "7a351800-fb7e-4145-903c-388554747556",
-          "displayName": "Username",
-          "nodeType": "ValidatedUsernameNode",
-        },
-        {
-          "_id": "804e6a68-1720-442b-926a-007e90f02782",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
-        },
-        {
-          "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
-        },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "64157fca-bd5b-4405-a4c8-64ffd98a5461": {
-      "_id": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "product-Saml2Node",
-        "collection": true,
-        "name": "SAML2 Authentication",
-      },
-      "allowCreate": true,
-      "authComparison": "MINIMUM",
-      "authnContextClassRef": [],
-      "authnContextDeclRef": [],
-      "binding": "HTTP_ARTIFACT",
-      "forceAuthn": false,
-      "idpEntityId": "urn:federation:MicrosoftOnline",
-      "isPassive": false,
-      "metaAlias": "/alpha/iSPAzure",
-      "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-      "requestBinding": "HTTP_REDIRECT",
-    },
-    "731c5810-020b-45c8-a7fc-3c21903ae2b3": {
-      "_id": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
-        },
-        {
+      "innerNodes": {
+        "038f9b2a-36b2-489b-9e03-386c9a62ea21": {
           "_id": "038f9b2a-36b2-489b-9e03-386c9a62ea21",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
-        },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "bf153f37-83dd-4f39-aa0c-74135430242e": {
-      "_id": "bf153f37-83dd-4f39-aa0c-74135430242e",
-      "_outcomes": [
-        {
-          "displayName": "Email Sent",
-          "id": "EMAIL_SENT",
-        },
-        {
-          "displayName": "Email Not Sent",
-          "id": "EMAIL_NOT_SENT",
-        },
-      ],
-      "_type": {
-        "_id": "EmailTemplateNode",
-        "collection": true,
-        "name": "Email Template Node",
-      },
-      "emailAttribute": "mail",
-      "emailTemplateName": "welcome",
-      "identityAttribute": "userName",
-    },
-    "d5cc2d52-6ce4-452d-85ea-3a5b50218b67": {
-      "_id": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "SocialProviderHandlerNode",
-        "collection": true,
-        "name": "Legacy Social Provider Handler Node",
-      },
-      "clientType": "BROWSER",
-      "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
-      "usernameAttribute": "userName",
-    },
-    "e2c39477-847a-4df2-9c5d-b449a752638b": {
-      "_id": "e2c39477-847a-4df2-9c5d-b449a752638b",
-      "_outcomes": [
-        {
-          "displayName": "known",
-          "id": "known",
-        },
-        {
-          "displayName": "unknown",
-          "id": "unknown",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "known",
-        "unknown",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "739bdc48-fd24-4c52-b353-88706d75558a",
-    },
-    "fc7e47cd-c679-4211-8e05-a36654f23c67": {
-      "_id": "fc7e47cd-c679-4211-8e05-a36654f23c67",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "TRUE",
-        },
-        {
-          "displayName": "False",
-          "id": "FALSE",
-        },
-        {
-          "displayName": "Locked",
-          "id": "LOCKED",
-        },
-        {
-          "displayName": "Cancelled",
-          "id": "CANCELLED",
-        },
-        {
-          "displayName": "Expired",
-          "id": "EXPIRED",
-        },
-      ],
-      "_type": {
-        "_id": "IdentityStoreDecisionNode",
-        "collection": true,
-        "name": "Identity Store Decision",
-      },
-      "minimumPasswordLength": 8,
-      "mixedCaseForPasswordChangeMessages": false,
-      "useUniversalIdForUsername": true,
-    },
-  },
-  "saml2Entities": {
-    "aVNQQXp1cmU": {
-      "_id": "aVNQQXp1cmU",
-      "entityId": "iSPAzure",
-      "entityLocation": "hosted",
-      "serviceProvider": {
-        "advanced": {
-          "ecpConfiguration": {
-            "ecpRequestIdpListFinderImpl": "com.sun.identity.saml2.plugins.ECPIDPFinder",
-          },
-          "idpProxy": {},
-          "relayStateUrlList": {},
-          "saeConfiguration": {
-            "spUrl": "https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure",
-          },
-        },
-        "assertionContent": {
-          "assertionTimeSkew": 300,
-          "authenticationContext": {
-            "authContextItems": [
-              {
-                "contextReference": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
-                "defaultItem": true,
-                "level": 0,
-              },
-            ],
-            "authenticationComparisonType": "Exact",
-            "authenticationContextMapper": "com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper",
-            "includeRequestedAuthenticationContext": true,
-          },
-          "basicAuthentication": {},
-          "nameIdFormat": {
-            "nameIdFormatList": [
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
-            ],
-          },
-          "signingAndEncryption": {
-            "encryption": {},
-            "requestResponseSigning": {},
-            "secretIdAndAlgorithms": {},
-          },
-        },
-        "assertionProcessing": {
-          "accountMapping": {
-            "spAccountMapper": "com.sun.identity.saml2.plugins.DefaultSPAccountMapper",
-            "useNameIDAsSPUserID": true,
-          },
-          "adapter": {},
-          "attributeMapper": {
-            "attributeMap": [
-              {
-                "key": "http://schemas.microsoft.com/identity/claims/displayname",
-                "value": "cn",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-                "value": "givenName",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-                "value": "sn",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-                "value": "mail",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
-                "value": "uid",
-              },
-            ],
-            "attributeMapper": "com.sun.identity.saml2.plugins.DefaultSPAttributeMapper",
-          },
-          "autoFederation": {
-            "autoFedEnabled": false,
-          },
-          "responseArtifactMessageEncoding": {
-            "encoding": "URI",
-          },
-          "url": {},
-        },
-        "services": {
-          "metaAlias": "/alpha/iSPAzure",
-          "serviceAttributes": {
-            "assertionConsumerService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-                "index": 0,
-                "isDefault": true,
-                "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "index": 1,
-                "isDefault": false,
-                "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-                "index": 2,
-                "isDefault": false,
-                "location": "https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure",
-              },
-            ],
-            "nameIdService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                "location": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-                "location": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
-              },
-            ],
-            "singleLogoutService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                "location": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-                "location": "https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure",
-              },
-            ],
-          },
-        },
-      },
-    },
-  },
-  "scripts": {
-    "23143919-6b78-40c3-b25e-beca19b229e0": {
-      "_id": "23143919-6b78-40c3-b25e-beca19b229e0",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from GitHub",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "GitHub Profile Normalization (VS)",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"GitHub rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
-    },
-    "484e6246-dbc6-4288-97e6-54e55431402e": {
-      "_id": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Apple",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Apple Profile Normalization",
-      "script": ""/*\\n * Copyright 2021-2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n *\\n * In some common default configurations, the following keys are required to be not empty:\\n * username, givenName, familyName, email.\\n *\\n * From RFC4517: A value of the Directory String syntax is a string of one or more\\n * arbitrary characters from the Universal Character Set (UCS).\\n * A zero-length character string is not permitted.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nString email = \\"change@me.com\\"\\nString subjectId = rawProfile.sub\\nString firstName = \\" \\"\\nString lastName = \\" \\"\\nString username = subjectId\\nString name\\n\\nif (rawProfile.isDefined(\\"email\\") && rawProfile.email.isNotNull()){ // User can elect to not share their email\\n    email = rawProfile.email.asString()\\n    username = email\\n}\\nif (rawProfile.isDefined(\\"name\\") && rawProfile.name.isNotNull()) {\\n    if (rawProfile.name.isDefined(\\"firstName\\") && rawProfile.name.firstName.isNotNull()) {\\n        firstName = rawProfile.name.firstName.asString()\\n    }\\n    if (rawProfile.name.isDefined(\\"lastName\\") && rawProfile.name.lastName.isNotNull()) {\\n        lastName = rawProfile.name.lastName.asString()\\n    }\\n}\\n\\nname = (firstName?.trim() ? firstName : \\"\\") + (lastName?.trim() ? ((firstName?.trim() ? \\" \\" : \\"\\") + lastName) : \\"\\")\\nname =  (!name?.trim()) ? \\" \\" : name\\n\\nreturn json(object(\\n        field(\\"id\\", subjectId),\\n        field(\\"displayName\\", name),\\n        field(\\"email\\", email),\\n        field(\\"givenName\\", firstName),\\n        field(\\"familyName\\", lastName),\\n        field(\\"username\\", username)))"",
-    },
-    "58c824ae-84ed-4724-82cd-db128fc3f6c": {
-      "_id": "58c824ae-84ed-4724-82cd-db128fc3f6c",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Converts a normalized social profile into a managed user",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Normalized Profile to Managed User",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nimport org.forgerock.json.JsonValue\\n\\nJsonValue managedUser = json(object(\\n        field(\\"givenName\\", normalizedProfile.givenName),\\n        field(\\"sn\\", normalizedProfile.familyName),\\n        field(\\"mail\\", normalizedProfile.email),\\n        field(\\"userName\\", normalizedProfile.username)))\\n\\nif (normalizedProfile.postalAddress.isNotNull()) managedUser.put(\\"postalAddress\\", normalizedProfile.postalAddress)\\nif (normalizedProfile.addressLocality.isNotNull()) managedUser.put(\\"city\\", normalizedProfile.addressLocality)\\nif (normalizedProfile.addressRegion.isNotNull()) managedUser.put(\\"stateProvince\\", normalizedProfile.addressRegion)\\nif (normalizedProfile.postalCode.isNotNull()) managedUser.put(\\"postalCode\\", normalizedProfile.postalCode)\\nif (normalizedProfile.country.isNotNull()) managedUser.put(\\"country\\", normalizedProfile.country)\\nif (normalizedProfile.phone.isNotNull()) managedUser.put(\\"telephoneNumber\\", normalizedProfile.phone)\\n\\n// if the givenName and familyName is null or empty\\n// then add a boolean flag to the shared state to indicate names are not present\\n// this could be used elsewhere\\n// for eg. this could be used in a scripted decision node to by-pass patching\\n// the user object with blank values when givenName  and familyName is not present\\nboolean noGivenName = normalizedProfile.givenName.isNull() || (!normalizedProfile.givenName.asString()?.trim())\\nboolean noFamilyName = normalizedProfile.familyName.isNull() || (!normalizedProfile.familyName.asString()?.trim())\\nsharedState.put(\\"nameEmptyOrNull\\", noGivenName && noFamilyName)\\n\\nreturn managedUser\\n"",
-    },
-    "58d29080-4563-480b-89bb-1e7719776a21": {
-      "_id": "58d29080-4563-480b-89bb-1e7719776a21",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Google",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Google Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.sub),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.given_name),\\n        field(\\"familyName\\", rawProfile.family_name),\\n        field(\\"photoUrl\\", rawProfile.picture),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email),\\n        field(\\"locale\\", rawProfile.locale)))"",
-    },
-    "6325cf19-a49b-471e-8d26-7e4df76df0e2": {
-      "_id": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from GitHub",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Okta Profile Normalization",
-      "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"Okta rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.preferred_username)))"",
-    },
-    "739bdc48-fd24-4c52-b353-88706d75558a": {
-      "_id": "739bdc48-fd24-4c52-b353-88706d75558a",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Check if username has already been collected.",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Check Username",
-      "script": ""/* Check Username\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Check if username has already been collected.\\n * Return \\"known\\" if yes, \\"unknown\\" otherwise.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - known\\n * - unknown\\n */\\n(function () {\\n    if (null != sharedState.get(\\"username\\")) {\\n        outcome = \\"known\\";\\n    }\\n    else {\\n        outcome = \\"unknown\\";\\n    }\\n}());"",
-    },
-    "73cecbfc-dad0-4395-be6a-6858ee3a80e5": {
-      "_id": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Microsoft",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Microsoft Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n{\\n    \\"@odata.context\\": \\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\\",\\n    \\"@odata.id\\": \\"https://graph.microsoft.com/v2/711ffa9c-5972-4713-ace3-688c9732614a/directoryObjects/7d7759e2-36d8-4e64-b173-3f890d7d46d6/Microsoft.DirectoryServices.User\\",\\n    \\"businessPhones\\": [\\n        \\"18014735451\\"\\n    ],\\n    \\"displayName\\": \\"Volker Scheuber\\",\\n    \\"givenName\\": \\"Volker\\",\\n    \\"jobTitle\\": null,\\n    \\"mail\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"mobilePhone\\": null,\\n    \\"officeLocation\\": null,\\n    \\"preferredLanguage\\": null,\\n    \\"surname\\": \\"Scheuber\\",\\n    \\"userPrincipalName\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"id\\": \\"7d7759e2-36d8-4e64-b173-3f890d7d46d6\\"\\n}\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.message(\\"Kauai Microsoft Profile Normalization: rawProfile={}\\", rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.displayName),\\n        field(\\"givenName\\", rawProfile.givenName),\\n        field(\\"familyName\\", rawProfile.surname),\\n        field(\\"email\\", rawProfile.userPrincipalName),\\n        field(\\"username\\", rawProfile.userPrincipalName),\\n        field(\\"groups\\", rawProfile.groups)))"",
-    },
-  },
-  "socialIdentityProviders": {
-    "apple-stoyan": {
-      "_id": "apple-stoyan",
-      "_type": {
-        "_id": "appleConfig",
-        "collection": true,
-        "name": "Client configuration for Apple.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "CHANGE ME",
-      "enableNativeNonce": true,
-      "enabled": false,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://appleid.apple.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectAfterFormPostURI": "https://openam-volker-dev.forgeblocks.com/login",
-      "redirectURI": "https://openam-volker-dev.forgeblocks.com/am/oauth2/alpha/client/form_post/apple-stoyan",
-      "requestNativeAppForUserInfo": false,
-      "responseMode": "FORM_POST",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "name",
-        "email",
-      ],
-      "tokenEndpoint": "https://appleid.apple.com/auth/token",
-      "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonDisplayName": "Apple",
-        "buttonImage": "/login/images/apple-logo.png",
-        "iconBackground": "#000000",
-        "iconClass": "fa-apple",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
-    },
-    "apple_web": {
-      "_id": "apple_web",
-      "_type": {
-        "_id": "appleConfig",
-        "collection": true,
-        "name": "Client configuration for Apple.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "io.scheuber.idc.signinWithApple.service",
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://appleid.apple.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectAfterFormPostURI": "https://idc.scheuber.io/login",
-      "redirectURI": "https://idc.scheuber.io/am/oauth2/client/form_post/apple_web",
-      "requestNativeAppForUserInfo": false,
-      "responseMode": "FORM_POST",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "name",
-        "email",
-      ],
-      "tokenEndpoint": "https://appleid.apple.com/auth/token",
-      "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonDisplayName": "Apple",
-        "buttonImage": "/login/images/apple-logo.png",
-        "iconBackground": "#000000",
-        "iconClass": "fa-apple",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
-    },
-    "azure": {
-      "_id": "azure",
-      "_type": {
-        "_id": "microsoftConfig",
-        "collection": true,
-        "name": "Client configuration for Microsoft.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "c42a3dc8-f276-496b-a722-269f131cc21c",
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "User.Read",
-        "openid",
-      ],
-      "tokenEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/token",
-      "transform": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonDisplayName": "Microsoft Azure",
-        "buttonImage": "/login/images/microsoft-logo.png",
-        "iconBackground": "#0078d7",
-        "iconClass": "fa-windows",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://graph.microsoft.com/v1.0/me",
-    },
-    "github": {
-      "_id": "github",
-      "_type": {
-        "_id": "oauth2Config",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OAuth2 specification.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://github.com/login/oauth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "bdae6d141d4dcf95a630",
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "user",
-      ],
-      "tokenEndpoint": "https://ig.mytestrun.com/login/oauth/access_token",
-      "transform": "23143919-6b78-40c3-b25e-beca19b229e0",
-      "uiConfig": {
-        "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
-        "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
-        "buttonDisplayName": "GitHub",
-        "buttonImage": "https://cdn-icons-png.flaticon.com/512/25/25231.png",
-        "iconBackground": "#4184f3",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://ig.mytestrun.com/user",
-    },
-    "google": {
-      "_id": "google",
-      "_type": {
-        "_id": "googleConfig",
-        "collection": true,
-        "name": "Client configuration for Google.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "297338177925-mho17cgnm540s2gre8h27feb6sbs1msd.apps.googleusercontent.com",
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://accounts.google.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://www.googleapis.com/oauth2/v4/token",
-      "transform": "58d29080-4563-480b-89bb-1e7719776a21",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
-        "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
-        "buttonDisplayName": "Google",
-        "buttonImage": "images/g-logo.png",
-        "iconBackground": "#4184f3",
-        "iconClass": "fa-google",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://www.googleapis.com/oauth2/v3/userinfo",
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://accounts.google.com/.well-known/openid-configuration",
-    },
-    "okta-trial-5735851": {
-      "_id": "okta-trial-5735851",
-      "_type": {
-        "_id": "oidcConfig",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OpenID Connect specification.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://trial-5735851.okta.com/oauth2/v1/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "0oa13r2cp29Rynmyw697",
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://trial-5735851.okta.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://trial-5735851.okta.com/oauth2/v1/token",
-      "transform": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
-      "uiConfig": {
-        "buttonDisplayName": "Okta",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://trial-5735851.okta.com/oauth2/v1/userinfo",
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://trial-5735851.okta.com/.well-known/openid-configuration",
-    },
-  },
-  "themes": [
-    {
-      "_id": "63e19668-909f-479e-83d7-be7a01cd8187",
-      "accountCardBackgroundColor": "#ffffff",
-      "accountCardHeaderColor": "#23282e",
-      "accountCardInnerBorderColor": "#e7eef4",
-      "accountCardInputBackgroundColor": "#ffffff",
-      "accountCardInputBorderColor": "#c0c9d5",
-      "accountCardInputLabelColor": "#5e6d82",
-      "accountCardInputSelectColor": "#e4f4fd",
-      "accountCardInputTextColor": "#23282e",
-      "accountCardOuterBorderColor": "#e7eef4",
-      "accountCardShadow": 3,
-      "accountCardTabActiveBorderColor": "#109cf1",
-      "accountCardTabActiveColor": "#e4f4fd",
-      "accountCardTextColor": "#5e6d82",
-      "accountFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
-<a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
-      "accountFooterEnabled": false,
-      "accountNavigationBackgroundColor": "#ffffff",
-      "accountNavigationTextColor": "#455469",
-      "accountNavigationToggleBorderColor": "#e7eef4",
-      "accountPageSections": {
-        "accountControls": {
-          "enabled": false,
-        },
-        "accountSecurity": {
-          "enabled": true,
-          "subsections": {
-            "password": {
-              "enabled": true,
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
             },
-            "securityQuestions": {
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
+        },
+        "228a44d5-fd78-4278-8999-fdd470ea7ebf": {
+          "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
+        },
+        "7a351800-fb7e-4145-903c-388554747556": {
+          "_id": "7a351800-fb7e-4145-903c-388554747556",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": false,
+        },
+        "804e6a68-1720-442b-926a-007e90f02782": {
+          "_id": "804e6a68-1720-442b-926a-007e90f02782",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
+        },
+        "dd16c8d4-baca-4ae0-bcd8-fb98b9040524": {
+          "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
+        },
+      },
+      "nodes": {
+        "278bf084-9eea-46fe-8ce9-2600dde3b046": {
+          "_id": "278bf084-9eea-46fe-8ce9-2600dde3b046",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "7a351800-fb7e-4145-903c-388554747556",
+              "displayName": "Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "804e6a68-1720-442b-926a-007e90f02782",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
+        },
+        "64157fca-bd5b-4405-a4c8-64ffd98a5461": {
+          "_id": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "product-Saml2Node",
+            "collection": true,
+            "name": "SAML2 Authentication",
+          },
+          "allowCreate": true,
+          "authComparison": "MINIMUM",
+          "authnContextClassRef": [],
+          "authnContextDeclRef": [],
+          "binding": "HTTP_ARTIFACT",
+          "forceAuthn": false,
+          "idpEntityId": "urn:federation:MicrosoftOnline",
+          "isPassive": false,
+          "metaAlias": "/alpha/iSPAzure",
+          "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+          "requestBinding": "HTTP_REDIRECT",
+        },
+        "731c5810-020b-45c8-a7fc-3c21903ae2b3": {
+          "_id": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "038f9b2a-36b2-489b-9e03-386c9a62ea21",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
+        },
+        "bf153f37-83dd-4f39-aa0c-74135430242e": {
+          "_id": "bf153f37-83dd-4f39-aa0c-74135430242e",
+          "_outcomes": [
+            {
+              "displayName": "Email Sent",
+              "id": "EMAIL_SENT",
+            },
+            {
+              "displayName": "Email Not Sent",
+              "id": "EMAIL_NOT_SENT",
+            },
+          ],
+          "_type": {
+            "_id": "EmailTemplateNode",
+            "collection": true,
+            "name": "Email Template Node",
+          },
+          "emailAttribute": "mail",
+          "emailTemplateName": "welcome",
+          "identityAttribute": "userName",
+        },
+        "d5cc2d52-6ce4-452d-85ea-3a5b50218b67": {
+          "_id": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "SocialProviderHandlerNode",
+            "collection": true,
+            "name": "Legacy Social Provider Handler Node",
+          },
+          "clientType": "BROWSER",
+          "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
+          "usernameAttribute": "userName",
+        },
+        "e2c39477-847a-4df2-9c5d-b449a752638b": {
+          "_id": "e2c39477-847a-4df2-9c5d-b449a752638b",
+          "_outcomes": [
+            {
+              "displayName": "known",
+              "id": "known",
+            },
+            {
+              "displayName": "unknown",
+              "id": "unknown",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "known",
+            "unknown",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "739bdc48-fd24-4c52-b353-88706d75558a",
+        },
+        "fc7e47cd-c679-4211-8e05-a36654f23c67": {
+          "_id": "fc7e47cd-c679-4211-8e05-a36654f23c67",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "TRUE",
+            },
+            {
+              "displayName": "False",
+              "id": "FALSE",
+            },
+            {
+              "displayName": "Locked",
+              "id": "LOCKED",
+            },
+            {
+              "displayName": "Cancelled",
+              "id": "CANCELLED",
+            },
+            {
+              "displayName": "Expired",
+              "id": "EXPIRED",
+            },
+          ],
+          "_type": {
+            "_id": "IdentityStoreDecisionNode",
+            "collection": true,
+            "name": "Identity Store Decision",
+          },
+          "minimumPasswordLength": 8,
+          "mixedCaseForPasswordChangeMessages": false,
+          "useUniversalIdForUsername": true,
+        },
+      },
+      "saml2Entities": {
+        "aVNQQXp1cmU": {
+          "_id": "aVNQQXp1cmU",
+          "entityId": "iSPAzure",
+          "entityLocation": "hosted",
+          "serviceProvider": {
+            "advanced": {
+              "ecpConfiguration": {
+                "ecpRequestIdpListFinderImpl": "com.sun.identity.saml2.plugins.ECPIDPFinder",
+              },
+              "idpProxy": {},
+              "relayStateUrlList": {},
+              "saeConfiguration": {
+                "spUrl": "https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure",
+              },
+            },
+            "assertionContent": {
+              "assertionTimeSkew": 300,
+              "authenticationContext": {
+                "authContextItems": [
+                  {
+                    "contextReference": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+                    "defaultItem": true,
+                    "level": 0,
+                  },
+                ],
+                "authenticationComparisonType": "Exact",
+                "authenticationContextMapper": "com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper",
+                "includeRequestedAuthenticationContext": true,
+              },
+              "basicAuthentication": {},
+              "nameIdFormat": {
+                "nameIdFormatList": [
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
+                ],
+              },
+              "signingAndEncryption": {
+                "encryption": {},
+                "requestResponseSigning": {},
+                "secretIdAndAlgorithms": {},
+              },
+            },
+            "assertionProcessing": {
+              "accountMapping": {
+                "spAccountMapper": "com.sun.identity.saml2.plugins.DefaultSPAccountMapper",
+                "useNameIDAsSPUserID": true,
+              },
+              "adapter": {},
+              "attributeMapper": {
+                "attributeMap": [
+                  {
+                    "key": "http://schemas.microsoft.com/identity/claims/displayname",
+                    "value": "cn",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+                    "value": "givenName",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+                    "value": "sn",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+                    "value": "mail",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+                    "value": "uid",
+                  },
+                ],
+                "attributeMapper": "com.sun.identity.saml2.plugins.DefaultSPAttributeMapper",
+              },
+              "autoFederation": {
+                "autoFedEnabled": false,
+              },
+              "responseArtifactMessageEncoding": {
+                "encoding": "URI",
+              },
+              "url": {},
+            },
+            "services": {
+              "metaAlias": "/alpha/iSPAzure",
+              "serviceAttributes": {
+                "assertionConsumerService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
+                    "index": 0,
+                    "isDefault": true,
+                    "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "index": 1,
+                    "isDefault": false,
+                    "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
+                    "index": 2,
+                    "isDefault": false,
+                    "location": "https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+                "nameIdService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "location": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+                    "location": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+                "singleLogoutService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "location": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+                    "location": "https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      "scripts": {
+        "23143919-6b78-40c3-b25e-beca19b229e0": {
+          "_id": "23143919-6b78-40c3-b25e-beca19b229e0",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from GitHub",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "GitHub Profile Normalization (VS)",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"GitHub rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
+        },
+        "484e6246-dbc6-4288-97e6-54e55431402e": {
+          "_id": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Apple",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Apple Profile Normalization",
+          "script": ""/*\\n * Copyright 2021-2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n *\\n * In some common default configurations, the following keys are required to be not empty:\\n * username, givenName, familyName, email.\\n *\\n * From RFC4517: A value of the Directory String syntax is a string of one or more\\n * arbitrary characters from the Universal Character Set (UCS).\\n * A zero-length character string is not permitted.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nString email = \\"change@me.com\\"\\nString subjectId = rawProfile.sub\\nString firstName = \\" \\"\\nString lastName = \\" \\"\\nString username = subjectId\\nString name\\n\\nif (rawProfile.isDefined(\\"email\\") && rawProfile.email.isNotNull()){ // User can elect to not share their email\\n    email = rawProfile.email.asString()\\n    username = email\\n}\\nif (rawProfile.isDefined(\\"name\\") && rawProfile.name.isNotNull()) {\\n    if (rawProfile.name.isDefined(\\"firstName\\") && rawProfile.name.firstName.isNotNull()) {\\n        firstName = rawProfile.name.firstName.asString()\\n    }\\n    if (rawProfile.name.isDefined(\\"lastName\\") && rawProfile.name.lastName.isNotNull()) {\\n        lastName = rawProfile.name.lastName.asString()\\n    }\\n}\\n\\nname = (firstName?.trim() ? firstName : \\"\\") + (lastName?.trim() ? ((firstName?.trim() ? \\" \\" : \\"\\") + lastName) : \\"\\")\\nname =  (!name?.trim()) ? \\" \\" : name\\n\\nreturn json(object(\\n        field(\\"id\\", subjectId),\\n        field(\\"displayName\\", name),\\n        field(\\"email\\", email),\\n        field(\\"givenName\\", firstName),\\n        field(\\"familyName\\", lastName),\\n        field(\\"username\\", username)))"",
+        },
+        "58c824ae-84ed-4724-82cd-db128fc3f6c": {
+          "_id": "58c824ae-84ed-4724-82cd-db128fc3f6c",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Converts a normalized social profile into a managed user",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Normalized Profile to Managed User",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nimport org.forgerock.json.JsonValue\\n\\nJsonValue managedUser = json(object(\\n        field(\\"givenName\\", normalizedProfile.givenName),\\n        field(\\"sn\\", normalizedProfile.familyName),\\n        field(\\"mail\\", normalizedProfile.email),\\n        field(\\"userName\\", normalizedProfile.username)))\\n\\nif (normalizedProfile.postalAddress.isNotNull()) managedUser.put(\\"postalAddress\\", normalizedProfile.postalAddress)\\nif (normalizedProfile.addressLocality.isNotNull()) managedUser.put(\\"city\\", normalizedProfile.addressLocality)\\nif (normalizedProfile.addressRegion.isNotNull()) managedUser.put(\\"stateProvince\\", normalizedProfile.addressRegion)\\nif (normalizedProfile.postalCode.isNotNull()) managedUser.put(\\"postalCode\\", normalizedProfile.postalCode)\\nif (normalizedProfile.country.isNotNull()) managedUser.put(\\"country\\", normalizedProfile.country)\\nif (normalizedProfile.phone.isNotNull()) managedUser.put(\\"telephoneNumber\\", normalizedProfile.phone)\\n\\n// if the givenName and familyName is null or empty\\n// then add a boolean flag to the shared state to indicate names are not present\\n// this could be used elsewhere\\n// for eg. this could be used in a scripted decision node to by-pass patching\\n// the user object with blank values when givenName  and familyName is not present\\nboolean noGivenName = normalizedProfile.givenName.isNull() || (!normalizedProfile.givenName.asString()?.trim())\\nboolean noFamilyName = normalizedProfile.familyName.isNull() || (!normalizedProfile.familyName.asString()?.trim())\\nsharedState.put(\\"nameEmptyOrNull\\", noGivenName && noFamilyName)\\n\\nreturn managedUser\\n"",
+        },
+        "58d29080-4563-480b-89bb-1e7719776a21": {
+          "_id": "58d29080-4563-480b-89bb-1e7719776a21",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Google",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Google Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.sub),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.given_name),\\n        field(\\"familyName\\", rawProfile.family_name),\\n        field(\\"photoUrl\\", rawProfile.picture),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email),\\n        field(\\"locale\\", rawProfile.locale)))"",
+        },
+        "6325cf19-a49b-471e-8d26-7e4df76df0e2": {
+          "_id": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from GitHub",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Okta Profile Normalization",
+          "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"Okta rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.preferred_username)))"",
+        },
+        "739bdc48-fd24-4c52-b353-88706d75558a": {
+          "_id": "739bdc48-fd24-4c52-b353-88706d75558a",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Check if username has already been collected.",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Check Username",
+          "script": ""/* Check Username\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Check if username has already been collected.\\n * Return \\"known\\" if yes, \\"unknown\\" otherwise.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - known\\n * - unknown\\n */\\n(function () {\\n    if (null != sharedState.get(\\"username\\")) {\\n        outcome = \\"known\\";\\n    }\\n    else {\\n        outcome = \\"unknown\\";\\n    }\\n}());"",
+        },
+        "73cecbfc-dad0-4395-be6a-6858ee3a80e5": {
+          "_id": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Microsoft",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Microsoft Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n{\\n    \\"@odata.context\\": \\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\\",\\n    \\"@odata.id\\": \\"https://graph.microsoft.com/v2/711ffa9c-5972-4713-ace3-688c9732614a/directoryObjects/7d7759e2-36d8-4e64-b173-3f890d7d46d6/Microsoft.DirectoryServices.User\\",\\n    \\"businessPhones\\": [\\n        \\"18014735451\\"\\n    ],\\n    \\"displayName\\": \\"Volker Scheuber\\",\\n    \\"givenName\\": \\"Volker\\",\\n    \\"jobTitle\\": null,\\n    \\"mail\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"mobilePhone\\": null,\\n    \\"officeLocation\\": null,\\n    \\"preferredLanguage\\": null,\\n    \\"surname\\": \\"Scheuber\\",\\n    \\"userPrincipalName\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"id\\": \\"7d7759e2-36d8-4e64-b173-3f890d7d46d6\\"\\n}\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.message(\\"Kauai Microsoft Profile Normalization: rawProfile={}\\", rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.displayName),\\n        field(\\"givenName\\", rawProfile.givenName),\\n        field(\\"familyName\\", rawProfile.surname),\\n        field(\\"email\\", rawProfile.userPrincipalName),\\n        field(\\"username\\", rawProfile.userPrincipalName),\\n        field(\\"groups\\", rawProfile.groups)))"",
+        },
+      },
+      "socialIdentityProviders": {
+        "apple-stoyan": {
+          "_id": "apple-stoyan",
+          "_type": {
+            "_id": "appleConfig",
+            "collection": true,
+            "name": "Client configuration for Apple.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "CHANGE ME",
+          "enableNativeNonce": true,
+          "enabled": false,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://appleid.apple.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectAfterFormPostURI": "https://openam-volker-dev.forgeblocks.com/login",
+          "redirectURI": "https://openam-volker-dev.forgeblocks.com/am/oauth2/alpha/client/form_post/apple-stoyan",
+          "requestNativeAppForUserInfo": false,
+          "responseMode": "FORM_POST",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "name",
+            "email",
+          ],
+          "tokenEndpoint": "https://appleid.apple.com/auth/token",
+          "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonDisplayName": "Apple",
+            "buttonImage": "/login/images/apple-logo.png",
+            "iconBackground": "#000000",
+            "iconClass": "fa-apple",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
+        },
+        "apple_web": {
+          "_id": "apple_web",
+          "_type": {
+            "_id": "appleConfig",
+            "collection": true,
+            "name": "Client configuration for Apple.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "io.scheuber.idc.signinWithApple.service",
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://appleid.apple.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectAfterFormPostURI": "https://idc.scheuber.io/login",
+          "redirectURI": "https://idc.scheuber.io/am/oauth2/client/form_post/apple_web",
+          "requestNativeAppForUserInfo": false,
+          "responseMode": "FORM_POST",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "name",
+            "email",
+          ],
+          "tokenEndpoint": "https://appleid.apple.com/auth/token",
+          "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonDisplayName": "Apple",
+            "buttonImage": "/login/images/apple-logo.png",
+            "iconBackground": "#000000",
+            "iconClass": "fa-apple",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
+        },
+        "azure": {
+          "_id": "azure",
+          "_type": {
+            "_id": "microsoftConfig",
+            "collection": true,
+            "name": "Client configuration for Microsoft.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "c42a3dc8-f276-496b-a722-269f131cc21c",
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "User.Read",
+            "openid",
+          ],
+          "tokenEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/token",
+          "transform": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonDisplayName": "Microsoft Azure",
+            "buttonImage": "/login/images/microsoft-logo.png",
+            "iconBackground": "#0078d7",
+            "iconClass": "fa-windows",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://graph.microsoft.com/v1.0/me",
+        },
+        "github": {
+          "_id": "github",
+          "_type": {
+            "_id": "oauth2Config",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OAuth2 specification.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://github.com/login/oauth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "bdae6d141d4dcf95a630",
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "user",
+          ],
+          "tokenEndpoint": "https://ig.mytestrun.com/login/oauth/access_token",
+          "transform": "23143919-6b78-40c3-b25e-beca19b229e0",
+          "uiConfig": {
+            "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
+            "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
+            "buttonDisplayName": "GitHub",
+            "buttonImage": "https://cdn-icons-png.flaticon.com/512/25/25231.png",
+            "iconBackground": "#4184f3",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://ig.mytestrun.com/user",
+        },
+        "google": {
+          "_id": "google",
+          "_type": {
+            "_id": "googleConfig",
+            "collection": true,
+            "name": "Client configuration for Google.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "297338177925-mho17cgnm540s2gre8h27feb6sbs1msd.apps.googleusercontent.com",
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://accounts.google.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://www.googleapis.com/oauth2/v4/token",
+          "transform": "58d29080-4563-480b-89bb-1e7719776a21",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
+            "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
+            "buttonDisplayName": "Google",
+            "buttonImage": "images/g-logo.png",
+            "iconBackground": "#4184f3",
+            "iconClass": "fa-google",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://www.googleapis.com/oauth2/v3/userinfo",
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://accounts.google.com/.well-known/openid-configuration",
+        },
+        "okta-trial-5735851": {
+          "_id": "okta-trial-5735851",
+          "_type": {
+            "_id": "oidcConfig",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OpenID Connect specification.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://trial-5735851.okta.com/oauth2/v1/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "0oa13r2cp29Rynmyw697",
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://trial-5735851.okta.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://trial-5735851.okta.com/oauth2/v1/token",
+          "transform": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
+          "uiConfig": {
+            "buttonDisplayName": "Okta",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://trial-5735851.okta.com/oauth2/v1/userinfo",
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://trial-5735851.okta.com/.well-known/openid-configuration",
+        },
+      },
+      "themes": [
+        {
+          "_id": "63e19668-909f-479e-83d7-be7a01cd8187",
+          "accountCardBackgroundColor": "#ffffff",
+          "accountCardHeaderColor": "#23282e",
+          "accountCardInnerBorderColor": "#e7eef4",
+          "accountCardInputBackgroundColor": "#ffffff",
+          "accountCardInputBorderColor": "#c0c9d5",
+          "accountCardInputLabelColor": "#5e6d82",
+          "accountCardInputSelectColor": "#e4f4fd",
+          "accountCardInputTextColor": "#23282e",
+          "accountCardOuterBorderColor": "#e7eef4",
+          "accountCardShadow": 3,
+          "accountCardTabActiveBorderColor": "#109cf1",
+          "accountCardTabActiveColor": "#e4f4fd",
+          "accountCardTextColor": "#5e6d82",
+          "accountFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
+<a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
+          "accountFooterEnabled": false,
+          "accountNavigationBackgroundColor": "#ffffff",
+          "accountNavigationTextColor": "#455469",
+          "accountNavigationToggleBorderColor": "#e7eef4",
+          "accountPageSections": {
+            "accountControls": {
               "enabled": false,
             },
-            "twoStepVerification": {
+            "accountSecurity": {
+              "enabled": true,
+              "subsections": {
+                "password": {
+                  "enabled": true,
+                },
+                "securityQuestions": {
+                  "enabled": false,
+                },
+                "twoStepVerification": {
+                  "enabled": true,
+                },
+                "username": {
+                  "enabled": true,
+                },
+              },
+            },
+            "consent": {
+              "enabled": false,
+            },
+            "oauthApplications": {
+              "enabled": false,
+            },
+            "personalInformation": {
               "enabled": true,
             },
-            "username": {
+            "preferences": {
+              "enabled": true,
+            },
+            "social": {
+              "enabled": false,
+            },
+            "trustedDevices": {
               "enabled": true,
             },
           },
-        },
-        "consent": {
-          "enabled": false,
-        },
-        "oauthApplications": {
-          "enabled": false,
-        },
-        "personalInformation": {
-          "enabled": true,
-        },
-        "preferences": {
-          "enabled": true,
-        },
-        "social": {
-          "enabled": false,
-        },
-        "trustedDevices": {
-          "enabled": true,
-        },
-      },
-      "accountTableRowHoverColor": "#f6f8fa",
-      "backgroundColor": "#FFFFFF",
-      "backgroundImage": "",
-      "bodyText": "#000000",
-      "boldLinks": false,
-      "buttonRounded": "0",
-      "dangerColor": "#f7685b",
-      "favicon": "",
-      "fontFamily": "Open Sans",
-      "isDefault": false,
-      "journeyCardBackgroundColor": "#ffffff",
-      "journeyCardShadow": 3,
-      "journeyCardTextColor": "#5e6d82",
-      "journeyCardTitleColor": "#23282e",
-      "journeyFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
+          "accountTableRowHoverColor": "#f6f8fa",
+          "backgroundColor": "#FFFFFF",
+          "backgroundImage": "",
+          "bodyText": "#000000",
+          "boldLinks": false,
+          "buttonRounded": "0",
+          "dangerColor": "#f7685b",
+          "favicon": "",
+          "fontFamily": "Open Sans",
+          "isDefault": false,
+          "journeyCardBackgroundColor": "#ffffff",
+          "journeyCardShadow": 3,
+          "journeyCardTextColor": "#5e6d82",
+          "journeyCardTitleColor": "#23282e",
+          "journeyFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
 <a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
-      "journeyFooterEnabled": false,
-      "journeyHeader": "<div class="d-flex justify-content-center py-4 flex-grow-1">Header Content</div>",
-      "journeyHeaderEnabled": false,
-      "journeyInputBackgroundColor": "#ffffff",
-      "journeyInputBorderColor": "#c0c9d5",
-      "journeyInputLabelColor": "#5e6d82",
-      "journeyInputSelectColor": "#e4f4fd",
-      "journeyInputTextColor": "#23282e",
-      "journeyJustifiedContent": "",
-      "journeyJustifiedContentEnabled": false,
-      "journeyLayout": "card",
-      "journeyTheaterMode": false,
-      "linkActiveColor": "#000000",
-      "linkColor": "#000000",
-      "linkedTrees": [
-        "FrodoTest",
-        "AA-FrodoTest",
+          "journeyFooterEnabled": false,
+          "journeyHeader": "<div class="d-flex justify-content-center py-4 flex-grow-1">Header Content</div>",
+          "journeyHeaderEnabled": false,
+          "journeyInputBackgroundColor": "#ffffff",
+          "journeyInputBorderColor": "#c0c9d5",
+          "journeyInputLabelColor": "#5e6d82",
+          "journeyInputSelectColor": "#e4f4fd",
+          "journeyInputTextColor": "#23282e",
+          "journeyJustifiedContent": "",
+          "journeyJustifiedContentEnabled": false,
+          "journeyLayout": "card",
+          "journeyTheaterMode": false,
+          "linkActiveColor": "#000000",
+          "linkColor": "#000000",
+          "linkedTrees": [
+            "FrodoTest",
+            "AA-FrodoTest",
+          ],
+          "logo": "https://cdn.forgerock.com/platform/themes/contrast/logo-contrast.svg",
+          "logoAltText": "Contrast",
+          "logoEnabled": false,
+          "logoHeight": "72",
+          "logoProfile": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
+          "logoProfileAltText": "Contrast",
+          "logoProfileCollapsed": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
+          "logoProfileCollapsedAltText": "",
+          "logoProfileCollapsedHeight": "22",
+          "logoProfileHeight": "22",
+          "name": "NoAccess",
+          "pageTitle": "#23282e",
+          "primaryColor": "#000000",
+          "primaryOffColor": "#000000",
+          "profileBackgroundColor": "#FFFFFF",
+          "profileMenuHighlightColor": "#FFFFFF",
+          "profileMenuHoverColor": "#FFFFFF",
+          "profileMenuHoverTextColor": "#000000",
+          "profileMenuTextHighlightColor": "#455469",
+          "secondaryColor": "#69788b",
+          "switchBackgroundColor": "#c0c9d5",
+          "textColor": "#ffffff",
+          "topBarBackgroundColor": "#ffffff",
+          "topBarBorderColor": "#e7eef4",
+          "topBarHeaderColor": "#23282e",
+          "topBarTextColor": "#69788b",
+        },
       ],
-      "logo": "https://cdn.forgerock.com/platform/themes/contrast/logo-contrast.svg",
-      "logoAltText": "Contrast",
-      "logoEnabled": false,
-      "logoHeight": "72",
-      "logoProfile": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
-      "logoProfileAltText": "Contrast",
-      "logoProfileCollapsed": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
-      "logoProfileCollapsedAltText": "",
-      "logoProfileCollapsedHeight": "22",
-      "logoProfileHeight": "22",
-      "name": "NoAccess",
-      "pageTitle": "#23282e",
-      "primaryColor": "#000000",
-      "primaryOffColor": "#000000",
-      "profileBackgroundColor": "#FFFFFF",
-      "profileMenuHighlightColor": "#FFFFFF",
-      "profileMenuHoverColor": "#FFFFFF",
-      "profileMenuHoverTextColor": "#000000",
-      "profileMenuTextHighlightColor": "#455469",
-      "secondaryColor": "#69788b",
-      "switchBackgroundColor": "#c0c9d5",
-      "textColor": "#ffffff",
-      "topBarBackgroundColor": "#ffffff",
-      "topBarBorderColor": "#e7eef4",
-      "topBarHeaderColor": "#23282e",
-      "topBarTextColor": "#69788b",
-    },
-  ],
-  "tree": {
-    "_id": "FrodoTest",
-    "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
-    "enabled": true,
-    "entryNodeId": "e2c39477-847a-4df2-9c5d-b449a752638b",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "278bf084-9eea-46fe-8ce9-2600dde3b046": {
-        "connections": {
-          "localAuthentication": "fc7e47cd-c679-4211-8e05-a36654f23c67",
-          "socialAuthentication": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
+      "tree": {
+        "_id": "FrodoTest",
+        "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
+        "enabled": true,
+        "entryNodeId": "e2c39477-847a-4df2-9c5d-b449a752638b",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "278bf084-9eea-46fe-8ce9-2600dde3b046": {
+            "connections": {
+              "localAuthentication": "fc7e47cd-c679-4211-8e05-a36654f23c67",
+              "socialAuthentication": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+            "x": 444,
+            "y": 273.015625,
+          },
+          "64157fca-bd5b-4405-a4c8-64ffd98a5461": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "SAML2 Authentication",
+            "nodeType": "product-Saml2Node",
+            "x": 1196,
+            "y": 188.015625,
+          },
+          "731c5810-020b-45c8-a7fc-3c21903ae2b3": {
+            "connections": {
+              "localAuthentication": "fc7e47cd-c679-4211-8e05-a36654f23c67",
+              "socialAuthentication": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+            "x": 443,
+            "y": 26.015625,
+          },
+          "bf153f37-83dd-4f39-aa0c-74135430242e": {
+            "connections": {
+              "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "EMAIL_SENT": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
+            },
+            "displayName": "Email Template Node",
+            "nodeType": "EmailTemplateNode",
+            "x": 967,
+            "y": 222.015625,
+          },
+          "d5cc2d52-6ce4-452d-85ea-3a5b50218b67": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "bf153f37-83dd-4f39-aa0c-74135430242e",
+            },
+            "displayName": "Social Login",
+            "nodeType": "SocialProviderHandlerNode",
+            "x": 702,
+            "y": 116.015625,
+          },
+          "e2c39477-847a-4df2-9c5d-b449a752638b": {
+            "connections": {
+              "known": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
+              "unknown": "278bf084-9eea-46fe-8ce9-2600dde3b046",
+            },
+            "displayName": "Check Username",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 200,
+            "y": 235.015625,
+          },
+          "fc7e47cd-c679-4211-8e05-a36654f23c67": {
+            "connections": {
+              "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Validate Creds",
+            "nodeType": "IdentityStoreDecisionNode",
+            "x": 702,
+            "y": 292.015625,
+          },
         },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-        "x": 444,
-        "y": 273.015625,
-      },
-      "64157fca-bd5b-4405-a4c8-64ffd98a5461": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1434,
+            "y": 60,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1433,
+            "y": 459,
+          },
+          "startNode": {
+            "x": 63,
+            "y": 252,
+          },
         },
-        "displayName": "SAML2 Authentication",
-        "nodeType": "product-Saml2Node",
-        "x": 1196,
-        "y": 188.015625,
-      },
-      "731c5810-020b-45c8-a7fc-3c21903ae2b3": {
-        "connections": {
-          "localAuthentication": "fc7e47cd-c679-4211-8e05-a36654f23c67",
-          "socialAuthentication": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
+        "uiConfig": {
+          "categories": "["Frodo","Prototype"]",
         },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-        "x": 443,
-        "y": 26.015625,
       },
-      "bf153f37-83dd-4f39-aa0c-74135430242e": {
-        "connections": {
-          "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "EMAIL_SENT": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
-        },
-        "displayName": "Email Template Node",
-        "nodeType": "EmailTemplateNode",
-        "x": 967,
-        "y": 222.015625,
-      },
-      "d5cc2d52-6ce4-452d-85ea-3a5b50218b67": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "bf153f37-83dd-4f39-aa0c-74135430242e",
-        },
-        "displayName": "Social Login",
-        "nodeType": "SocialProviderHandlerNode",
-        "x": 702,
-        "y": 116.015625,
-      },
-      "e2c39477-847a-4df2-9c5d-b449a752638b": {
-        "connections": {
-          "known": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
-          "unknown": "278bf084-9eea-46fe-8ce9-2600dde3b046",
-        },
-        "displayName": "Check Username",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 200,
-        "y": 235.015625,
-      },
-      "fc7e47cd-c679-4211-8e05-a36654f23c67": {
-        "connections": {
-          "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-        },
-        "displayName": "Validate Creds",
-        "nodeType": "IdentityStoreDecisionNode",
-        "x": 702,
-        "y": 292.015625,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1434,
-        "y": 60,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1433,
-        "y": 459,
-      },
-      "startNode": {
-        "x": 63,
-        "y": 252,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Frodo","Prototype"]",
     },
   },
 }
@@ -7109,207 +7157,211 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/ForgottenUsername.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {
-    "forgottenUsername": {
-      "_id": "emailTemplate/forgottenUsername",
-      "defaultLocale": "en",
-      "enabled": true,
-      "from": "",
-      "html": {
-        "en": "<html><body>{{#if object.userName}}<p>Your username is '{{object.userName}}'.</p>{{else}}If you received this email in error, please disregard.{{/if}}<p><a href="{{object.resumeURI}}">Click here to login</a></p></body></html>",
-        "fr": "<html><body>{{#if object.userName}}<p>Votre nom d'utilisateur est '{{object.userName}}'.</p>{{else}}Si vous avez reçu cet e-mail par erreur, veuillez ne pas en tenir compte.{{/if}}<p><a href="{{object.resumeURI}}">Cliquez ici pour vous connecter</a></p></body></html>",
-      },
-      "message": {
-        "en": "<html><head></head><body style="background-color: #324054; color: #455469; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>{{#if object.userName}}Your username is '{{object.userName}}'.</p><p>{{else}}If you received this email in error, please disregard.{{/if}}</p><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Click here to login</a></p></div></body></html>",
-        "fr": "<html><head></head><body style="background-color: #324054; color: #455469; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;">{{#if object.userName}}<p>Votre nom d'utilisateur est '{{object.userName}}'.</p>{{else}}Si vous avez reçu cet e-mail par erreur, veuillez ne pas en tenir compte.{{/if}}<p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Cliquez ici pour vous connecter</a></p></div></body></html>",
-      },
-      "mimeType": "text/html",
-      "styles": "body{background-color:#324054;color:#5e6d82;padding:60px;text-align:center}a{text-decoration:none;color:#109cf1}.content{background-color:#fff;border-radius:4px;margin:0 auto;padding:48px;width:235px}",
-      "subject": {
-        "en": "Account Information - username",
-        "fr": "Informations sur le compte - nom d'utilisateur",
-      },
-    },
-  },
-  "innerNodes": {
-    "9f1e8d94-4922-481b-9e14-212b66548900": {
-      "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+  "trees": {
+    "ForgottenUsername": {
+      "circlesOfTrust": {},
+      "emailTemplates": {
+        "forgottenUsername": {
+          "_id": "emailTemplate/forgottenUsername",
+          "defaultLocale": "en",
+          "enabled": true,
+          "from": "",
+          "html": {
+            "en": "<html><body>{{#if object.userName}}<p>Your username is '{{object.userName}}'.</p>{{else}}If you received this email in error, please disregard.{{/if}}<p><a href="{{object.resumeURI}}">Click here to login</a></p></body></html>",
+            "fr": "<html><body>{{#if object.userName}}<p>Votre nom d'utilisateur est '{{object.userName}}'.</p>{{else}}Si vous avez reçu cet e-mail par erreur, veuillez ne pas en tenir compte.{{/if}}<p><a href="{{object.resumeURI}}">Cliquez ici pour vous connecter</a></p></body></html>",
+          },
+          "message": {
+            "en": "<html><head></head><body style="background-color: #324054; color: #455469; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>{{#if object.userName}}Your username is '{{object.userName}}'.</p><p>{{else}}If you received this email in error, please disregard.{{/if}}</p><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Click here to login</a></p></div></body></html>",
+            "fr": "<html><head></head><body style="background-color: #324054; color: #455469; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;">{{#if object.userName}}<p>Votre nom d'utilisateur est '{{object.userName}}'.</p>{{else}}Si vous avez reçu cet e-mail par erreur, veuillez ne pas en tenir compte.{{/if}}<p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Cliquez ici pour vous connecter</a></p></div></body></html>",
+          },
+          "mimeType": "text/html",
+          "styles": "body{background-color:#324054;color:#5e6d82;padding:60px;text-align:center}a{text-decoration:none;color:#109cf1}.content{background-color:#fff;border-radius:4px;margin:0 auto;padding:48px;width:235px}",
+          "subject": {
+            "en": "Account Information - username",
+            "fr": "Informations sur le compte - nom d'utilisateur",
+          },
         },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
       },
-      "attributesToCollect": [
-        "mail",
-      ],
-      "identityAttribute": "mail",
-      "required": true,
-      "validateInputs": false,
-    },
-  },
-  "nodes": {
-    "5e2a7c95-94af-4b23-8724-deb13853726a": {
-      "_id": "5e2a7c95-94af-4b23-8724-deb13853726a",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+      "innerNodes": {
+        "9f1e8d94-4922-481b-9e14-212b66548900": {
           "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "mail",
+          ],
+          "identityAttribute": "mail",
+          "required": true,
+          "validateInputs": false,
         },
-      ],
-      "pageDescription": {
-        "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
       },
-      "pageHeader": {
-        "en": "Forgotten Username",
-      },
-    },
-    "b93ce36e-1976-4610-b24f-8d6760b5463b": {
-      "_id": "b93ce36e-1976-4610-b24f-8d6760b5463b",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "nodes": {
+        "5e2a7c95-94af-4b23-8724-deb13853726a": {
+          "_id": "5e2a7c95-94af-4b23-8724-deb13853726a",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
+          },
+          "pageHeader": {
+            "en": "Forgotten Username",
+          },
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "b93ce36e-1976-4610-b24f-8d6760b5463b": {
+          "_id": "b93ce36e-1976-4610-b24f-8d6760b5463b",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "Login",
         },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
-      },
-      "tree": "Login",
-    },
-    "bf9ea8d5-9802-4f26-9664-a21840faac23": {
-      "_id": "bf9ea8d5-9802-4f26-9664-a21840faac23",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+        "bf9ea8d5-9802-4f26-9664-a21840faac23": {
+          "_id": "bf9ea8d5-9802-4f26-9664-a21840faac23",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "IdentifyExistingUserNode",
+            "collection": true,
+            "name": "Identify Existing User",
+          },
+          "identifier": "userName",
+          "identityAttribute": "mail",
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca": {
+          "_id": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "forgottenUsername",
+          "identityAttribute": "mail",
+          "objectLookup": true,
         },
-      ],
-      "_type": {
-        "_id": "IdentifyExistingUserNode",
-        "collection": true,
-        "name": "Identify Existing User",
       },
-      "identifier": "userName",
-      "identityAttribute": "mail",
-    },
-    "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca": {
-      "_id": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "ForgottenUsername",
+        "description": "Forgotten Username Tree",
+        "enabled": true,
+        "entryNodeId": "5e2a7c95-94af-4b23-8724-deb13853726a",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "5e2a7c95-94af-4b23-8724-deb13853726a": {
+            "connections": {
+              "outcome": "bf9ea8d5-9802-4f26-9664-a21840faac23",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 139,
+            "y": 146,
+          },
+          "b93ce36e-1976-4610-b24f-8d6760b5463b": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Inner Tree Evaluator",
+            "nodeType": "InnerTreeEvaluatorNode",
+            "x": 767,
+            "y": 188,
+          },
+          "bf9ea8d5-9802-4f26-9664-a21840faac23": {
+            "connections": {
+              "false": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
+              "true": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
+            },
+            "displayName": "Identify Existing User",
+            "nodeType": "IdentifyExistingUserNode",
+            "x": 324,
+            "y": 152,
+          },
+          "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca": {
+            "connections": {
+              "outcome": "b93ce36e-1976-4610-b24f-8d6760b5463b",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+            "x": 563,
+            "y": 193,
+          },
         },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
-      },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "forgottenUsername",
-      "identityAttribute": "mail",
-      "objectLookup": true,
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "ForgottenUsername",
-    "description": "Forgotten Username Tree",
-    "enabled": true,
-    "entryNodeId": "5e2a7c95-94af-4b23-8724-deb13853726a",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "5e2a7c95-94af-4b23-8724-deb13853726a": {
-        "connections": {
-          "outcome": "bf9ea8d5-9802-4f26-9664-a21840faac23",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 970,
+            "y": 149,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 982,
+            "y": 252,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 25,
+          },
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 139,
-        "y": 146,
-      },
-      "b93ce36e-1976-4610-b24f-8d6760b5463b": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "uiConfig": {
+          "categories": "["Username Reset"]",
         },
-        "displayName": "Inner Tree Evaluator",
-        "nodeType": "InnerTreeEvaluatorNode",
-        "x": 767,
-        "y": 188,
       },
-      "bf9ea8d5-9802-4f26-9664-a21840faac23": {
-        "connections": {
-          "false": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
-          "true": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
-        },
-        "displayName": "Identify Existing User",
-        "nodeType": "IdentifyExistingUserNode",
-        "x": 324,
-        "y": 152,
-      },
-      "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca": {
-        "connections": {
-          "outcome": "b93ce36e-1976-4610-b24f-8d6760b5463b",
-        },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-        "x": 563,
-        "y": 193,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 970,
-        "y": 149,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 982,
-        "y": 252,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 25,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Username Reset"]",
     },
   },
 }
@@ -7317,52 +7369,54 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/FrodoTest.journey.json 1`] = `
 {
-  "circlesOfTrust": {
-    "2f04818d-561e-4f8a-82e8-af2426112138": {
-      "_id": "2f04818d-561e-4f8a-82e8-af2426112138",
-      "_type": {
-        "_id": "circlesoftrust",
-        "collection": true,
-        "name": "Circle of Trust",
+  "trees": {
+    "FrodoTest": {
+      "circlesOfTrust": {
+        "2f04818d-561e-4f8a-82e8-af2426112138": {
+          "_id": "2f04818d-561e-4f8a-82e8-af2426112138",
+          "_type": {
+            "_id": "circlesoftrust",
+            "collection": true,
+            "name": "Circle of Trust",
+          },
+          "status": "active",
+          "trustedProviders": [
+            "benefits-IDP|saml2",
+            "iSPAzure|saml2",
+          ],
+        },
+        "AzureCOT": {
+          "_id": "AzureCOT",
+          "_type": {
+            "_id": "circlesoftrust",
+            "collection": true,
+            "name": "Circle of Trust",
+          },
+          "status": "active",
+          "trustedProviders": [
+            "iSPAzure|saml2",
+            "urn:federation:MicrosoftOnline|saml2",
+            "https://sts.windows.net/711ffa9c-5972-4713-ace3-688c9732614a/|saml2",
+            "SPAzure|saml2",
+            "https://idc.scheuber.io/am/saml2/IDPAzure|saml2",
+          ],
+        },
       },
-      "status": "active",
-      "trustedProviders": [
-        "benefits-IDP|saml2",
-        "iSPAzure|saml2",
-      ],
-    },
-    "AzureCOT": {
-      "_id": "AzureCOT",
-      "_type": {
-        "_id": "circlesoftrust",
-        "collection": true,
-        "name": "Circle of Trust",
-      },
-      "status": "active",
-      "trustedProviders": [
-        "iSPAzure|saml2",
-        "urn:federation:MicrosoftOnline|saml2",
-        "https://sts.windows.net/711ffa9c-5972-4713-ace3-688c9732614a/|saml2",
-        "SPAzure|saml2",
-        "https://idc.scheuber.io/am/saml2/IDPAzure|saml2",
-      ],
-    },
-  },
-  "emailTemplates": {
-    "welcome": {
-      "_id": "emailTemplate/welcome",
-      "defaultLocale": "en",
-      "displayName": "Welcome",
-      "enabled": true,
-      "from": "saas@forgerock.com",
-      "html": {
-        "en": "<div class="content"><p>Welcome. Your username is '{{object.userName}}'.</p></div>",
-      },
-      "message": {
-        "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>Welcome. Your username is '{{object.userName}}'.</p></div></body></html>",
-      },
-      "mimeType": "text/html",
-      "styles": "body{
+      "emailTemplates": {
+        "welcome": {
+          "_id": "emailTemplate/welcome",
+          "defaultLocale": "en",
+          "displayName": "Welcome",
+          "enabled": true,
+          "from": "saas@forgerock.com",
+          "html": {
+            "en": "<div class="content"><p>Welcome. Your username is '{{object.userName}}'.</p></div>",
+          },
+          "message": {
+            "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>Welcome. Your username is '{{object.userName}}'.</p></div></body></html>",
+          },
+          "mimeType": "text/html",
+          "styles": "body{
  background-color:#324054;
  color:#5e6d82;
  padding:60px;
@@ -7380,1257 +7434,1259 @@ a{
  width:235px
 }
 ",
-      "subject": {
-        "en": "Your account has been created",
+          "subject": {
+            "en": "Your account has been created",
+          },
+        },
       },
-    },
-  },
-  "innerNodes": {
-    "051c1939-7dd5-4cf1-866e-48f57541b6ac": {
-      "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "28595125-e97a-40e7-aa3c-bebdb6821949": {
-      "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4": {
-      "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "ac343c95-8873-410e-823b-0931a71fc0c7": {
-      "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "fe762924-bc07-4f50-9234-17ab245efff1": {
-      "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": false,
-    },
-  },
-  "nodes": {
-    "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
-      "_id": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "SocialProviderHandlerNode",
-        "collection": true,
-        "name": "Social Provider Handler Node",
-      },
-      "clientType": "BROWSER",
-      "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
-      "usernameAttribute": "userName",
-    },
-    "4951364c-59be-42cd-9cd7-79c9392214db": {
-      "_id": "4951364c-59be-42cd-9cd7-79c9392214db",
-      "_outcomes": [
-        {
-          "displayName": "known",
-          "id": "known",
-        },
-        {
-          "displayName": "unknown",
-          "id": "unknown",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "known",
-        "unknown",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "739bdc48-fd24-4c52-b353-88706d75558a",
-    },
-    "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
-      "_id": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "TRUE",
-        },
-        {
-          "displayName": "False",
-          "id": "FALSE",
-        },
-        {
-          "displayName": "Locked",
-          "id": "LOCKED",
-        },
-        {
-          "displayName": "Cancelled",
-          "id": "CANCELLED",
-        },
-        {
-          "displayName": "Expired",
-          "id": "EXPIRED",
-        },
-      ],
-      "_type": {
-        "_id": "IdentityStoreDecisionNode",
-        "collection": true,
-        "name": "Identity Store Decision",
-      },
-      "minimumPasswordLength": 8,
-      "mixedCaseForPasswordChangeMessages": false,
-      "useUniversalIdForUsername": true,
-    },
-    "650203c3-47f7-439d-a554-669cb7b08c57": {
-      "_id": "650203c3-47f7-439d-a554-669cb7b08c57",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "product-Saml2Node",
-        "collection": true,
-        "name": "SAML2 Authentication",
-      },
-      "allowCreate": true,
-      "authComparison": "MINIMUM",
-      "authnContextClassRef": [],
-      "authnContextDeclRef": [],
-      "binding": "HTTP_ARTIFACT",
-      "forceAuthn": false,
-      "idpEntityId": "urn:federation:MicrosoftOnline",
-      "isPassive": false,
-      "metaAlias": "/alpha/iSPAzure",
-      "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-      "requestBinding": "HTTP_REDIRECT",
-    },
-    "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
-      "_id": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
-          "displayName": "Username",
-          "nodeType": "ValidatedUsernameNode",
-        },
-        {
+      "innerNodes": {
+        "051c1939-7dd5-4cf1-866e-48f57541b6ac": {
           "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-        {
+        "28595125-e97a-40e7-aa3c-bebdb6821949": {
           "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
-      "_id": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
-        },
-        {
+        "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4": {
           "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "c859d258-79c1-4448-bd52-12e4e414af92": {
-      "_id": "c859d258-79c1-4448-bd52-12e4e414af92",
-      "_outcomes": [
-        {
-          "displayName": "Email Sent",
-          "id": "EMAIL_SENT",
+        "ac343c95-8873-410e-823b-0931a71fc0c7": {
+          "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-        {
-          "displayName": "Email Not Sent",
-          "id": "EMAIL_NOT_SENT",
+        "fe762924-bc07-4f50-9234-17ab245efff1": {
+          "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": false,
         },
-      ],
-      "_type": {
-        "_id": "EmailTemplateNode",
-        "collection": true,
-        "name": "Email Template Node",
       },
-      "emailAttribute": "mail",
-      "emailTemplateName": "welcome",
-      "identityAttribute": "userName",
-    },
-  },
-  "saml2Entities": {
-    "aVNQQXp1cmU": {
-      "_id": "aVNQQXp1cmU",
-      "entityId": "iSPAzure",
-      "entityLocation": "hosted",
-      "serviceProvider": {
-        "advanced": {
-          "ecpConfiguration": {
-            "ecpRequestIdpListFinderImpl": "com.sun.identity.saml2.plugins.ECPIDPFinder",
+      "nodes": {
+        "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
+          "_id": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "SocialProviderHandlerNode",
+            "collection": true,
+            "name": "Social Provider Handler Node",
           },
-          "idpProxy": {},
-          "relayStateUrlList": {},
-          "saeConfiguration": {
-            "spUrl": "https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure",
-          },
+          "clientType": "BROWSER",
+          "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
+          "usernameAttribute": "userName",
         },
-        "assertionContent": {
-          "assertionTimeSkew": 300,
-          "authenticationContext": {
-            "authContextItems": [
-              {
-                "contextReference": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
-                "defaultItem": true,
-                "level": 0,
-              },
-            ],
-            "authenticationComparisonType": "Exact",
-            "authenticationContextMapper": "com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper",
-            "includeRequestedAuthenticationContext": true,
+        "4951364c-59be-42cd-9cd7-79c9392214db": {
+          "_id": "4951364c-59be-42cd-9cd7-79c9392214db",
+          "_outcomes": [
+            {
+              "displayName": "known",
+              "id": "known",
+            },
+            {
+              "displayName": "unknown",
+              "id": "unknown",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
           },
-          "basicAuthentication": {},
-          "nameIdFormat": {
-            "nameIdFormatList": [
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
-            ],
-          },
-          "signingAndEncryption": {
-            "encryption": {},
-            "requestResponseSigning": {},
-            "secretIdAndAlgorithms": {},
-          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "known",
+            "unknown",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "739bdc48-fd24-4c52-b353-88706d75558a",
         },
-        "assertionProcessing": {
-          "accountMapping": {
-            "spAccountMapper": "com.sun.identity.saml2.plugins.DefaultSPAccountMapper",
-            "useNameIDAsSPUserID": true,
+        "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
+          "_id": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "TRUE",
+            },
+            {
+              "displayName": "False",
+              "id": "FALSE",
+            },
+            {
+              "displayName": "Locked",
+              "id": "LOCKED",
+            },
+            {
+              "displayName": "Cancelled",
+              "id": "CANCELLED",
+            },
+            {
+              "displayName": "Expired",
+              "id": "EXPIRED",
+            },
+          ],
+          "_type": {
+            "_id": "IdentityStoreDecisionNode",
+            "collection": true,
+            "name": "Identity Store Decision",
           },
-          "adapter": {
-            "spAdapterScript": "07ee6240-d106-4e25-a781-5fcabc477d22",
-          },
-          "attributeMapper": {
-            "attributeMap": [
-              {
-                "key": "http://schemas.microsoft.com/identity/claims/displayname",
-                "value": "cn",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-                "value": "givenName",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-                "value": "sn",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-                "value": "mail",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
-                "value": "uid",
-              },
-            ],
-            "attributeMapper": "com.sun.identity.saml2.plugins.DefaultSPAttributeMapper",
-          },
-          "autoFederation": {
-            "autoFedEnabled": false,
-          },
-          "responseArtifactMessageEncoding": {
-            "encoding": "URI",
-          },
-          "url": {},
+          "minimumPasswordLength": 8,
+          "mixedCaseForPasswordChangeMessages": false,
+          "useUniversalIdForUsername": true,
         },
-        "services": {
+        "650203c3-47f7-439d-a554-669cb7b08c57": {
+          "_id": "650203c3-47f7-439d-a554-669cb7b08c57",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "product-Saml2Node",
+            "collection": true,
+            "name": "SAML2 Authentication",
+          },
+          "allowCreate": true,
+          "authComparison": "MINIMUM",
+          "authnContextClassRef": [],
+          "authnContextDeclRef": [],
+          "binding": "HTTP_ARTIFACT",
+          "forceAuthn": false,
+          "idpEntityId": "urn:federation:MicrosoftOnline",
+          "isPassive": false,
           "metaAlias": "/alpha/iSPAzure",
-          "serviceAttributes": {
-            "assertionConsumerService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-                "index": 0,
-                "isDefault": true,
-                "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "index": 1,
-                "isDefault": false,
-                "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-                "index": 2,
-                "isDefault": false,
-                "location": "https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure",
-              },
-            ],
-            "nameIdService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                "location": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-                "location": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
-              },
-            ],
-            "singleLogoutService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                "location": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-                "location": "https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure",
-              },
-            ],
-          },
+          "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+          "requestBinding": "HTTP_REDIRECT",
         },
-      },
-    },
-    "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l": {
-      "_id": "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l",
-      "base64EntityXML": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI_Pgo8RW50aXR5RGVzY3JpcHRvciBlbnRpdHlJRD0idXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5lIiBJRD0iX2U0NmExMTkzLWU4YTctNDhlZC04MDRmLTE1MTY3MjllY2I1ZiIgeG1sbnM9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDptZXRhZGF0YSIgeG1sbnM6cXVlcnk9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOm1ldGFkYXRhOmV4dDpxdWVyeSIgeG1sbnM6bWRhdHRyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphdHRyaWJ1dGUiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIHhtbG5zOnhlbmM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jIyIgeG1sbnM6eGVuYzExPSJodHRwOi8vd3d3LnczLm9yZy8yMDA5L3htbGVuYzExIyIgeG1sbnM6YWxnPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphbGdzdXBwb3J0IiB4bWxuczp4NTA5cXJ5PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTpYNTA5OnF1ZXJ5IiB4bWxuczpkcz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI-CiAgICA8RXh0ZW5zaW9ucz4KICAgICAgICA8YWxnOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNzaGExIi8-CiAgICAgICAgPGFsZzpTaWduaW5nTWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI3JzYS1zaGExIi8-CiAgICA8L0V4dGVuc2lvbnM-CiAgICA8U1BTU09EZXNjcmlwdG9yIFdhbnRBc3NlcnRpb25zU2lnbmVkPSJ0cnVlIiBwcm90b2NvbFN1cHBvcnRFbnVtZXJhdGlvbj0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIDxkczpYNTA5RGF0YT4KICAgICAgICAgICAgICAgICAgICA8ZHM6WDUwOUNlcnRpZmljYXRlPgpNSUlDL1RDQ0FlV2dBd0lCQWdJUWJnREhmaTN0MUpOR1Zxd0Q1LzdsbWpBTkJna3Foa2lHOXcwQkFRc0ZBREFwTVNjd0pRWURWUVFECkV4NU1hWFpsSUVsRUlGTlVVeUJUYVdkdWFXNW5JRkIxWW14cFl5QkxaWGt3SGhjTk1qQXhNakl4TURBd01EQXdXaGNOTWpVeE1qSXgKTURBd01EQXdXakFwTVNjd0pRWURWUVFERXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dnZ0VpTUEwRwpDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREZUMC8wLzJxUXVybllhMExiSkhGOVlZb3poRUg2cjltQ3hWREJZYmV3ClNHNHRHZ3JXcHNld1EvOTZwY2N6R01RY3RNdlUraDJlWDM4SHgvZjlKQUlEYnVSUXpRbHNQaFFTN0REWjZXbFRYVSt0OGQvZzJDN2YKcFNvTHM0S1ZkSmloNHh5akxVV2orQksvaWpzUmpCdDRSaXc5VmJKSC9EZFdLeW9TTWJFQ0VpRStzMVJ0TFAvZVlvTW1OZnh5UUdxVwppckNOcVZOQlRscXpZUXA0ZGdGMGZvWXk0a3RveHdtUU9Wb1RjSU1GWXAxSTRwRlBJN0N4dU1Ma2ZLMFg3YVRiTTdZR3Bodk1mSnhKCmtqclFkeUk3RzVkMXQ0RE5pM3prRWJCVDdGR0FyNnFQdDNLbjlyYWxwcUpLSGRwRUJBOU4wdk53UW81WFRZSWhVYlBRMTZJUkFnTUIKQUFHaklUQWZNQjBHQTFVZERnUVdCQlJzN3RQbWZra3NTcjY3S3RFbEhqWVpiZWFDVGpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpKcXdNWlNqUUozNngrMXN0eTZFZUxLUUxRZXdRd1BhRUM0N1p1dCs4YlhlZDZROGpNWjBiZmEvTU03WHF1RWNhYmFNWkxRdUtMZnQ0CjRZWHdYWFFPZlFySTJxalFyM2VUb0pGbERUOWhSMHJmcDl3UXF0dER4ZDZBYTZSV3dEVGdvNW9LVVFDVEtMSGhFeTh1V3pTY0swZUcKdDJkN1RXVGFEWGpSU3dOcTZ0TTdmUmhaczA3dEtCVjN4Zmk5RVF5L21sYXZBTUZSQlZtODZOU283QXNPRzFJT01xMDNVM29vQ1dBWApoOVBkdnZITmZIaEgxOWZ1dEFuQy9IZU9qd1JGMVFjNTI3YUJNcGhZRlFMZGlUaGZtZm1pRS9BaFFxQ3daMm9FN3VDSmhCdFIrS2IxClpHaGpJMzVwSGZzU3FHaUZhN0tyKzVhdmU4MjJQRGNrZTg5TXZnPT0KICAgICAgICAgICAgICAgICAgICA8L2RzOlg1MDlDZXJ0aWZpY2F0ZT4KICAgICAgICAgICAgICAgIDwvZHM6WDUwOURhdGE-CiAgICAgICAgICAgIDwvZHM6S2V5SW5mbz4KICAgICAgICA8L0tleURlc2NyaXB0b3I-CiAgICAgICAgPEtleURlc2NyaXB0b3IgdXNlPSJzaWduaW5nIj4KICAgICAgICAgICAgPGRzOktleUluZm8-CiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICA8ZHM6WDUwOURhdGE-CiAgICAgICAgICAgICAgICAgICAgPGRzOlg1MDlDZXJ0aWZpY2F0ZT4KTUlJQy9UQ0NBZVdnQXdJQkFnSVFOL0dQZWduVDhibFAyRWNTZE1NYkJ6QU5CZ2txaGtpRzl3MEJBUXNGQURBcE1TY3dKUVlEVlFRRApFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd0hoY05NakV3TWpFNE1EQXdNREF3V2hjTk1qWXdNakU0Ck1EQXdNREF3V2pBcE1TY3dKUVlEVlFRREV4NU1hWFpsSUVsRUlGTlVVeUJUYVdkdWFXNW5JRkIxWW14cFl5QkxaWGt3Z2dFaU1BMEcKQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURYZExHVTJMbDVSUGREVW5LUStmL0hTNXFpVGF5MmNDaDlVMkFTNm9ETQo2U094VmhZR3RvZUoxVlBlYmNMbnBnTGZoUHh6cndXb1Z6WFNFRitWUlFibllJRDJKYjRraGpneUVlb1RoazNWcXJUaHdoYWhwU2JCCmcydm8wNnZJT3AxVFMyUjFCaXdIS1RMb0IxaTFJSm5hSUZTQzNCTjZwWTRmbFhXeUxRdC81QUJYRWx2MlhaTHFYTTlFZWZqNkppNDAKbkxJc2lXNGRXdzNCRGEveXdXVzBNc2lXNW9qR3E0dm92Y0FnRU5lLzROVWJqdTcwZ0hQL1dTNUQ5Ylc1cCtPSVFpNy91bnJsV2UvaAozQTZqdEJiYlJsWFlYbE4rWjIydVRUeXlDRC9XOHplWGFBQ0x2SGFnd0VNclFlUERYQlpxYy9pWDJrSStvb1pyMXNDL0gzOVJBZ01CCkFBR2pJVEFmTUIwR0ExVWREZ1FXQkJTclgyZG0zTHdUOWpiL3ArYkFBZFlRcEUrL05qQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZXFKZllIbnNBOXFoR3R0WEZmRnBQVzREUUxoNXc2SkNjZTd2R3ZXSU5yNWZyMURuUWRjT3Ird3dqUS90cWJja0FMMnY2ejFBcWpoUwo3OGtiZmVnbkFRRHdpb0paMW9sWVl2TE94S29hNkhGK2IxL3AwTWx1YjhadWtrMm4xYjJsS1BCQk9pYk9hc1NZN2dRRHdsSVppN3RsCjluTVR4VWZkWUsrRTVBeHY3RFZubVVDd2NubnBWNS8xU0ZkTnlXMmtXTzRDNjhycmpNT3ZFQ2Z3cktrYmZWSk04ZjlrckVVQnVvQkYKOGRURHY3RDJaTTRRMmJ1QzcwTmJmYU5XVVgweUZ2S0kwSXVUcWs4UkJmR1RSUTRmWkFiaE1QYXlrRXBCdTZkTmpUaTVZT2EwbE5xRgpHUzdBeDdsZUNoNXg5bFY4ZWxjTGtYczh5U284QU9RSmswaGdJdz09CiAgICAgICAgICAgICAgICAgICAgPC9kczpYNTA5Q2VydGlmaWNhdGU-CiAgICAgICAgICAgICAgICA8L2RzOlg1MDlEYXRhPgogICAgICAgICAgICA8L2RzOktleUluZm8-CiAgICAgICAgPC9LZXlEZXNjcmlwdG9yPgogICAgICAgIDxLZXlEZXNjcmlwdG9yIHVzZT0ic2lnbmluZyI-CiAgICAgICAgICAgIDxkczpLZXlJbmZvPgogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRTi9HUGVnblQ4YmxQMkVjU2RNTWJCekFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpFd01qRTRNREF3TURBd1doY05Nall3TWpFNApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEWGRMR1UyTGw1UlBkRFVuS1ErZi9IUzVxaVRheTJjQ2g5VTJBUzZvRE0KNlNPeFZoWUd0b2VKMVZQZWJjTG5wZ0xmaFB4enJ3V29WelhTRUYrVlJRYm5ZSUQySmI0a2hqZ3lFZW9UaGszVnFyVGh3aGFocFNiQgpnMnZvMDZ2SU9wMVRTMlIxQml3SEtUTG9CMWkxSUpuYUlGU0MzQk42cFk0ZmxYV3lMUXQvNUFCWEVsdjJYWkxxWE05RWVmajZKaTQwCm5MSXNpVzRkV3czQkRhL3l3V1cwTXNpVzVvakdxNHZvdmNBZ0VOZS80TlVianU3MGdIUC9XUzVEOWJXNXArT0lRaTcvdW5ybFdlL2gKM0E2anRCYmJSbFhZWGxOK1oyMnVUVHl5Q0QvVzh6ZVhhQUNMdkhhZ3dFTXJRZVBEWEJacWMvaVgya0krb29acjFzQy9IMzlSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCU3JYMmRtM0x3VDlqYi9wK2JBQWRZUXBFKy9OakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCmVxSmZZSG5zQTlxaEd0dFhGZkZwUFc0RFFMaDV3NkpDY2U3dkd2V0lOcjVmcjFEblFkY09yK3d3alEvdHFiY2tBTDJ2NnoxQXFqaFMKNzhrYmZlZ25BUUR3aW9KWjFvbFlZdkxPeEtvYTZIRitiMS9wME1sdWI4WnVrazJuMWIybEtQQkJPaWJPYXNTWTdnUUR3bElaaTd0bAo5bk1UeFVmZFlLK0U1QXh2N0RWbm1VQ3djbm5wVjUvMVNGZE55VzJrV080QzY4cnJqTU92RUNmd3JLa2JmVkpNOGY5a3JFVUJ1b0JGCjhkVER2N0QyWk00UTJidUM3ME5iZmFOV1VYMHlGdktJMEl1VHFrOFJCZkdUUlE0ZlpBYmhNUGF5a0VwQnU2ZE5qVGk1WU9hMGxOcUYKR1M3QXg3bGVDaDV4OWxWOGVsY0xrWHM4eVNvOEFPUUprMGhnSXc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8U2luZ2xlTG9nb3V0U2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NUIiBMb2NhdGlvbj0iaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2xvZ2luLnNyZiIvPgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6ZW1haWxBZGRyZXNzPC9OYW1lSURGb3JtYXQ-CiAgICAgICAgPE5hbWVJREZvcm1hdD51cm46bWFjZTpzaGliYm9sZXRoOjEuMDpuYW1lSWRlbnRpZmllcjwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQ8L05hbWVJREZvcm1hdD4KICAgICAgICA8TmFtZUlERm9ybWF0PnVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpuYW1laWQtZm9ybWF0OnRyYW5zaWVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6cGVyc2lzdGVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxBc3NlcnRpb25Db25zdW1lclNlcnZpY2UgaW5kZXg9IjAiIGlzRGVmYXVsdD0idHJ1ZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vbG9naW4ubWljcm9zb2Z0b25saW5lLmNvbS9sb2dpbi5zcmYiLz4KICAgICAgICA8QXNzZXJ0aW9uQ29uc3VtZXJTZXJ2aWNlIGluZGV4PSIxIiBpc0RlZmF1bHQ9ImZhbHNlIiBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NULVNpbXBsZVNpZ24iIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICAgICAgPEFzc2VydGlvbkNvbnN1bWVyU2VydmljZSBpbmRleD0iMiIgaXNEZWZhdWx0PSJmYWxzZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOlBBT1MiIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICA8L1NQU1NPRGVzY3JpcHRvcj4KPC9FbnRpdHlEZXNjcmlwdG9yPgoK",
-      "entityId": "urn:federation:MicrosoftOnline",
-      "entityLocation": "remote",
-      "serviceProvider": {
-        "advanced": {
-          "idpProxy": {},
-          "saeConfiguration": {},
-        },
-        "assertionContent": {
-          "basicAuthentication": {},
-          "nameIdFormat": {
-            "nameIdFormatList": [
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-              "urn:mace:shibboleth:1.0:nameIdentifier",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-            ],
-          },
-          "signingAndEncryption": {
-            "encryption": {},
-            "requestResponseSigning": {
-              "assertion": true,
+        "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
+          "_id": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
             },
-            "secretIdAndAlgorithms": {},
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
+              "displayName": "Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
+        },
+        "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
+          "_id": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
+        },
+        "c859d258-79c1-4448-bd52-12e4e414af92": {
+          "_id": "c859d258-79c1-4448-bd52-12e4e414af92",
+          "_outcomes": [
+            {
+              "displayName": "Email Sent",
+              "id": "EMAIL_SENT",
+            },
+            {
+              "displayName": "Email Not Sent",
+              "id": "EMAIL_NOT_SENT",
+            },
+          ],
+          "_type": {
+            "_id": "EmailTemplateNode",
+            "collection": true,
+            "name": "Email Template Node",
+          },
+          "emailAttribute": "mail",
+          "emailTemplateName": "welcome",
+          "identityAttribute": "userName",
+        },
+      },
+      "saml2Entities": {
+        "aVNQQXp1cmU": {
+          "_id": "aVNQQXp1cmU",
+          "entityId": "iSPAzure",
+          "entityLocation": "hosted",
+          "serviceProvider": {
+            "advanced": {
+              "ecpConfiguration": {
+                "ecpRequestIdpListFinderImpl": "com.sun.identity.saml2.plugins.ECPIDPFinder",
+              },
+              "idpProxy": {},
+              "relayStateUrlList": {},
+              "saeConfiguration": {
+                "spUrl": "https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure",
+              },
+            },
+            "assertionContent": {
+              "assertionTimeSkew": 300,
+              "authenticationContext": {
+                "authContextItems": [
+                  {
+                    "contextReference": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+                    "defaultItem": true,
+                    "level": 0,
+                  },
+                ],
+                "authenticationComparisonType": "Exact",
+                "authenticationContextMapper": "com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper",
+                "includeRequestedAuthenticationContext": true,
+              },
+              "basicAuthentication": {},
+              "nameIdFormat": {
+                "nameIdFormatList": [
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
+                ],
+              },
+              "signingAndEncryption": {
+                "encryption": {},
+                "requestResponseSigning": {},
+                "secretIdAndAlgorithms": {},
+              },
+            },
+            "assertionProcessing": {
+              "accountMapping": {
+                "spAccountMapper": "com.sun.identity.saml2.plugins.DefaultSPAccountMapper",
+                "useNameIDAsSPUserID": true,
+              },
+              "adapter": {
+                "spAdapterScript": "07ee6240-d106-4e25-a781-5fcabc477d22",
+              },
+              "attributeMapper": {
+                "attributeMap": [
+                  {
+                    "key": "http://schemas.microsoft.com/identity/claims/displayname",
+                    "value": "cn",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+                    "value": "givenName",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+                    "value": "sn",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+                    "value": "mail",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+                    "value": "uid",
+                  },
+                ],
+                "attributeMapper": "com.sun.identity.saml2.plugins.DefaultSPAttributeMapper",
+              },
+              "autoFederation": {
+                "autoFedEnabled": false,
+              },
+              "responseArtifactMessageEncoding": {
+                "encoding": "URI",
+              },
+              "url": {},
+            },
+            "services": {
+              "metaAlias": "/alpha/iSPAzure",
+              "serviceAttributes": {
+                "assertionConsumerService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
+                    "index": 0,
+                    "isDefault": true,
+                    "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "index": 1,
+                    "isDefault": false,
+                    "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
+                    "index": 2,
+                    "isDefault": false,
+                    "location": "https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+                "nameIdService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "location": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+                    "location": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+                "singleLogoutService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "location": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+                    "location": "https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+              },
+            },
           },
         },
-        "assertionProcessing": {
-          "attributeMapper": {
-            "attributeMap": [
-              {
-                "binary": false,
-                "localAttribute": "mail",
-                "samlAttribute": "IDPEmail",
+        "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l": {
+          "_id": "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l",
+          "base64EntityXML": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI_Pgo8RW50aXR5RGVzY3JpcHRvciBlbnRpdHlJRD0idXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5lIiBJRD0iX2U0NmExMTkzLWU4YTctNDhlZC04MDRmLTE1MTY3MjllY2I1ZiIgeG1sbnM9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDptZXRhZGF0YSIgeG1sbnM6cXVlcnk9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOm1ldGFkYXRhOmV4dDpxdWVyeSIgeG1sbnM6bWRhdHRyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphdHRyaWJ1dGUiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIHhtbG5zOnhlbmM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jIyIgeG1sbnM6eGVuYzExPSJodHRwOi8vd3d3LnczLm9yZy8yMDA5L3htbGVuYzExIyIgeG1sbnM6YWxnPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphbGdzdXBwb3J0IiB4bWxuczp4NTA5cXJ5PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTpYNTA5OnF1ZXJ5IiB4bWxuczpkcz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI-CiAgICA8RXh0ZW5zaW9ucz4KICAgICAgICA8YWxnOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNzaGExIi8-CiAgICAgICAgPGFsZzpTaWduaW5nTWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI3JzYS1zaGExIi8-CiAgICA8L0V4dGVuc2lvbnM-CiAgICA8U1BTU09EZXNjcmlwdG9yIFdhbnRBc3NlcnRpb25zU2lnbmVkPSJ0cnVlIiBwcm90b2NvbFN1cHBvcnRFbnVtZXJhdGlvbj0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIDxkczpYNTA5RGF0YT4KICAgICAgICAgICAgICAgICAgICA8ZHM6WDUwOUNlcnRpZmljYXRlPgpNSUlDL1RDQ0FlV2dBd0lCQWdJUWJnREhmaTN0MUpOR1Zxd0Q1LzdsbWpBTkJna3Foa2lHOXcwQkFRc0ZBREFwTVNjd0pRWURWUVFECkV4NU1hWFpsSUVsRUlGTlVVeUJUYVdkdWFXNW5JRkIxWW14cFl5QkxaWGt3SGhjTk1qQXhNakl4TURBd01EQXdXaGNOTWpVeE1qSXgKTURBd01EQXdXakFwTVNjd0pRWURWUVFERXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dnZ0VpTUEwRwpDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRREZUMC8wLzJxUXVybllhMExiSkhGOVlZb3poRUg2cjltQ3hWREJZYmV3ClNHNHRHZ3JXcHNld1EvOTZwY2N6R01RY3RNdlUraDJlWDM4SHgvZjlKQUlEYnVSUXpRbHNQaFFTN0REWjZXbFRYVSt0OGQvZzJDN2YKcFNvTHM0S1ZkSmloNHh5akxVV2orQksvaWpzUmpCdDRSaXc5VmJKSC9EZFdLeW9TTWJFQ0VpRStzMVJ0TFAvZVlvTW1OZnh5UUdxVwppckNOcVZOQlRscXpZUXA0ZGdGMGZvWXk0a3RveHdtUU9Wb1RjSU1GWXAxSTRwRlBJN0N4dU1Ma2ZLMFg3YVRiTTdZR3Bodk1mSnhKCmtqclFkeUk3RzVkMXQ0RE5pM3prRWJCVDdGR0FyNnFQdDNLbjlyYWxwcUpLSGRwRUJBOU4wdk53UW81WFRZSWhVYlBRMTZJUkFnTUIKQUFHaklUQWZNQjBHQTFVZERnUVdCQlJzN3RQbWZra3NTcjY3S3RFbEhqWVpiZWFDVGpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQpKcXdNWlNqUUozNngrMXN0eTZFZUxLUUxRZXdRd1BhRUM0N1p1dCs4YlhlZDZROGpNWjBiZmEvTU03WHF1RWNhYmFNWkxRdUtMZnQ0CjRZWHdYWFFPZlFySTJxalFyM2VUb0pGbERUOWhSMHJmcDl3UXF0dER4ZDZBYTZSV3dEVGdvNW9LVVFDVEtMSGhFeTh1V3pTY0swZUcKdDJkN1RXVGFEWGpSU3dOcTZ0TTdmUmhaczA3dEtCVjN4Zmk5RVF5L21sYXZBTUZSQlZtODZOU283QXNPRzFJT01xMDNVM29vQ1dBWApoOVBkdnZITmZIaEgxOWZ1dEFuQy9IZU9qd1JGMVFjNTI3YUJNcGhZRlFMZGlUaGZtZm1pRS9BaFFxQ3daMm9FN3VDSmhCdFIrS2IxClpHaGpJMzVwSGZzU3FHaUZhN0tyKzVhdmU4MjJQRGNrZTg5TXZnPT0KICAgICAgICAgICAgICAgICAgICA8L2RzOlg1MDlDZXJ0aWZpY2F0ZT4KICAgICAgICAgICAgICAgIDwvZHM6WDUwOURhdGE-CiAgICAgICAgICAgIDwvZHM6S2V5SW5mbz4KICAgICAgICA8L0tleURlc2NyaXB0b3I-CiAgICAgICAgPEtleURlc2NyaXB0b3IgdXNlPSJzaWduaW5nIj4KICAgICAgICAgICAgPGRzOktleUluZm8-CiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICA8ZHM6WDUwOURhdGE-CiAgICAgICAgICAgICAgICAgICAgPGRzOlg1MDlDZXJ0aWZpY2F0ZT4KTUlJQy9UQ0NBZVdnQXdJQkFnSVFOL0dQZWduVDhibFAyRWNTZE1NYkJ6QU5CZ2txaGtpRzl3MEJBUXNGQURBcE1TY3dKUVlEVlFRRApFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd0hoY05NakV3TWpFNE1EQXdNREF3V2hjTk1qWXdNakU0Ck1EQXdNREF3V2pBcE1TY3dKUVlEVlFRREV4NU1hWFpsSUVsRUlGTlVVeUJUYVdkdWFXNW5JRkIxWW14cFl5QkxaWGt3Z2dFaU1BMEcKQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURYZExHVTJMbDVSUGREVW5LUStmL0hTNXFpVGF5MmNDaDlVMkFTNm9ETQo2U094VmhZR3RvZUoxVlBlYmNMbnBnTGZoUHh6cndXb1Z6WFNFRitWUlFibllJRDJKYjRraGpneUVlb1RoazNWcXJUaHdoYWhwU2JCCmcydm8wNnZJT3AxVFMyUjFCaXdIS1RMb0IxaTFJSm5hSUZTQzNCTjZwWTRmbFhXeUxRdC81QUJYRWx2MlhaTHFYTTlFZWZqNkppNDAKbkxJc2lXNGRXdzNCRGEveXdXVzBNc2lXNW9qR3E0dm92Y0FnRU5lLzROVWJqdTcwZ0hQL1dTNUQ5Ylc1cCtPSVFpNy91bnJsV2UvaAozQTZqdEJiYlJsWFlYbE4rWjIydVRUeXlDRC9XOHplWGFBQ0x2SGFnd0VNclFlUERYQlpxYy9pWDJrSStvb1pyMXNDL0gzOVJBZ01CCkFBR2pJVEFmTUIwR0ExVWREZ1FXQkJTclgyZG0zTHdUOWpiL3ArYkFBZFlRcEUrL05qQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZXFKZllIbnNBOXFoR3R0WEZmRnBQVzREUUxoNXc2SkNjZTd2R3ZXSU5yNWZyMURuUWRjT3Ird3dqUS90cWJja0FMMnY2ejFBcWpoUwo3OGtiZmVnbkFRRHdpb0paMW9sWVl2TE94S29hNkhGK2IxL3AwTWx1YjhadWtrMm4xYjJsS1BCQk9pYk9hc1NZN2dRRHdsSVppN3RsCjluTVR4VWZkWUsrRTVBeHY3RFZubVVDd2NubnBWNS8xU0ZkTnlXMmtXTzRDNjhycmpNT3ZFQ2Z3cktrYmZWSk04ZjlrckVVQnVvQkYKOGRURHY3RDJaTTRRMmJ1QzcwTmJmYU5XVVgweUZ2S0kwSXVUcWs4UkJmR1RSUTRmWkFiaE1QYXlrRXBCdTZkTmpUaTVZT2EwbE5xRgpHUzdBeDdsZUNoNXg5bFY4ZWxjTGtYczh5U284QU9RSmswaGdJdz09CiAgICAgICAgICAgICAgICAgICAgPC9kczpYNTA5Q2VydGlmaWNhdGU-CiAgICAgICAgICAgICAgICA8L2RzOlg1MDlEYXRhPgogICAgICAgICAgICA8L2RzOktleUluZm8-CiAgICAgICAgPC9LZXlEZXNjcmlwdG9yPgogICAgICAgIDxLZXlEZXNjcmlwdG9yIHVzZT0ic2lnbmluZyI-CiAgICAgICAgICAgIDxkczpLZXlJbmZvPgogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRTi9HUGVnblQ4YmxQMkVjU2RNTWJCekFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpFd01qRTRNREF3TURBd1doY05Nall3TWpFNApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEWGRMR1UyTGw1UlBkRFVuS1ErZi9IUzVxaVRheTJjQ2g5VTJBUzZvRE0KNlNPeFZoWUd0b2VKMVZQZWJjTG5wZ0xmaFB4enJ3V29WelhTRUYrVlJRYm5ZSUQySmI0a2hqZ3lFZW9UaGszVnFyVGh3aGFocFNiQgpnMnZvMDZ2SU9wMVRTMlIxQml3SEtUTG9CMWkxSUpuYUlGU0MzQk42cFk0ZmxYV3lMUXQvNUFCWEVsdjJYWkxxWE05RWVmajZKaTQwCm5MSXNpVzRkV3czQkRhL3l3V1cwTXNpVzVvakdxNHZvdmNBZ0VOZS80TlVianU3MGdIUC9XUzVEOWJXNXArT0lRaTcvdW5ybFdlL2gKM0E2anRCYmJSbFhZWGxOK1oyMnVUVHl5Q0QvVzh6ZVhhQUNMdkhhZ3dFTXJRZVBEWEJacWMvaVgya0krb29acjFzQy9IMzlSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCU3JYMmRtM0x3VDlqYi9wK2JBQWRZUXBFKy9OakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCmVxSmZZSG5zQTlxaEd0dFhGZkZwUFc0RFFMaDV3NkpDY2U3dkd2V0lOcjVmcjFEblFkY09yK3d3alEvdHFiY2tBTDJ2NnoxQXFqaFMKNzhrYmZlZ25BUUR3aW9KWjFvbFlZdkxPeEtvYTZIRitiMS9wME1sdWI4WnVrazJuMWIybEtQQkJPaWJPYXNTWTdnUUR3bElaaTd0bAo5bk1UeFVmZFlLK0U1QXh2N0RWbm1VQ3djbm5wVjUvMVNGZE55VzJrV080QzY4cnJqTU92RUNmd3JLa2JmVkpNOGY5a3JFVUJ1b0JGCjhkVER2N0QyWk00UTJidUM3ME5iZmFOV1VYMHlGdktJMEl1VHFrOFJCZkdUUlE0ZlpBYmhNUGF5a0VwQnU2ZE5qVGk1WU9hMGxOcUYKR1M3QXg3bGVDaDV4OWxWOGVsY0xrWHM4eVNvOEFPUUprMGhnSXc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8U2luZ2xlTG9nb3V0U2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NUIiBMb2NhdGlvbj0iaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2xvZ2luLnNyZiIvPgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6ZW1haWxBZGRyZXNzPC9OYW1lSURGb3JtYXQ-CiAgICAgICAgPE5hbWVJREZvcm1hdD51cm46bWFjZTpzaGliYm9sZXRoOjEuMDpuYW1lSWRlbnRpZmllcjwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQ8L05hbWVJREZvcm1hdD4KICAgICAgICA8TmFtZUlERm9ybWF0PnVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpuYW1laWQtZm9ybWF0OnRyYW5zaWVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6cGVyc2lzdGVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxBc3NlcnRpb25Db25zdW1lclNlcnZpY2UgaW5kZXg9IjAiIGlzRGVmYXVsdD0idHJ1ZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vbG9naW4ubWljcm9zb2Z0b25saW5lLmNvbS9sb2dpbi5zcmYiLz4KICAgICAgICA8QXNzZXJ0aW9uQ29uc3VtZXJTZXJ2aWNlIGluZGV4PSIxIiBpc0RlZmF1bHQ9ImZhbHNlIiBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NULVNpbXBsZVNpZ24iIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICAgICAgPEFzc2VydGlvbkNvbnN1bWVyU2VydmljZSBpbmRleD0iMiIgaXNEZWZhdWx0PSJmYWxzZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOlBBT1MiIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICA8L1NQU1NPRGVzY3JpcHRvcj4KPC9FbnRpdHlEZXNjcmlwdG9yPgoK",
+          "entityId": "urn:federation:MicrosoftOnline",
+          "entityLocation": "remote",
+          "serviceProvider": {
+            "advanced": {
+              "idpProxy": {},
+              "saeConfiguration": {},
+            },
+            "assertionContent": {
+              "basicAuthentication": {},
+              "nameIdFormat": {
+                "nameIdFormatList": [
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                  "urn:mace:shibboleth:1.0:nameIdentifier",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+                ],
               },
-              {
-                "binary": false,
-                "localAttribute": "UOPClassID",
-                "samlAttribute": "UOPClassID",
+              "signingAndEncryption": {
+                "encryption": {},
+                "requestResponseSigning": {
+                  "assertion": true,
+                },
+                "secretIdAndAlgorithms": {},
               },
-            ],
-          },
-          "responseArtifactMessageEncoding": {
-            "encoding": "URI",
+            },
+            "assertionProcessing": {
+              "attributeMapper": {
+                "attributeMap": [
+                  {
+                    "binary": false,
+                    "localAttribute": "mail",
+                    "samlAttribute": "IDPEmail",
+                  },
+                  {
+                    "binary": false,
+                    "localAttribute": "UOPClassID",
+                    "samlAttribute": "UOPClassID",
+                  },
+                ],
+              },
+              "responseArtifactMessageEncoding": {
+                "encoding": "URI",
+              },
+            },
+            "services": {
+              "serviceAttributes": {
+                "assertionConsumerService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "index": 0,
+                    "isDefault": true,
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
+                    "index": 1,
+                    "isDefault": false,
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
+                    "index": 2,
+                    "isDefault": false,
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                ],
+                "singleLogoutService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                ],
+              },
+            },
           },
         },
-        "services": {
-          "serviceAttributes": {
-            "assertionConsumerService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "index": 0,
-                "isDefault": true,
-                "location": "https://login.microsoftonline.com/login.srf",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
-                "index": 1,
-                "isDefault": false,
-                "location": "https://login.microsoftonline.com/login.srf",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-                "index": 2,
-                "isDefault": false,
-                "location": "https://login.microsoftonline.com/login.srf",
-              },
-            ],
-            "singleLogoutService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://login.microsoftonline.com/login.srf",
-              },
-            ],
+      },
+      "scripts": {
+        "23143919-6b78-40c3-b25e-beca19b229e0": {
+          "_id": "23143919-6b78-40c3-b25e-beca19b229e0",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from GitHub",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "GitHub Profile Normalization (VS)",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"GitHub rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
+        },
+        "484e6246-dbc6-4288-97e6-54e55431402e": {
+          "_id": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Apple",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Apple Profile Normalization",
+          "script": ""/*\\n * Copyright 2021-2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n *\\n * In some common default configurations, the following keys are required to be not empty:\\n * username, givenName, familyName, email.\\n *\\n * From RFC4517: A value of the Directory String syntax is a string of one or more\\n * arbitrary characters from the Universal Character Set (UCS).\\n * A zero-length character string is not permitted.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nString email = \\"change@me.com\\"\\nString subjectId = rawProfile.sub\\nString firstName = \\" \\"\\nString lastName = \\" \\"\\nString username = subjectId\\nString name\\n\\nif (rawProfile.isDefined(\\"email\\") && rawProfile.email.isNotNull()){ // User can elect to not share their email\\n    email = rawProfile.email.asString()\\n    username = email\\n}\\nif (rawProfile.isDefined(\\"name\\") && rawProfile.name.isNotNull()) {\\n    if (rawProfile.name.isDefined(\\"firstName\\") && rawProfile.name.firstName.isNotNull()) {\\n        firstName = rawProfile.name.firstName.asString()\\n    }\\n    if (rawProfile.name.isDefined(\\"lastName\\") && rawProfile.name.lastName.isNotNull()) {\\n        lastName = rawProfile.name.lastName.asString()\\n    }\\n}\\n\\nname = (firstName?.trim() ? firstName : \\"\\") + (lastName?.trim() ? ((firstName?.trim() ? \\" \\" : \\"\\") + lastName) : \\"\\")\\nname =  (!name?.trim()) ? \\" \\" : name\\n\\nreturn json(object(\\n        field(\\"id\\", subjectId),\\n        field(\\"displayName\\", name),\\n        field(\\"email\\", email),\\n        field(\\"givenName\\", firstName),\\n        field(\\"familyName\\", lastName),\\n        field(\\"username\\", username)))"",
+        },
+        "58c824ae-84ed-4724-82cd-db128fc3f6c": {
+          "_id": "58c824ae-84ed-4724-82cd-db128fc3f6c",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Converts a normalized social profile into a managed user",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Normalized Profile to Managed User",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nimport org.forgerock.json.JsonValue\\n\\nJsonValue managedUser = json(object(\\n        field(\\"givenName\\", normalizedProfile.givenName),\\n        field(\\"sn\\", normalizedProfile.familyName),\\n        field(\\"mail\\", normalizedProfile.email),\\n        field(\\"userName\\", normalizedProfile.username)))\\n\\nif (normalizedProfile.postalAddress.isNotNull()) managedUser.put(\\"postalAddress\\", normalizedProfile.postalAddress)\\nif (normalizedProfile.addressLocality.isNotNull()) managedUser.put(\\"city\\", normalizedProfile.addressLocality)\\nif (normalizedProfile.addressRegion.isNotNull()) managedUser.put(\\"stateProvince\\", normalizedProfile.addressRegion)\\nif (normalizedProfile.postalCode.isNotNull()) managedUser.put(\\"postalCode\\", normalizedProfile.postalCode)\\nif (normalizedProfile.country.isNotNull()) managedUser.put(\\"country\\", normalizedProfile.country)\\nif (normalizedProfile.phone.isNotNull()) managedUser.put(\\"telephoneNumber\\", normalizedProfile.phone)\\n\\n// if the givenName and familyName is null or empty\\n// then add a boolean flag to the shared state to indicate names are not present\\n// this could be used elsewhere\\n// for eg. this could be used in a scripted decision node to by-pass patching\\n// the user object with blank values when givenName  and familyName is not present\\nboolean noGivenName = normalizedProfile.givenName.isNull() || (!normalizedProfile.givenName.asString()?.trim())\\nboolean noFamilyName = normalizedProfile.familyName.isNull() || (!normalizedProfile.familyName.asString()?.trim())\\nsharedState.put(\\"nameEmptyOrNull\\", noGivenName && noFamilyName)\\n\\nreturn managedUser\\n"",
+        },
+        "58d29080-4563-480b-89bb-1e7719776a21": {
+          "_id": "58d29080-4563-480b-89bb-1e7719776a21",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Google",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Google Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.sub),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.given_name),\\n        field(\\"familyName\\", rawProfile.family_name),\\n        field(\\"photoUrl\\", rawProfile.picture),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email),\\n        field(\\"locale\\", rawProfile.locale)))"",
+        },
+        "6325cf19-a49b-471e-8d26-7e4df76df0e2": {
+          "_id": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from GitHub",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Okta Profile Normalization",
+          "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"Okta rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.preferred_username)))"",
+        },
+        "739bdc48-fd24-4c52-b353-88706d75558a": {
+          "_id": "739bdc48-fd24-4c52-b353-88706d75558a",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Check if username has already been collected.",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Check Username",
+          "script": ""/* Check Username\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Check if username has already been collected.\\n * Return \\"known\\" if yes, \\"unknown\\" otherwise.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - known\\n * - unknown\\n */\\n(function () {\\n    if (null != sharedState.get(\\"username\\")) {\\n        outcome = \\"known\\";\\n    }\\n    else {\\n        outcome = \\"unknown\\";\\n    }\\n}());"",
+        },
+        "73cecbfc-dad0-4395-be6a-6858ee3a80e5": {
+          "_id": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Microsoft",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Microsoft Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n{\\n    \\"@odata.context\\": \\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\\",\\n    \\"@odata.id\\": \\"https://graph.microsoft.com/v2/711ffa9c-5972-4713-ace3-688c9732614a/directoryObjects/7d7759e2-36d8-4e64-b173-3f890d7d46d6/Microsoft.DirectoryServices.User\\",\\n    \\"businessPhones\\": [\\n        \\"18014735451\\"\\n    ],\\n    \\"displayName\\": \\"Volker Scheuber\\",\\n    \\"givenName\\": \\"Volker\\",\\n    \\"jobTitle\\": null,\\n    \\"mail\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"mobilePhone\\": null,\\n    \\"officeLocation\\": null,\\n    \\"preferredLanguage\\": null,\\n    \\"surname\\": \\"Scheuber\\",\\n    \\"userPrincipalName\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"id\\": \\"7d7759e2-36d8-4e64-b173-3f890d7d46d6\\"\\n}\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.message(\\"Kauai Microsoft Profile Normalization: rawProfile={}\\", rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.displayName),\\n        field(\\"givenName\\", rawProfile.givenName),\\n        field(\\"familyName\\", rawProfile.surname),\\n        field(\\"email\\", rawProfile.userPrincipalName),\\n        field(\\"username\\", rawProfile.userPrincipalName),\\n        field(\\"groups\\", rawProfile.groups)))"",
+        },
+        "bae1d54a-e97d-4997-aa5d-c027f21af82c": {
+          "_id": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Facebook",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Facebook Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
+        },
+        "dbe0bf9a-72aa-49d5-8483-9db147985a47": {
+          "_id": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from ADFS",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "ADFS Profile Normalization (JS)",
+          "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n * This script returns the social identity profile information for the authenticating user\\n * in a standard form expected by the Social Provider Handler Node.\\n *\\n * Defined variables:\\n * rawProfile - The social identity provider profile information for the authenticating user.\\n *              JsonValue (1).\\n * logger - The debug logger instance:\\n *          https://backstage.forgerock.com/docs/am/7/scripting-guide/scripting-api-global-logger.html#scripting-api-global-logger.\\n * realm - String (primitive).\\n *         The name of the realm the user is authenticating to.\\n * requestHeaders - TreeMap (2).\\n *                  The object that provides methods for accessing headers in the login request:\\n *                  https://backstage.forgerock.com/docs/am/7/authentication-guide/scripting-api-node.html#scripting-api-node-requestHeaders.\\n * requestParameters - TreeMap (2).\\n *                     The object that contains the authentication request parameters.\\n * selectedIdp - String (primitive).\\n *               The social identity provider name. For example: google.\\n * sharedState - LinkedHashMap (3).\\n *               The object that holds the state of the authentication tree and allows data exchange between the stateless nodes:\\n *               https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n * transientState - LinkedHashMap (3).\\n *                  The object for storing sensitive information that must not leave the server unencrypted,\\n *                  and that may not need to persist between authentication requests during the authentication session:\\n *                  https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n *\\n * Return - a JsonValue (1).\\n *          The result of the last statement in the script is returned to the server.\\n *          Currently, the Immediately Invoked Function Expression (also known as Self-Executing Anonymous Function)\\n *          is the last (and only) statement in this script, and its return value will become the script result.\\n *          Do not use \\"return variable\\" statement outside of a function definition.\\n *\\n *          This script's last statement should result in a JsonValue (1) with the following keys:\\n *          {\\n *              {\\"displayName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"email\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"familyName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"givenName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"id\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"locale\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"photoUrl\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"username\\": \\"corresponding-social-identity-provider-value\\"}\\n *          }\\n *\\n *          The consumer of this data defines which keys are required and which are optional.\\n *          For example, the script associated with the Social Provider Handler Node and,\\n *          ultimately, the managed object created/updated with this data\\n *          will expect certain keys to be populated.\\n *          In some common default configurations, the following keys are required to be not empty:\\n *          username, givenName, familyName, email.\\n *\\n *          From RFC4517: A value of the Directory String syntax is a string of one or more\\n *          arbitrary characters from the Universal Character Set (UCS).\\n *          A zero-length character string is not permitted.\\n *\\n * (1) JsonValue - https://backstage.forgerock.com/docs/am/7/apidocs/org/forgerock/json/JsonValue.html.\\n * (2) TreeMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/TreeMap.html.\\n * (3) LinkedHashMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/LinkedHashMap.html.\\n */\\n\\n(function () {\\n    var frJava = JavaImporter(\\n        org.forgerock.json.JsonValue\\n    );\\n\\n    var normalizedProfileData = frJava.JsonValue.json(frJava.JsonValue.object());\\n  \\n  \\t//logger.message('Seguin rawProfile: '+rawProfile);\\n\\n    normalizedProfileData.put('id', rawProfile.get('sub').asString());\\n    normalizedProfileData.put('displayName', rawProfile.get('givenName').asString() + ' ' + rawProfile.get('sn').asString());\\n    normalizedProfileData.put('email', rawProfile.get('mail').asString());\\n    normalizedProfileData.put('givenName', rawProfile.get('givenName').asString());\\n    normalizedProfileData.put('familyName', rawProfile.get('sn').asString());\\n    normalizedProfileData.put('username', rawProfile.get('upn').asString());\\n    normalizedProfileData.put('roles', rawProfile.get('roles').asString());\\n  \\n  \\t//logger.message('Seguin normalizedProfileData: '+normalizedProfileData);\\n\\n    return normalizedProfileData;\\n}());"",
+        },
+      },
+      "socialIdentityProviders": {
+        "adfs": {
+          "_id": "adfs",
+          "_type": {
+            "_id": "oidcConfig",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OpenID Connect specification.",
           },
-        },
-      },
-    },
-  },
-  "scripts": {
-    "23143919-6b78-40c3-b25e-beca19b229e0": {
-      "_id": "23143919-6b78-40c3-b25e-beca19b229e0",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from GitHub",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "GitHub Profile Normalization (VS)",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"GitHub rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
-    },
-    "484e6246-dbc6-4288-97e6-54e55431402e": {
-      "_id": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Apple",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Apple Profile Normalization",
-      "script": ""/*\\n * Copyright 2021-2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n *\\n * In some common default configurations, the following keys are required to be not empty:\\n * username, givenName, familyName, email.\\n *\\n * From RFC4517: A value of the Directory String syntax is a string of one or more\\n * arbitrary characters from the Universal Character Set (UCS).\\n * A zero-length character string is not permitted.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nString email = \\"change@me.com\\"\\nString subjectId = rawProfile.sub\\nString firstName = \\" \\"\\nString lastName = \\" \\"\\nString username = subjectId\\nString name\\n\\nif (rawProfile.isDefined(\\"email\\") && rawProfile.email.isNotNull()){ // User can elect to not share their email\\n    email = rawProfile.email.asString()\\n    username = email\\n}\\nif (rawProfile.isDefined(\\"name\\") && rawProfile.name.isNotNull()) {\\n    if (rawProfile.name.isDefined(\\"firstName\\") && rawProfile.name.firstName.isNotNull()) {\\n        firstName = rawProfile.name.firstName.asString()\\n    }\\n    if (rawProfile.name.isDefined(\\"lastName\\") && rawProfile.name.lastName.isNotNull()) {\\n        lastName = rawProfile.name.lastName.asString()\\n    }\\n}\\n\\nname = (firstName?.trim() ? firstName : \\"\\") + (lastName?.trim() ? ((firstName?.trim() ? \\" \\" : \\"\\") + lastName) : \\"\\")\\nname =  (!name?.trim()) ? \\" \\" : name\\n\\nreturn json(object(\\n        field(\\"id\\", subjectId),\\n        field(\\"displayName\\", name),\\n        field(\\"email\\", email),\\n        field(\\"givenName\\", firstName),\\n        field(\\"familyName\\", lastName),\\n        field(\\"username\\", username)))"",
-    },
-    "58c824ae-84ed-4724-82cd-db128fc3f6c": {
-      "_id": "58c824ae-84ed-4724-82cd-db128fc3f6c",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Converts a normalized social profile into a managed user",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Normalized Profile to Managed User",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nimport org.forgerock.json.JsonValue\\n\\nJsonValue managedUser = json(object(\\n        field(\\"givenName\\", normalizedProfile.givenName),\\n        field(\\"sn\\", normalizedProfile.familyName),\\n        field(\\"mail\\", normalizedProfile.email),\\n        field(\\"userName\\", normalizedProfile.username)))\\n\\nif (normalizedProfile.postalAddress.isNotNull()) managedUser.put(\\"postalAddress\\", normalizedProfile.postalAddress)\\nif (normalizedProfile.addressLocality.isNotNull()) managedUser.put(\\"city\\", normalizedProfile.addressLocality)\\nif (normalizedProfile.addressRegion.isNotNull()) managedUser.put(\\"stateProvince\\", normalizedProfile.addressRegion)\\nif (normalizedProfile.postalCode.isNotNull()) managedUser.put(\\"postalCode\\", normalizedProfile.postalCode)\\nif (normalizedProfile.country.isNotNull()) managedUser.put(\\"country\\", normalizedProfile.country)\\nif (normalizedProfile.phone.isNotNull()) managedUser.put(\\"telephoneNumber\\", normalizedProfile.phone)\\n\\n// if the givenName and familyName is null or empty\\n// then add a boolean flag to the shared state to indicate names are not present\\n// this could be used elsewhere\\n// for eg. this could be used in a scripted decision node to by-pass patching\\n// the user object with blank values when givenName  and familyName is not present\\nboolean noGivenName = normalizedProfile.givenName.isNull() || (!normalizedProfile.givenName.asString()?.trim())\\nboolean noFamilyName = normalizedProfile.familyName.isNull() || (!normalizedProfile.familyName.asString()?.trim())\\nsharedState.put(\\"nameEmptyOrNull\\", noGivenName && noFamilyName)\\n\\nreturn managedUser\\n"",
-    },
-    "58d29080-4563-480b-89bb-1e7719776a21": {
-      "_id": "58d29080-4563-480b-89bb-1e7719776a21",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Google",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Google Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.sub),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.given_name),\\n        field(\\"familyName\\", rawProfile.family_name),\\n        field(\\"photoUrl\\", rawProfile.picture),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email),\\n        field(\\"locale\\", rawProfile.locale)))"",
-    },
-    "6325cf19-a49b-471e-8d26-7e4df76df0e2": {
-      "_id": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from GitHub",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Okta Profile Normalization",
-      "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"Okta rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.preferred_username)))"",
-    },
-    "739bdc48-fd24-4c52-b353-88706d75558a": {
-      "_id": "739bdc48-fd24-4c52-b353-88706d75558a",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Check if username has already been collected.",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Check Username",
-      "script": ""/* Check Username\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Check if username has already been collected.\\n * Return \\"known\\" if yes, \\"unknown\\" otherwise.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - known\\n * - unknown\\n */\\n(function () {\\n    if (null != sharedState.get(\\"username\\")) {\\n        outcome = \\"known\\";\\n    }\\n    else {\\n        outcome = \\"unknown\\";\\n    }\\n}());"",
-    },
-    "73cecbfc-dad0-4395-be6a-6858ee3a80e5": {
-      "_id": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Microsoft",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Microsoft Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n{\\n    \\"@odata.context\\": \\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\\",\\n    \\"@odata.id\\": \\"https://graph.microsoft.com/v2/711ffa9c-5972-4713-ace3-688c9732614a/directoryObjects/7d7759e2-36d8-4e64-b173-3f890d7d46d6/Microsoft.DirectoryServices.User\\",\\n    \\"businessPhones\\": [\\n        \\"18014735451\\"\\n    ],\\n    \\"displayName\\": \\"Volker Scheuber\\",\\n    \\"givenName\\": \\"Volker\\",\\n    \\"jobTitle\\": null,\\n    \\"mail\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"mobilePhone\\": null,\\n    \\"officeLocation\\": null,\\n    \\"preferredLanguage\\": null,\\n    \\"surname\\": \\"Scheuber\\",\\n    \\"userPrincipalName\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"id\\": \\"7d7759e2-36d8-4e64-b173-3f890d7d46d6\\"\\n}\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.message(\\"Kauai Microsoft Profile Normalization: rawProfile={}\\", rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.displayName),\\n        field(\\"givenName\\", rawProfile.givenName),\\n        field(\\"familyName\\", rawProfile.surname),\\n        field(\\"email\\", rawProfile.userPrincipalName),\\n        field(\\"username\\", rawProfile.userPrincipalName),\\n        field(\\"groups\\", rawProfile.groups)))"",
-    },
-    "bae1d54a-e97d-4997-aa5d-c027f21af82c": {
-      "_id": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Facebook",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Facebook Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
-    },
-    "dbe0bf9a-72aa-49d5-8483-9db147985a47": {
-      "_id": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from ADFS",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "ADFS Profile Normalization (JS)",
-      "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n * This script returns the social identity profile information for the authenticating user\\n * in a standard form expected by the Social Provider Handler Node.\\n *\\n * Defined variables:\\n * rawProfile - The social identity provider profile information for the authenticating user.\\n *              JsonValue (1).\\n * logger - The debug logger instance:\\n *          https://backstage.forgerock.com/docs/am/7/scripting-guide/scripting-api-global-logger.html#scripting-api-global-logger.\\n * realm - String (primitive).\\n *         The name of the realm the user is authenticating to.\\n * requestHeaders - TreeMap (2).\\n *                  The object that provides methods for accessing headers in the login request:\\n *                  https://backstage.forgerock.com/docs/am/7/authentication-guide/scripting-api-node.html#scripting-api-node-requestHeaders.\\n * requestParameters - TreeMap (2).\\n *                     The object that contains the authentication request parameters.\\n * selectedIdp - String (primitive).\\n *               The social identity provider name. For example: google.\\n * sharedState - LinkedHashMap (3).\\n *               The object that holds the state of the authentication tree and allows data exchange between the stateless nodes:\\n *               https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n * transientState - LinkedHashMap (3).\\n *                  The object for storing sensitive information that must not leave the server unencrypted,\\n *                  and that may not need to persist between authentication requests during the authentication session:\\n *                  https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n *\\n * Return - a JsonValue (1).\\n *          The result of the last statement in the script is returned to the server.\\n *          Currently, the Immediately Invoked Function Expression (also known as Self-Executing Anonymous Function)\\n *          is the last (and only) statement in this script, and its return value will become the script result.\\n *          Do not use \\"return variable\\" statement outside of a function definition.\\n *\\n *          This script's last statement should result in a JsonValue (1) with the following keys:\\n *          {\\n *              {\\"displayName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"email\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"familyName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"givenName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"id\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"locale\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"photoUrl\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"username\\": \\"corresponding-social-identity-provider-value\\"}\\n *          }\\n *\\n *          The consumer of this data defines which keys are required and which are optional.\\n *          For example, the script associated with the Social Provider Handler Node and,\\n *          ultimately, the managed object created/updated with this data\\n *          will expect certain keys to be populated.\\n *          In some common default configurations, the following keys are required to be not empty:\\n *          username, givenName, familyName, email.\\n *\\n *          From RFC4517: A value of the Directory String syntax is a string of one or more\\n *          arbitrary characters from the Universal Character Set (UCS).\\n *          A zero-length character string is not permitted.\\n *\\n * (1) JsonValue - https://backstage.forgerock.com/docs/am/7/apidocs/org/forgerock/json/JsonValue.html.\\n * (2) TreeMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/TreeMap.html.\\n * (3) LinkedHashMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/LinkedHashMap.html.\\n */\\n\\n(function () {\\n    var frJava = JavaImporter(\\n        org.forgerock.json.JsonValue\\n    );\\n\\n    var normalizedProfileData = frJava.JsonValue.json(frJava.JsonValue.object());\\n  \\n  \\t//logger.message('Seguin rawProfile: '+rawProfile);\\n\\n    normalizedProfileData.put('id', rawProfile.get('sub').asString());\\n    normalizedProfileData.put('displayName', rawProfile.get('givenName').asString() + ' ' + rawProfile.get('sn').asString());\\n    normalizedProfileData.put('email', rawProfile.get('mail').asString());\\n    normalizedProfileData.put('givenName', rawProfile.get('givenName').asString());\\n    normalizedProfileData.put('familyName', rawProfile.get('sn').asString());\\n    normalizedProfileData.put('username', rawProfile.get('upn').asString());\\n    normalizedProfileData.put('roles', rawProfile.get('roles').asString());\\n  \\n  \\t//logger.message('Seguin normalizedProfileData: '+normalizedProfileData);\\n\\n    return normalizedProfileData;\\n}());"",
-    },
-  },
-  "socialIdentityProviders": {
-    "adfs": {
-      "_id": "adfs",
-      "_type": {
-        "_id": "oidcConfig",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OpenID Connect specification.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "aa9a179e-cdba-4db8-8477-3d1069d5ec04",
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://adfs.mytestrun.com/adfs",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://adfs.mytestrun.com/adfs/discovery/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "RS256",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/token",
-      "transform": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonDisplayName": "Microsoft ADFS",
-        "buttonImage": "/login/images/microsoft-logo.png",
-        "iconBackground": "#0078d7",
-        "iconClass": "fa-windows",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://adfs.mytestrun.com/adfs/.well-known/openid-configuration",
-    },
-    "apple-stoyan": {
-      "_id": "apple-stoyan",
-      "_type": {
-        "_id": "appleConfig",
-        "collection": true,
-        "name": "Client configuration for Apple.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "CHANGE ME",
-      "enableNativeNonce": true,
-      "enabled": false,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://appleid.apple.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectAfterFormPostURI": "https://openam-volker-dev.forgeblocks.com/login",
-      "redirectURI": "https://openam-volker-dev.forgeblocks.com/am/oauth2/alpha/client/form_post/apple-stoyan",
-      "requestNativeAppForUserInfo": false,
-      "responseMode": "FORM_POST",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "name",
-        "email",
-      ],
-      "tokenEndpoint": "https://appleid.apple.com/auth/token",
-      "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonDisplayName": "Apple",
-        "buttonImage": "/login/images/apple-logo.png",
-        "iconBackground": "#000000",
-        "iconClass": "fa-apple",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
-    },
-    "apple_web": {
-      "_id": "apple_web",
-      "_type": {
-        "_id": "appleConfig",
-        "collection": true,
-        "name": "Client configuration for Apple.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "io.scheuber.idc.signinWithApple.service",
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://appleid.apple.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectAfterFormPostURI": "https://idc.scheuber.io/login",
-      "redirectURI": "https://idc.scheuber.io/am/oauth2/client/form_post/apple_web",
-      "requestNativeAppForUserInfo": false,
-      "responseMode": "FORM_POST",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "name",
-        "email",
-      ],
-      "tokenEndpoint": "https://appleid.apple.com/auth/token",
-      "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonDisplayName": "Apple",
-        "buttonImage": "/login/images/apple-logo.png",
-        "iconBackground": "#000000",
-        "iconClass": "fa-apple",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
-    },
-    "azure": {
-      "_id": "azure",
-      "_type": {
-        "_id": "microsoftConfig",
-        "collection": true,
-        "name": "Client configuration for Microsoft.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "c42a3dc8-f276-496b-a722-269f131cc21c",
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "User.Read",
-        "openid",
-      ],
-      "tokenEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/token",
-      "transform": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonDisplayName": "Microsoft Azure",
-        "buttonImage": "/login/images/microsoft-logo.png",
-        "iconBackground": "#0078d7",
-        "iconClass": "fa-windows",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://graph.microsoft.com/v1.0/me",
-    },
-    "facebook": {
-      "_id": "facebook",
-      "_type": {
-        "_id": "oauth2Config",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OAuth2 specification.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://www.facebook.com/dialog/oauth",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "123741918345526",
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 3600,
-      "redirectURI": "https://idc.scheuber.io/am/XUI/?realm=%2Falpha",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "email",
-      ],
-      "tokenEndpoint": "https://graph.facebook.com/v2.7/oauth/access_token",
-      "transform": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
-      "uiConfig": {
-        "buttonClass": "fa-facebook-official",
-        "buttonCustomStyle": "background-color: #3b5998; border-color: #3b5998; color: white;",
-        "buttonCustomStyleHover": "background-color: #334b7d; border-color: #334b7d; color: white;",
-        "buttonDisplayName": "Facebook",
-        "buttonImage": "",
-        "iconBackground": "#3b5998",
-        "iconClass": "fa-facebook",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://graph.facebook.com/me?fields=id,name,picture,email,first_name,last_name,locale",
-    },
-    "github": {
-      "_id": "github",
-      "_type": {
-        "_id": "oauth2Config",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OAuth2 specification.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://github.com/login/oauth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "bdae6d141d4dcf95a630",
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "user",
-      ],
-      "tokenEndpoint": "https://ig.mytestrun.com/login/oauth/access_token",
-      "transform": "23143919-6b78-40c3-b25e-beca19b229e0",
-      "uiConfig": {
-        "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
-        "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
-        "buttonDisplayName": "GitHub",
-        "buttonImage": "https://cdn-icons-png.flaticon.com/512/25/25231.png",
-        "iconBackground": "#4184f3",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://ig.mytestrun.com/user",
-    },
-    "google": {
-      "_id": "google",
-      "_type": {
-        "_id": "googleConfig",
-        "collection": true,
-        "name": "Client configuration for Google.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "297338177925-mho17cgnm540s2gre8h27feb6sbs1msd.apps.googleusercontent.com",
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://accounts.google.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://www.googleapis.com/oauth2/v4/token",
-      "transform": "58d29080-4563-480b-89bb-1e7719776a21",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
-        "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
-        "buttonDisplayName": "Google",
-        "buttonImage": "images/g-logo.png",
-        "iconBackground": "#4184f3",
-        "iconClass": "fa-google",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://www.googleapis.com/oauth2/v3/userinfo",
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://accounts.google.com/.well-known/openid-configuration",
-    },
-    "okta-trial-5735851": {
-      "_id": "okta-trial-5735851",
-      "_type": {
-        "_id": "oidcConfig",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OpenID Connect specification.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://trial-5735851.okta.com/oauth2/v1/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "0oa13r2cp29Rynmyw697",
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://trial-5735851.okta.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://trial-5735851.okta.com/oauth2/v1/token",
-      "transform": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
-      "uiConfig": {
-        "buttonDisplayName": "Okta",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://trial-5735851.okta.com/oauth2/v1/userinfo",
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://trial-5735851.okta.com/.well-known/openid-configuration",
-    },
-  },
-  "themes": [
-    {
-      "_id": "63e19668-909f-479e-83d7-be7a01cd8187",
-      "accountCardBackgroundColor": "#ffffff",
-      "accountCardHeaderColor": "#23282e",
-      "accountCardInnerBorderColor": "#e7eef4",
-      "accountCardInputBackgroundColor": "#ffffff",
-      "accountCardInputBorderColor": "#c0c9d5",
-      "accountCardInputLabelColor": "#5e6d82",
-      "accountCardInputSelectColor": "#e4f4fd",
-      "accountCardInputTextColor": "#23282e",
-      "accountCardOuterBorderColor": "#e7eef4",
-      "accountCardShadow": 3,
-      "accountCardTabActiveBorderColor": "#109cf1",
-      "accountCardTabActiveColor": "#e4f4fd",
-      "accountCardTextColor": "#5e6d82",
-      "accountFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
-<a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
-      "accountFooterEnabled": false,
-      "accountNavigationBackgroundColor": "#ffffff",
-      "accountNavigationTextColor": "#455469",
-      "accountNavigationToggleBorderColor": "#e7eef4",
-      "accountPageSections": {
-        "accountControls": {
-          "enabled": false,
-        },
-        "accountSecurity": {
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "aa9a179e-cdba-4db8-8477-3d1069d5ec04",
+          "enableNativeNonce": true,
           "enabled": true,
-          "subsections": {
-            "password": {
-              "enabled": true,
-            },
-            "securityQuestions": {
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://adfs.mytestrun.com/adfs",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://adfs.mytestrun.com/adfs/discovery/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "RS256",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/token",
+          "transform": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonDisplayName": "Microsoft ADFS",
+            "buttonImage": "/login/images/microsoft-logo.png",
+            "iconBackground": "#0078d7",
+            "iconClass": "fa-windows",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://adfs.mytestrun.com/adfs/.well-known/openid-configuration",
+        },
+        "apple-stoyan": {
+          "_id": "apple-stoyan",
+          "_type": {
+            "_id": "appleConfig",
+            "collection": true,
+            "name": "Client configuration for Apple.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "CHANGE ME",
+          "enableNativeNonce": true,
+          "enabled": false,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://appleid.apple.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectAfterFormPostURI": "https://openam-volker-dev.forgeblocks.com/login",
+          "redirectURI": "https://openam-volker-dev.forgeblocks.com/am/oauth2/alpha/client/form_post/apple-stoyan",
+          "requestNativeAppForUserInfo": false,
+          "responseMode": "FORM_POST",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "name",
+            "email",
+          ],
+          "tokenEndpoint": "https://appleid.apple.com/auth/token",
+          "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonDisplayName": "Apple",
+            "buttonImage": "/login/images/apple-logo.png",
+            "iconBackground": "#000000",
+            "iconClass": "fa-apple",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
+        },
+        "apple_web": {
+          "_id": "apple_web",
+          "_type": {
+            "_id": "appleConfig",
+            "collection": true,
+            "name": "Client configuration for Apple.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "io.scheuber.idc.signinWithApple.service",
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://appleid.apple.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectAfterFormPostURI": "https://idc.scheuber.io/login",
+          "redirectURI": "https://idc.scheuber.io/am/oauth2/client/form_post/apple_web",
+          "requestNativeAppForUserInfo": false,
+          "responseMode": "FORM_POST",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "name",
+            "email",
+          ],
+          "tokenEndpoint": "https://appleid.apple.com/auth/token",
+          "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonDisplayName": "Apple",
+            "buttonImage": "/login/images/apple-logo.png",
+            "iconBackground": "#000000",
+            "iconClass": "fa-apple",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
+        },
+        "azure": {
+          "_id": "azure",
+          "_type": {
+            "_id": "microsoftConfig",
+            "collection": true,
+            "name": "Client configuration for Microsoft.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "c42a3dc8-f276-496b-a722-269f131cc21c",
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "User.Read",
+            "openid",
+          ],
+          "tokenEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/token",
+          "transform": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonDisplayName": "Microsoft Azure",
+            "buttonImage": "/login/images/microsoft-logo.png",
+            "iconBackground": "#0078d7",
+            "iconClass": "fa-windows",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://graph.microsoft.com/v1.0/me",
+        },
+        "facebook": {
+          "_id": "facebook",
+          "_type": {
+            "_id": "oauth2Config",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OAuth2 specification.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://www.facebook.com/dialog/oauth",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "123741918345526",
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 3600,
+          "redirectURI": "https://idc.scheuber.io/am/XUI/?realm=%2Falpha",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "email",
+          ],
+          "tokenEndpoint": "https://graph.facebook.com/v2.7/oauth/access_token",
+          "transform": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
+          "uiConfig": {
+            "buttonClass": "fa-facebook-official",
+            "buttonCustomStyle": "background-color: #3b5998; border-color: #3b5998; color: white;",
+            "buttonCustomStyleHover": "background-color: #334b7d; border-color: #334b7d; color: white;",
+            "buttonDisplayName": "Facebook",
+            "buttonImage": "",
+            "iconBackground": "#3b5998",
+            "iconClass": "fa-facebook",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://graph.facebook.com/me?fields=id,name,picture,email,first_name,last_name,locale",
+        },
+        "github": {
+          "_id": "github",
+          "_type": {
+            "_id": "oauth2Config",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OAuth2 specification.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://github.com/login/oauth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "bdae6d141d4dcf95a630",
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "user",
+          ],
+          "tokenEndpoint": "https://ig.mytestrun.com/login/oauth/access_token",
+          "transform": "23143919-6b78-40c3-b25e-beca19b229e0",
+          "uiConfig": {
+            "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
+            "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
+            "buttonDisplayName": "GitHub",
+            "buttonImage": "https://cdn-icons-png.flaticon.com/512/25/25231.png",
+            "iconBackground": "#4184f3",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://ig.mytestrun.com/user",
+        },
+        "google": {
+          "_id": "google",
+          "_type": {
+            "_id": "googleConfig",
+            "collection": true,
+            "name": "Client configuration for Google.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "297338177925-mho17cgnm540s2gre8h27feb6sbs1msd.apps.googleusercontent.com",
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://accounts.google.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://www.googleapis.com/oauth2/v4/token",
+          "transform": "58d29080-4563-480b-89bb-1e7719776a21",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
+            "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
+            "buttonDisplayName": "Google",
+            "buttonImage": "images/g-logo.png",
+            "iconBackground": "#4184f3",
+            "iconClass": "fa-google",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://www.googleapis.com/oauth2/v3/userinfo",
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://accounts.google.com/.well-known/openid-configuration",
+        },
+        "okta-trial-5735851": {
+          "_id": "okta-trial-5735851",
+          "_type": {
+            "_id": "oidcConfig",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OpenID Connect specification.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://trial-5735851.okta.com/oauth2/v1/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "0oa13r2cp29Rynmyw697",
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://trial-5735851.okta.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://trial-5735851.okta.com/oauth2/v1/token",
+          "transform": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
+          "uiConfig": {
+            "buttonDisplayName": "Okta",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://trial-5735851.okta.com/oauth2/v1/userinfo",
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://trial-5735851.okta.com/.well-known/openid-configuration",
+        },
+      },
+      "themes": [
+        {
+          "_id": "63e19668-909f-479e-83d7-be7a01cd8187",
+          "accountCardBackgroundColor": "#ffffff",
+          "accountCardHeaderColor": "#23282e",
+          "accountCardInnerBorderColor": "#e7eef4",
+          "accountCardInputBackgroundColor": "#ffffff",
+          "accountCardInputBorderColor": "#c0c9d5",
+          "accountCardInputLabelColor": "#5e6d82",
+          "accountCardInputSelectColor": "#e4f4fd",
+          "accountCardInputTextColor": "#23282e",
+          "accountCardOuterBorderColor": "#e7eef4",
+          "accountCardShadow": 3,
+          "accountCardTabActiveBorderColor": "#109cf1",
+          "accountCardTabActiveColor": "#e4f4fd",
+          "accountCardTextColor": "#5e6d82",
+          "accountFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
+<a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
+          "accountFooterEnabled": false,
+          "accountNavigationBackgroundColor": "#ffffff",
+          "accountNavigationTextColor": "#455469",
+          "accountNavigationToggleBorderColor": "#e7eef4",
+          "accountPageSections": {
+            "accountControls": {
               "enabled": false,
             },
-            "twoStepVerification": {
+            "accountSecurity": {
+              "enabled": true,
+              "subsections": {
+                "password": {
+                  "enabled": true,
+                },
+                "securityQuestions": {
+                  "enabled": false,
+                },
+                "twoStepVerification": {
+                  "enabled": true,
+                },
+                "username": {
+                  "enabled": true,
+                },
+              },
+            },
+            "consent": {
+              "enabled": false,
+            },
+            "oauthApplications": {
+              "enabled": false,
+            },
+            "personalInformation": {
               "enabled": true,
             },
-            "username": {
+            "preferences": {
+              "enabled": true,
+            },
+            "social": {
+              "enabled": false,
+            },
+            "trustedDevices": {
               "enabled": true,
             },
           },
-        },
-        "consent": {
-          "enabled": false,
-        },
-        "oauthApplications": {
-          "enabled": false,
-        },
-        "personalInformation": {
-          "enabled": true,
-        },
-        "preferences": {
-          "enabled": true,
-        },
-        "social": {
-          "enabled": false,
-        },
-        "trustedDevices": {
-          "enabled": true,
-        },
-      },
-      "accountTableRowHoverColor": "#f6f8fa",
-      "backgroundColor": "#FFFFFF",
-      "backgroundImage": "",
-      "bodyText": "#000000",
-      "boldLinks": false,
-      "buttonRounded": "0",
-      "dangerColor": "#f7685b",
-      "favicon": "",
-      "fontFamily": "Open Sans",
-      "isDefault": false,
-      "journeyCardBackgroundColor": "#ffffff",
-      "journeyCardShadow": 3,
-      "journeyCardTextColor": "#5e6d82",
-      "journeyCardTitleColor": "#23282e",
-      "journeyFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
+          "accountTableRowHoverColor": "#f6f8fa",
+          "backgroundColor": "#FFFFFF",
+          "backgroundImage": "",
+          "bodyText": "#000000",
+          "boldLinks": false,
+          "buttonRounded": "0",
+          "dangerColor": "#f7685b",
+          "favicon": "",
+          "fontFamily": "Open Sans",
+          "isDefault": false,
+          "journeyCardBackgroundColor": "#ffffff",
+          "journeyCardShadow": 3,
+          "journeyCardTextColor": "#5e6d82",
+          "journeyCardTitleColor": "#23282e",
+          "journeyFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
 <a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
-      "journeyFooterEnabled": false,
-      "journeyHeader": "<div class="d-flex justify-content-center py-4 flex-grow-1">Header Content</div>",
-      "journeyHeaderEnabled": false,
-      "journeyInputBackgroundColor": "#ffffff",
-      "journeyInputBorderColor": "#c0c9d5",
-      "journeyInputLabelColor": "#5e6d82",
-      "journeyInputSelectColor": "#e4f4fd",
-      "journeyInputTextColor": "#23282e",
-      "journeyJustifiedContent": "",
-      "journeyJustifiedContentEnabled": false,
-      "journeyLayout": "card",
-      "journeyTheaterMode": false,
-      "linkActiveColor": "#000000",
-      "linkColor": "#000000",
-      "linkedTrees": [
-        "FrodoTest",
-        "AA-FrodoTest",
+          "journeyFooterEnabled": false,
+          "journeyHeader": "<div class="d-flex justify-content-center py-4 flex-grow-1">Header Content</div>",
+          "journeyHeaderEnabled": false,
+          "journeyInputBackgroundColor": "#ffffff",
+          "journeyInputBorderColor": "#c0c9d5",
+          "journeyInputLabelColor": "#5e6d82",
+          "journeyInputSelectColor": "#e4f4fd",
+          "journeyInputTextColor": "#23282e",
+          "journeyJustifiedContent": "",
+          "journeyJustifiedContentEnabled": false,
+          "journeyLayout": "card",
+          "journeyTheaterMode": false,
+          "linkActiveColor": "#000000",
+          "linkColor": "#000000",
+          "linkedTrees": [
+            "FrodoTest",
+            "AA-FrodoTest",
+          ],
+          "logo": "https://cdn.forgerock.com/platform/themes/contrast/logo-contrast.svg",
+          "logoAltText": "Contrast",
+          "logoEnabled": false,
+          "logoHeight": "72",
+          "logoProfile": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
+          "logoProfileAltText": "Contrast",
+          "logoProfileCollapsed": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
+          "logoProfileCollapsedAltText": "",
+          "logoProfileCollapsedHeight": "22",
+          "logoProfileHeight": "22",
+          "name": "NoAccess",
+          "pageTitle": "#23282e",
+          "primaryColor": "#000000",
+          "primaryOffColor": "#000000",
+          "profileBackgroundColor": "#FFFFFF",
+          "profileMenuHighlightColor": "#FFFFFF",
+          "profileMenuHoverColor": "#FFFFFF",
+          "profileMenuHoverTextColor": "#000000",
+          "profileMenuTextHighlightColor": "#455469",
+          "secondaryColor": "#69788b",
+          "switchBackgroundColor": "#c0c9d5",
+          "textColor": "#ffffff",
+          "topBarBackgroundColor": "#ffffff",
+          "topBarBorderColor": "#e7eef4",
+          "topBarHeaderColor": "#23282e",
+          "topBarTextColor": "#69788b",
+        },
       ],
-      "logo": "https://cdn.forgerock.com/platform/themes/contrast/logo-contrast.svg",
-      "logoAltText": "Contrast",
-      "logoEnabled": false,
-      "logoHeight": "72",
-      "logoProfile": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
-      "logoProfileAltText": "Contrast",
-      "logoProfileCollapsed": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
-      "logoProfileCollapsedAltText": "",
-      "logoProfileCollapsedHeight": "22",
-      "logoProfileHeight": "22",
-      "name": "NoAccess",
-      "pageTitle": "#23282e",
-      "primaryColor": "#000000",
-      "primaryOffColor": "#000000",
-      "profileBackgroundColor": "#FFFFFF",
-      "profileMenuHighlightColor": "#FFFFFF",
-      "profileMenuHoverColor": "#FFFFFF",
-      "profileMenuHoverTextColor": "#000000",
-      "profileMenuTextHighlightColor": "#455469",
-      "secondaryColor": "#69788b",
-      "switchBackgroundColor": "#c0c9d5",
-      "textColor": "#ffffff",
-      "topBarBackgroundColor": "#ffffff",
-      "topBarBorderColor": "#e7eef4",
-      "topBarHeaderColor": "#23282e",
-      "topBarTextColor": "#69788b",
-    },
-  ],
-  "tree": {
-    "_id": "FrodoTest",
-    "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
-    "enabled": true,
-    "entryNodeId": "4951364c-59be-42cd-9cd7-79c9392214db",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "c859d258-79c1-4448-bd52-12e4e414af92",
+      "tree": {
+        "_id": "FrodoTest",
+        "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
+        "enabled": true,
+        "entryNodeId": "4951364c-59be-42cd-9cd7-79c9392214db",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "c859d258-79c1-4448-bd52-12e4e414af92",
+            },
+            "displayName": "Social Login",
+            "nodeType": "SocialProviderHandlerNode",
+            "x": 702,
+            "y": 116.015625,
+          },
+          "4951364c-59be-42cd-9cd7-79c9392214db": {
+            "connections": {
+              "known": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
+              "unknown": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+            },
+            "displayName": "Check Username",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 200,
+            "y": 235.015625,
+          },
+          "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
+            "connections": {
+              "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Validate Creds",
+            "nodeType": "IdentityStoreDecisionNode",
+            "x": 702,
+            "y": 292.015625,
+          },
+          "650203c3-47f7-439d-a554-669cb7b08c57": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "SAML2 Authentication",
+            "nodeType": "product-Saml2Node",
+            "x": 1196,
+            "y": 188.015625,
+          },
+          "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
+            "connections": {
+              "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+              "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+            "x": 444,
+            "y": 273.015625,
+          },
+          "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
+            "connections": {
+              "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+              "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+            "x": 443,
+            "y": 26.015625,
+          },
+          "c859d258-79c1-4448-bd52-12e4e414af92": {
+            "connections": {
+              "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "EMAIL_SENT": "650203c3-47f7-439d-a554-669cb7b08c57",
+            },
+            "displayName": "Email Template Node",
+            "nodeType": "EmailTemplateNode",
+            "x": 967,
+            "y": 222.015625,
+          },
         },
-        "displayName": "Social Login",
-        "nodeType": "SocialProviderHandlerNode",
-        "x": 702,
-        "y": 116.015625,
-      },
-      "4951364c-59be-42cd-9cd7-79c9392214db": {
-        "connections": {
-          "known": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
-          "unknown": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1434,
+            "y": 60,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1433,
+            "y": 459,
+          },
+          "startNode": {
+            "x": 63,
+            "y": 252,
+          },
         },
-        "displayName": "Check Username",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 200,
-        "y": 235.015625,
-      },
-      "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
-        "connections": {
-          "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "uiConfig": {
+          "categories": "["Frodo","Prototype"]",
         },
-        "displayName": "Validate Creds",
-        "nodeType": "IdentityStoreDecisionNode",
-        "x": 702,
-        "y": 292.015625,
       },
-      "650203c3-47f7-439d-a554-669cb7b08c57": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "SAML2 Authentication",
-        "nodeType": "product-Saml2Node",
-        "x": 1196,
-        "y": 188.015625,
-      },
-      "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
-        "connections": {
-          "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-          "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
-        },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-        "x": 444,
-        "y": 273.015625,
-      },
-      "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
-        "connections": {
-          "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-          "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
-        },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-        "x": 443,
-        "y": 26.015625,
-      },
-      "c859d258-79c1-4448-bd52-12e4e414af92": {
-        "connections": {
-          "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "EMAIL_SENT": "650203c3-47f7-439d-a554-669cb7b08c57",
-        },
-        "displayName": "Email Template Node",
-        "nodeType": "EmailTemplateNode",
-        "x": 967,
-        "y": 222.015625,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1434,
-        "y": 60,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1433,
-        "y": 459,
-      },
-      "startNode": {
-        "x": 63,
-        "y": 252,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Frodo","Prototype"]",
     },
   },
 }
@@ -8638,267 +8694,271 @@ a{
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/Login.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "0c80c39b-4813-4e67-b4fb-5a0bba85f994": {
-      "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0": {
-      "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": false,
-    },
-  },
-  "nodes": {
-    "2119f332-0f69-4088-a7a1-6582bf0f2001": {
-      "_id": "2119f332-0f69-4088-a7a1-6582bf0f2001",
-      "_outcomes": [
-        {
-          "displayName": "Retry",
-          "id": "Retry",
-        },
-        {
-          "displayName": "Reject",
-          "id": "Reject",
-        },
-      ],
-      "_type": {
-        "_id": "RetryLimitDecisionNode",
-        "collection": true,
-        "name": "Retry Limit Decision",
-      },
-      "incrementUserAttributeOnFailure": true,
-      "retryLimit": 5,
-    },
-    "33b24514-3e50-4180-8f08-ab6f4e51b07e": {
-      "_id": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
-      },
-      "tree": "ProgressiveProfile",
-    },
-    "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5": {
-      "_id": "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AccountLockoutNode",
-        "collection": true,
-        "name": "Account Lockout",
-      },
-      "lockAction": "LOCK",
-    },
-    "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708": {
-      "_id": "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "TRUE",
-        },
-        {
-          "displayName": "False",
-          "id": "FALSE",
-        },
-        {
-          "displayName": "Locked",
-          "id": "LOCKED",
-        },
-        {
-          "displayName": "Cancelled",
-          "id": "CANCELLED",
-        },
-        {
-          "displayName": "Expired",
-          "id": "EXPIRED",
-        },
-      ],
-      "_type": {
-        "_id": "IdentityStoreDecisionNode",
-        "collection": true,
-        "name": "Identity Store Decision",
-      },
-      "minimumPasswordLength": 8,
-      "mixedCaseForPasswordChangeMessages": false,
-      "useUniversalIdForUsername": false,
-    },
-    "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8": {
-      "_id": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
-          "displayName": "Platform Username",
-          "nodeType": "ValidatedUsernameNode",
-        },
-        {
+  "trees": {
+    "Login": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "0c80c39b-4813-4e67-b4fb-5a0bba85f994": {
           "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-      ],
-      "pageDescription": {
-        "en": "New here? <a href="#/service/Registration">Create an account</a><br><a href="#/service/ForgottenUsername">Forgot username?</a><a href="#/service/ResetPassword"> Forgot password?</a>",
-      },
-      "pageHeader": {
-        "en": "Sign In",
-      },
-    },
-    "bba3e0d8-8525-4e82-bf48-ac17f7988917": {
-      "_id": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+        "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0": {
+          "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": false,
         },
-      ],
-      "_type": {
-        "_id": "IncrementLoginCountNode",
-        "collection": true,
-        "name": "Increment Login Count",
       },
-      "identityAttribute": "userName",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "Login",
-    "description": "Platform Login Tree",
-    "enabled": true,
-    "entryNodeId": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "2119f332-0f69-4088-a7a1-6582bf0f2001": {
-        "connections": {
-          "Reject": "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5",
-          "Retry": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
+      "nodes": {
+        "2119f332-0f69-4088-a7a1-6582bf0f2001": {
+          "_id": "2119f332-0f69-4088-a7a1-6582bf0f2001",
+          "_outcomes": [
+            {
+              "displayName": "Retry",
+              "id": "Retry",
+            },
+            {
+              "displayName": "Reject",
+              "id": "Reject",
+            },
+          ],
+          "_type": {
+            "_id": "RetryLimitDecisionNode",
+            "collection": true,
+            "name": "Retry Limit Decision",
+          },
+          "incrementUserAttributeOnFailure": true,
+          "retryLimit": 5,
         },
-        "displayName": "Retry Limit Decision",
-        "nodeType": "RetryLimitDecisionNode",
-        "x": 612,
-        "y": 105.015625,
-      },
-      "33b24514-3e50-4180-8f08-ab6f4e51b07e": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "33b24514-3e50-4180-8f08-ab6f4e51b07e": {
+          "_id": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "ProgressiveProfile",
         },
-        "displayName": "Inner Tree Evaluator",
-        "nodeType": "InnerTreeEvaluatorNode",
-        "x": 827,
-        "y": 13,
-      },
-      "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5": {
-        "connections": {
-          "outcome": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5": {
+          "_id": "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AccountLockoutNode",
+            "collection": true,
+            "name": "Account Lockout",
+          },
+          "lockAction": "LOCK",
         },
-        "displayName": "Account Lockout",
-        "nodeType": "AccountLockoutNode",
-        "x": 836,
-        "y": 184.015625,
-      },
-      "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708": {
-        "connections": {
-          "CANCELLED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "EXPIRED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "FALSE": "2119f332-0f69-4088-a7a1-6582bf0f2001",
-          "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "TRUE": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
+        "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708": {
+          "_id": "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "TRUE",
+            },
+            {
+              "displayName": "False",
+              "id": "FALSE",
+            },
+            {
+              "displayName": "Locked",
+              "id": "LOCKED",
+            },
+            {
+              "displayName": "Cancelled",
+              "id": "CANCELLED",
+            },
+            {
+              "displayName": "Expired",
+              "id": "EXPIRED",
+            },
+          ],
+          "_type": {
+            "_id": "IdentityStoreDecisionNode",
+            "collection": true,
+            "name": "Identity Store Decision",
+          },
+          "minimumPasswordLength": 8,
+          "mixedCaseForPasswordChangeMessages": false,
+          "useUniversalIdForUsername": false,
         },
-        "displayName": "Identity Store Decision",
-        "nodeType": "IdentityStoreDecisionNode",
-        "x": 352,
-        "y": 40.015625,
-      },
-      "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8": {
-        "connections": {
-          "outcome": "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708",
+        "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8": {
+          "_id": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
+              "displayName": "Platform Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "New here? <a href="#/service/Registration">Create an account</a><br><a href="#/service/ForgottenUsername">Forgot username?</a><a href="#/service/ResetPassword"> Forgot password?</a>",
+          },
+          "pageHeader": {
+            "en": "Sign In",
+          },
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 136,
-        "y": 59,
-      },
-      "bba3e0d8-8525-4e82-bf48-ac17f7988917": {
-        "connections": {
-          "outcome": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
+        "bba3e0d8-8525-4e82-bf48-ac17f7988917": {
+          "_id": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "IncrementLoginCountNode",
+            "collection": true,
+            "name": "Increment Login Count",
+          },
+          "identityAttribute": "userName",
         },
-        "displayName": "Increment Login Count",
-        "nodeType": "IncrementLoginCountNode",
-        "x": 579,
-        "y": 34,
       },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1073,
-        "y": 30,
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "Login",
+        "description": "Platform Login Tree",
+        "enabled": true,
+        "entryNodeId": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "2119f332-0f69-4088-a7a1-6582bf0f2001": {
+            "connections": {
+              "Reject": "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5",
+              "Retry": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
+            },
+            "displayName": "Retry Limit Decision",
+            "nodeType": "RetryLimitDecisionNode",
+            "x": 612,
+            "y": 105.015625,
+          },
+          "33b24514-3e50-4180-8f08-ab6f4e51b07e": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Inner Tree Evaluator",
+            "nodeType": "InnerTreeEvaluatorNode",
+            "x": 827,
+            "y": 13,
+          },
+          "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5": {
+            "connections": {
+              "outcome": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "Account Lockout",
+            "nodeType": "AccountLockoutNode",
+            "x": 836,
+            "y": 184.015625,
+          },
+          "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708": {
+            "connections": {
+              "CANCELLED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "EXPIRED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "FALSE": "2119f332-0f69-4088-a7a1-6582bf0f2001",
+              "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "TRUE": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
+            },
+            "displayName": "Identity Store Decision",
+            "nodeType": "IdentityStoreDecisionNode",
+            "x": 352,
+            "y": 40.015625,
+          },
+          "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8": {
+            "connections": {
+              "outcome": "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 136,
+            "y": 59,
+          },
+          "bba3e0d8-8525-4e82-bf48-ac17f7988917": {
+            "connections": {
+              "outcome": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
+            },
+            "displayName": "Increment Login Count",
+            "nodeType": "IncrementLoginCountNode",
+            "x": 579,
+            "y": 34,
+          },
+        },
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1073,
+            "y": 30,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 761,
+            "y": 401,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 25,
+          },
+        },
+        "uiConfig": {
+          "categories": "["Authentication"]",
+        },
       },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 761,
-        "y": 401,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 25,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Authentication"]",
     },
   },
 }
@@ -8906,189 +8966,193 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/ProgressiveProfile.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {
-    "0a042e10-b22e-4e02-86c4-65e26e775f7a": {
-      "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
-      },
-      "attributesToCollect": [
-        "preferences/updates",
-        "preferences/marketing",
-      ],
-      "identityAttribute": "userName",
-      "required": false,
-      "validateInputs": false,
-    },
-  },
-  "nodes": {
-    "423a959a-a1b9-498a-b0f7-596b6b6e775a": {
-      "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
-      "_outcomes": [
-        {
-          "displayName": "Patched",
-          "id": "PATCHED",
-        },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
-        },
-      ],
-      "_type": {
-        "_id": "PatchObjectNode",
-        "collection": true,
-        "name": "Patch Object",
-      },
-      "identityAttribute": "userName",
-      "identityResource": "managed/alpha_user",
-      "ignoredFields": [],
-      "patchAsObject": false,
-    },
-    "8afdaec3-275e-4301-bb53-34f03e6a4b29": {
-      "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "LoginCountDecisionNode",
-        "collection": true,
-        "name": "Login Count Decision",
-      },
-      "amount": 3,
-      "identityAttribute": "userName",
-      "interval": "AT",
-    },
-    "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e": {
-      "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "QueryFilterDecisionNode",
-        "collection": true,
-        "name": "Query Filter Decision",
-      },
-      "identityAttribute": "userName",
-      "queryFilter": "!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false",
-    },
-    "a5aecad8-854a-4ed5-b719-ff6c90e858c0": {
-      "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+  "trees": {
+    "ProgressiveProfile": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {
+        "0a042e10-b22e-4e02-86c4-65e26e775f7a": {
           "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "preferences/updates",
+            "preferences/marketing",
+          ],
+          "identityAttribute": "userName",
+          "required": false,
+          "validateInputs": false,
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {
-        "en": "Please select your preferences",
       },
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "ProgressiveProfile",
-    "description": "Prompt for missing preferences on 3rd login",
-    "enabled": true,
-    "entryNodeId": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "423a959a-a1b9-498a-b0f7-596b6b6e775a": {
-        "connections": {
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+      "nodes": {
+        "423a959a-a1b9-498a-b0f7-596b6b6e775a": {
+          "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
+          "_outcomes": [
+            {
+              "displayName": "Patched",
+              "id": "PATCHED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "PatchObjectNode",
+            "collection": true,
+            "name": "Patch Object",
+          },
+          "identityAttribute": "userName",
+          "identityResource": "managed/alpha_user",
+          "ignoredFields": [],
+          "patchAsObject": false,
         },
-        "displayName": "Patch Object",
-        "nodeType": "PatchObjectNode",
-        "x": 766,
-        "y": 36,
-      },
-      "8afdaec3-275e-4301-bb53-34f03e6a4b29": {
-        "connections": {
-          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "true": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
+        "8afdaec3-275e-4301-bb53-34f03e6a4b29": {
+          "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "LoginCountDecisionNode",
+            "collection": true,
+            "name": "Login Count Decision",
+          },
+          "amount": 3,
+          "identityAttribute": "userName",
+          "interval": "AT",
         },
-        "displayName": "Login Count Decision",
-        "nodeType": "LoginCountDecisionNode",
-        "x": 152,
-        "y": 36,
-      },
-      "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e": {
-        "connections": {
-          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "true": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
+        "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e": {
+          "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "QueryFilterDecisionNode",
+            "collection": true,
+            "name": "Query Filter Decision",
+          },
+          "identityAttribute": "userName",
+          "queryFilter": "!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false",
         },
-        "displayName": "Query Filter Decision",
-        "nodeType": "QueryFilterDecisionNode",
-        "x": 357,
-        "y": 36,
-      },
-      "a5aecad8-854a-4ed5-b719-ff6c90e858c0": {
-        "connections": {
-          "outcome": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
+        "a5aecad8-854a-4ed5-b719-ff6c90e858c0": {
+          "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {
+            "en": "Please select your preferences",
+          },
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 555,
-        "y": 20,
       },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 802,
-        "y": 312,
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "ProgressiveProfile",
+        "description": "Prompt for missing preferences on 3rd login",
+        "enabled": true,
+        "entryNodeId": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "423a959a-a1b9-498a-b0f7-596b6b6e775a": {
+            "connections": {
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Patch Object",
+            "nodeType": "PatchObjectNode",
+            "x": 766,
+            "y": 36,
+          },
+          "8afdaec3-275e-4301-bb53-34f03e6a4b29": {
+            "connections": {
+              "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "true": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
+            },
+            "displayName": "Login Count Decision",
+            "nodeType": "LoginCountDecisionNode",
+            "x": 152,
+            "y": 36,
+          },
+          "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e": {
+            "connections": {
+              "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "true": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
+            },
+            "displayName": "Query Filter Decision",
+            "nodeType": "QueryFilterDecisionNode",
+            "x": 357,
+            "y": 36,
+          },
+          "a5aecad8-854a-4ed5-b719-ff6c90e858c0": {
+            "connections": {
+              "outcome": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 555,
+            "y": 20,
+          },
+        },
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 802,
+            "y": 312,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 919,
+            "y": 171,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 58.5,
+          },
+        },
+        "uiConfig": {
+          "categories": "["Progressive Profile"]",
+        },
       },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 919,
-        "y": 171,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 58.5,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Progressive Profile"]",
     },
   },
 }
@@ -9096,289 +9160,293 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/Registration.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {
-    "registration": {
-      "_id": "emailTemplate/registration",
-      "defaultLocale": "en",
-      "enabled": true,
-      "from": "",
-      "html": {
-        "en": "<html><body><h3>This is your registration email.</h3><p><a href="{{object.resumeURI}}">Email verification link</a></p></body></html>",
-        "fr": "<html><body><h3>Ceci est votre mail d'inscription.</h3><p><a href="{{object.resumeURI}}">Lien de vérification email</a></p></body></html>",
-      },
-      "message": {
-        "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><h3>This is your registration email.</h3><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Email verification link</a></p></div></body></html>",
-        "fr": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><h3>Ceci est votre mail d'inscription.</h3><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Lien de vérification email</a></p></div></body></html>",
-      },
-      "mimeType": "text/html",
-      "styles": "body{background-color:#324054;color:#5e6d82;padding:60px;text-align:center}a{text-decoration:none;color:#109cf1}.content{background-color:#fff;border-radius:4px;margin:0 auto;padding:48px;width:235px}",
-      "subject": {
-        "en": "Register new account",
-        "fr": "Créer un nouveau compte",
-      },
-    },
-  },
-  "innerNodes": {
-    "120c69d3-90b4-4ad4-b7af-380e8b119340": {
-      "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+  "trees": {
+    "Registration": {
+      "circlesOfTrust": {},
+      "emailTemplates": {
+        "registration": {
+          "_id": "emailTemplate/registration",
+          "defaultLocale": "en",
+          "enabled": true,
+          "from": "",
+          "html": {
+            "en": "<html><body><h3>This is your registration email.</h3><p><a href="{{object.resumeURI}}">Email verification link</a></p></body></html>",
+            "fr": "<html><body><h3>Ceci est votre mail d'inscription.</h3><p><a href="{{object.resumeURI}}">Lien de vérification email</a></p></body></html>",
+          },
+          "message": {
+            "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><h3>This is your registration email.</h3><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Email verification link</a></p></div></body></html>",
+            "fr": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><h3>Ceci est votre mail d'inscription.</h3><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Lien de vérification email</a></p></div></body></html>",
+          },
+          "mimeType": "text/html",
+          "styles": "body{background-color:#324054;color:#5e6d82;padding:60px;text-align:center}a{text-decoration:none;color:#109cf1}.content{background-color:#fff;border-radius:4px;margin:0 auto;padding:48px;width:235px}",
+          "subject": {
+            "en": "Register new account",
+            "fr": "Créer un nouveau compte",
+          },
         },
-      ],
-      "_type": {
-        "_id": "KbaCreateNode",
-        "collection": true,
-        "name": "KBA Definition",
       },
-      "allowUserDefinedQuestions": true,
-      "message": {
-        "en": "Select a security question",
-      },
-    },
-    "3d8709a1-f09f-4d1f-8094-2850e472c1db": {
-      "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": true,
-    },
-    "7fcaf48e-a754-4959-858b-05b2933b825f": {
-      "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": true,
-    },
-    "b4a0e915-c15d-4b83-9c9d-18347d645976": {
-      "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AcceptTermsAndConditionsNode",
-        "collection": true,
-        "name": "Accept Terms and Conditions",
-      },
-    },
-    "d3ce2036-1523-4ce8-b1a2-895a2a036667": {
-      "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
-      },
-      "attributesToCollect": [
-        "givenName",
-        "sn",
-        "mail",
-        "preferences/marketing",
-        "preferences/updates",
-      ],
-      "identityAttribute": "userName",
-      "required": true,
-      "validateInputs": true,
-    },
-  },
-  "nodes": {
-    "0c091c49-f3af-48fb-ac6f-07fba0499dd6": {
-      "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
-          "displayName": "Platform Username",
-          "nodeType": "ValidatedUsernameNode",
-        },
-        {
-          "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
-        },
-        {
-          "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
-        },
-        {
+      "innerNodes": {
+        "120c69d3-90b4-4ad4-b7af-380e8b119340": {
           "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
-          "displayName": "KBA Definition",
-          "nodeType": "KbaCreateNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "KbaCreateNode",
+            "collection": true,
+            "name": "KBA Definition",
+          },
+          "allowUserDefinedQuestions": true,
+          "message": {
+            "en": "Select a security question",
+          },
         },
-        {
+        "3d8709a1-f09f-4d1f-8094-2850e472c1db": {
+          "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": true,
+        },
+        "7fcaf48e-a754-4959-858b-05b2933b825f": {
+          "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": true,
+        },
+        "b4a0e915-c15d-4b83-9c9d-18347d645976": {
           "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
-          "displayName": "Accept Terms and Conditions",
-          "nodeType": "AcceptTermsAndConditionsNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AcceptTermsAndConditionsNode",
+            "collection": true,
+            "name": "Accept Terms and Conditions",
+          },
         },
-      ],
-      "pageDescription": {
-        "en": "Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>",
-      },
-      "pageHeader": {
-        "en": "Sign Up",
-      },
-    },
-    "466f8b54-07fb-4e31-a11d-a6842618cc37": {
-      "_id": "466f8b54-07fb-4e31-a11d-a6842618cc37",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+        "d3ce2036-1523-4ce8-b1a2-895a2a036667": {
+          "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "givenName",
+            "sn",
+            "mail",
+            "preferences/marketing",
+            "preferences/updates",
+          ],
+          "identityAttribute": "userName",
+          "required": true,
+          "validateInputs": true,
         },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
       },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "registration",
-      "identityAttribute": "userName",
-      "objectLookup": false,
-    },
-    "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b": {
-      "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+      "nodes": {
+        "0c091c49-f3af-48fb-ac6f-07fba0499dd6": {
+          "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
+              "displayName": "Platform Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+            {
+              "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
+              "displayName": "KBA Definition",
+              "nodeType": "KbaCreateNode",
+            },
+            {
+              "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
+              "displayName": "Accept Terms and Conditions",
+              "nodeType": "AcceptTermsAndConditionsNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>",
+          },
+          "pageHeader": {
+            "en": "Sign Up",
+          },
         },
-      ],
-      "_type": {
-        "_id": "IncrementLoginCountNode",
-        "collection": true,
-        "name": "Increment Login Count",
-      },
-      "identityAttribute": "userName",
-    },
-    "ad5dcbb3-7335-49b7-b3e7-7d850bb88237": {
-      "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
-      "_outcomes": [
-        {
-          "displayName": "Created",
-          "id": "CREATED",
+        "466f8b54-07fb-4e31-a11d-a6842618cc37": {
+          "_id": "466f8b54-07fb-4e31-a11d-a6842618cc37",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "registration",
+          "identityAttribute": "userName",
+          "objectLookup": false,
         },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
+        "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b": {
+          "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "IncrementLoginCountNode",
+            "collection": true,
+            "name": "Increment Login Count",
+          },
+          "identityAttribute": "userName",
         },
-      ],
-      "_type": {
-        "_id": "CreateObjectNode",
-        "collection": true,
-        "name": "Create Object",
-      },
-      "identityResource": "managed/alpha_user",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "Registration",
-    "description": "Platform Registration Tree",
-    "enabled": true,
-    "entryNodeId": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "0c091c49-f3af-48fb-ac6f-07fba0499dd6": {
-        "connections": {
-          "outcome": "466f8b54-07fb-4e31-a11d-a6842618cc37",
+        "ad5dcbb3-7335-49b7-b3e7-7d850bb88237": {
+          "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
+          "_outcomes": [
+            {
+              "displayName": "Created",
+              "id": "CREATED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "CreateObjectNode",
+            "collection": true,
+            "name": "Create Object",
+          },
+          "identityResource": "managed/alpha_user",
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 261,
-        "y": 168,
       },
-      "466f8b54-07fb-4e31-a11d-a6842618cc37": {
-        "connections": {
-          "outcome": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "Registration",
+        "description": "Platform Registration Tree",
+        "enabled": true,
+        "entryNodeId": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "0c091c49-f3af-48fb-ac6f-07fba0499dd6": {
+            "connections": {
+              "outcome": "466f8b54-07fb-4e31-a11d-a6842618cc37",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 261,
+            "y": 168,
+          },
+          "466f8b54-07fb-4e31-a11d-a6842618cc37": {
+            "connections": {
+              "outcome": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+            "x": 484,
+            "y": 267.015625,
+          },
+          "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b": {
+            "connections": {
+              "outcome": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Increment Login Count",
+            "nodeType": "IncrementLoginCountNode",
+            "x": 861,
+            "y": 221,
+          },
+          "ad5dcbb3-7335-49b7-b3e7-7d850bb88237": {
+            "connections": {
+              "CREATED": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "Create Object",
+            "nodeType": "CreateObjectNode",
+            "x": 717,
+            "y": 283,
+          },
         },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-        "x": 484,
-        "y": 267.015625,
-      },
-      "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b": {
-        "connections": {
-          "outcome": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1085,
+            "y": 248,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 921,
+            "y": 370,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 25,
+          },
         },
-        "displayName": "Increment Login Count",
-        "nodeType": "IncrementLoginCountNode",
-        "x": 861,
-        "y": 221,
-      },
-      "ad5dcbb3-7335-49b7-b3e7-7d850bb88237": {
-        "connections": {
-          "CREATED": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "uiConfig": {
+          "categories": "["Registration"]",
         },
-        "displayName": "Create Object",
-        "nodeType": "CreateObjectNode",
-        "x": 717,
-        "y": 283,
       },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1085,
-        "y": 248,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 921,
-        "y": 370,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 25,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Registration"]",
     },
   },
 }
@@ -9386,257 +9454,261 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/ResetPassword.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {
-    "resetPassword": {
-      "_id": "emailTemplate/resetPassword",
-      "defaultLocale": "en",
-      "enabled": true,
-      "from": "",
-      "message": {
-        "en": "<h3>Click to reset your password</h3><h4><a href="{{object.resumeURI}}">Password reset link</a></h4>",
-        "fr": "<h3>Cliquez pour réinitialiser votre mot de passe</h3><h4><a href="{{object.resumeURI}}">Mot de passe lien de réinitialisation</a></h4>",
-      },
-      "mimeType": "text/html",
-      "subject": {
-        "en": "Reset your password",
-        "fr": "Réinitialisez votre mot de passe",
-      },
-    },
-  },
-  "innerNodes": {
-    "009c19c8-9572-47bb-adb2-1f092c559a43": {
-      "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+  "trees": {
+    "ResetPassword": {
+      "circlesOfTrust": {},
+      "emailTemplates": {
+        "resetPassword": {
+          "_id": "emailTemplate/resetPassword",
+          "defaultLocale": "en",
+          "enabled": true,
+          "from": "",
+          "message": {
+            "en": "<h3>Click to reset your password</h3><h4><a href="{{object.resumeURI}}">Password reset link</a></h4>",
+            "fr": "<h3>Cliquez pour réinitialiser votre mot de passe</h3><h4><a href="{{object.resumeURI}}">Mot de passe lien de réinitialisation</a></h4>",
+          },
+          "mimeType": "text/html",
+          "subject": {
+            "en": "Reset your password",
+            "fr": "Réinitialisez votre mot de passe",
+          },
         },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
       },
-      "passwordAttribute": "password",
-      "validateInput": true,
-    },
-    "276afa7c-a680-4cf4-a5f6-d6c78191f5c9": {
-      "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "AttributeCollectorNode",
-        "collection": true,
-        "name": "Attribute Collector",
-      },
-      "attributesToCollect": [
-        "mail",
-      ],
-      "identityAttribute": "mail",
-      "required": true,
-      "validateInputs": false,
-    },
-  },
-  "nodes": {
-    "06c97be5-7fdd-4739-aea1-ecc7fe082865": {
-      "_id": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
-      },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "resetPassword",
-      "identityAttribute": "mail",
-      "objectLookup": true,
-    },
-    "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a": {
-      "_id": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "IdentifyExistingUserNode",
-        "collection": true,
-        "name": "Identify Existing User",
-      },
-      "identifier": "userName",
-      "identityAttribute": "mail",
-    },
-    "989f0bf8-a328-4217-b82b-5275d79ca8bd": {
-      "_id": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
-      "_outcomes": [
-        {
-          "displayName": "Patched",
-          "id": "PATCHED",
-        },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
-        },
-      ],
-      "_type": {
-        "_id": "PatchObjectNode",
-        "collection": true,
-        "name": "Patch Object",
-      },
-      "identityAttribute": "mail",
-      "identityResource": "managed/alpha_user",
-      "ignoredFields": [],
-      "patchAsObject": false,
-    },
-    "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b": {
-      "_id": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
-          "displayName": "Attribute Collector",
-          "nodeType": "AttributeCollectorNode",
-        },
-      ],
-      "pageDescription": {
-        "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
-      },
-      "pageHeader": {
-        "en": "Reset Password",
-      },
-    },
-    "e4c752f9-c625-48c9-9644-a58802fa9e9c": {
-      "_id": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+      "innerNodes": {
+        "009c19c8-9572-47bb-adb2-1f092c559a43": {
           "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": true,
         },
-      ],
-      "pageDescription": {
-        "en": "Change password",
-      },
-      "pageHeader": {
-        "en": "Reset Password",
-      },
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "ResetPassword",
-    "description": "Reset Password Tree",
-    "enabled": true,
-    "entryNodeId": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "06c97be5-7fdd-4739-aea1-ecc7fe082865": {
-        "connections": {
-          "outcome": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
+        "276afa7c-a680-4cf4-a5f6-d6c78191f5c9": {
+          "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "AttributeCollectorNode",
+            "collection": true,
+            "name": "Attribute Collector",
+          },
+          "attributesToCollect": [
+            "mail",
+          ],
+          "identityAttribute": "mail",
+          "required": true,
+          "validateInputs": false,
         },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-        "x": 453,
-        "y": 66,
       },
-      "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a": {
-        "connections": {
-          "false": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
-          "true": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
+      "nodes": {
+        "06c97be5-7fdd-4739-aea1-ecc7fe082865": {
+          "_id": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to the address you entered. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "resetPassword",
+          "identityAttribute": "mail",
+          "objectLookup": true,
         },
-        "displayName": "Identify Existing User",
-        "nodeType": "IdentifyExistingUserNode",
-        "x": 271,
-        "y": 21,
-      },
-      "989f0bf8-a328-4217-b82b-5275d79ca8bd": {
-        "connections": {
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a": {
+          "_id": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "IdentifyExistingUserNode",
+            "collection": true,
+            "name": "Identify Existing User",
+          },
+          "identifier": "userName",
+          "identityAttribute": "mail",
         },
-        "displayName": "Patch Object",
-        "nodeType": "PatchObjectNode",
-        "x": 819,
-        "y": 61,
-      },
-      "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b": {
-        "connections": {
-          "outcome": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
+        "989f0bf8-a328-4217-b82b-5275d79ca8bd": {
+          "_id": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
+          "_outcomes": [
+            {
+              "displayName": "Patched",
+              "id": "PATCHED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "PatchObjectNode",
+            "collection": true,
+            "name": "Patch Object",
+          },
+          "identityAttribute": "mail",
+          "identityResource": "managed/alpha_user",
+          "ignoredFields": [],
+          "patchAsObject": false,
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 103,
-        "y": 50,
-      },
-      "e4c752f9-c625-48c9-9644-a58802fa9e9c": {
-        "connections": {
-          "outcome": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
+        "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b": {
+          "_id": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
+              "displayName": "Attribute Collector",
+              "nodeType": "AttributeCollectorNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter your email address or <a href="#/service/Login">Sign in</a>",
+          },
+          "pageHeader": {
+            "en": "Reset Password",
+          },
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 643,
-        "y": 50,
+        "e4c752f9-c625-48c9-9644-a58802fa9e9c": {
+          "_id": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Change password",
+          },
+          "pageHeader": {
+            "en": "Reset Password",
+          },
+        },
       },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 970,
-        "y": 79,
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "ResetPassword",
+        "description": "Reset Password Tree",
+        "enabled": true,
+        "entryNodeId": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "06c97be5-7fdd-4739-aea1-ecc7fe082865": {
+            "connections": {
+              "outcome": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+            "x": 453,
+            "y": 66,
+          },
+          "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a": {
+            "connections": {
+              "false": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
+              "true": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
+            },
+            "displayName": "Identify Existing User",
+            "nodeType": "IdentifyExistingUserNode",
+            "x": 271,
+            "y": 21,
+          },
+          "989f0bf8-a328-4217-b82b-5275d79ca8bd": {
+            "connections": {
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Patch Object",
+            "nodeType": "PatchObjectNode",
+            "x": 819,
+            "y": 61,
+          },
+          "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b": {
+            "connections": {
+              "outcome": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 103,
+            "y": 50,
+          },
+          "e4c752f9-c625-48c9-9644-a58802fa9e9c": {
+            "connections": {
+              "outcome": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 643,
+            "y": 50,
+          },
+        },
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 970,
+            "y": 79,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 981,
+            "y": 147,
+          },
+          "startNode": {
+            "x": 25,
+            "y": 25,
+          },
+        },
+        "uiConfig": {
+          "categories": "["Password Reset"]",
+        },
       },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 981,
-        "y": 147,
-      },
-      "startNode": {
-        "x": 25,
-        "y": 25,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Password Reset"]",
     },
   },
 }
@@ -9644,310 +9716,314 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/UpdatePassword.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {
-    "updatePassword": {
-      "_id": "emailTemplate/updatePassword",
-      "defaultLocale": "en",
-      "enabled": true,
-      "from": "",
-      "html": {
-        "en": "<h3>Verify email to update password</h3><p><a href="{{object.resumeURI}}">Update password link</a></p>",
-      },
-      "message": {
-        "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><h3 id="verifyemailtoupdatepassword">Verify email to update password</h3><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Update password link</a></p></div></body></html>",
-      },
-      "mimeType": "text/html",
-      "styles": "body{background-color:#324054;color:#5e6d82;padding:60px;text-align:center}a{text-decoration:none;color:#109cf1}.content{background-color:#fff;border-radius:4px;margin:0 auto;padding:48px;width:235px}",
-      "subject": {
-        "en": "Update your password",
-      },
-    },
-  },
-  "innerNodes": {
-    "21a99653-a7a7-47ee-b650-f493a84bba09": {
-      "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+  "trees": {
+    "UpdatePassword": {
+      "circlesOfTrust": {},
+      "emailTemplates": {
+        "updatePassword": {
+          "_id": "emailTemplate/updatePassword",
+          "defaultLocale": "en",
+          "enabled": true,
+          "from": "",
+          "html": {
+            "en": "<h3>Verify email to update password</h3><p><a href="{{object.resumeURI}}">Update password link</a></p>",
+          },
+          "message": {
+            "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><h3 id="verifyemailtoupdatepassword">Verify email to update password</h3><p><a href="{{object.resumeURI}}" style="text-decoration: none; color: #109cf1;">Update password link</a></p></div></body></html>",
+          },
+          "mimeType": "text/html",
+          "styles": "body{background-color:#324054;color:#5e6d82;padding:60px;text-align:center}a{text-decoration:none;color:#109cf1}.content{background-color:#fff;border-radius:4px;margin:0 auto;padding:48px;width:235px}",
+          "subject": {
+            "en": "Update your password",
+          },
         },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
       },
-      "passwordAttribute": "password",
-      "validateInput": true,
-    },
-    "fe2962fc-4db3-4066-8624-553649afc438": {
-      "_id": "fe2962fc-4db3-4066-8624-553649afc438",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-  },
-  "nodes": {
-    "0f0904e6-1da3-4cdb-9abf-0d2545016fab": {
-      "_id": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "AttributePresentDecisionNode",
-        "collection": true,
-        "name": "Attribute Present Decision",
-      },
-      "identityAttribute": "userName",
-      "presentAttribute": "password",
-    },
-    "20237b34-26cb-4a0b-958f-abb422290d42": {
-      "_id": "20237b34-26cb-4a0b-958f-abb422290d42",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "fe2962fc-4db3-4066-8624-553649afc438",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
-        },
-      ],
-      "pageDescription": {
-        "en": "Enter current password",
-      },
-      "pageHeader": {
-        "en": "Verify Existing Password",
-      },
-    },
-    "3990ce1f-cce6-435b-ae1c-f138e89411c1": {
-      "_id": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
-      "_outcomes": [
-        {
-          "displayName": "Patched",
-          "id": "PATCHED",
-        },
-        {
-          "displayName": "Failed",
-          "id": "FAILURE",
-        },
-      ],
-      "_type": {
-        "_id": "PatchObjectNode",
-        "collection": true,
-        "name": "Patch Object",
-      },
-      "identityAttribute": "userName",
-      "identityResource": "managed/alpha_user",
-      "ignoredFields": [
-        "userName",
-      ],
-      "patchAsObject": false,
-    },
-    "7d1deabe-cd98-49c8-943f-ca12305775f3": {
-      "_id": "7d1deabe-cd98-49c8-943f-ca12305775f3",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "DataStoreDecisionNode",
-        "collection": true,
-        "name": "Data Store Decision",
-      },
-    },
-    "a3d97b53-e38a-4b24-aed0-a021050eb744": {
-      "_id": "a3d97b53-e38a-4b24-aed0-a021050eb744",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "EmailSuspendNode",
-        "collection": true,
-        "name": "Email Suspend Node",
-      },
-      "emailAttribute": "mail",
-      "emailSuspendMessage": {
-        "en": "An email has been sent to your address, please verify your email address to update your password. Click the link in that email to proceed.",
-      },
-      "emailTemplateName": "updatePassword",
-      "identityAttribute": "userName",
-      "objectLookup": true,
-    },
-    "d018fcd1-4e22-4160-8c41-63bee51c9cb3": {
-      "_id": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
+      "innerNodes": {
+        "21a99653-a7a7-47ee-b650-f493a84bba09": {
           "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
-          "displayName": "Platform Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": true,
         },
-      ],
-      "pageDescription": {
-        "en": "Enter new password",
-      },
-      "pageHeader": {
-        "en": "Update Password",
-      },
-    },
-    "d1b79744-493a-44fe-bc26-7d324a8caa4e": {
-      "_id": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
+        "fe2962fc-4db3-4066-8624-553649afc438": {
+          "_id": "fe2962fc-4db3-4066-8624-553649afc438",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-      ],
-      "_type": {
-        "_id": "SessionDataNode",
-        "collection": true,
-        "name": "Get Session Data",
       },
-      "sessionDataKey": "UserToken",
-      "sharedStateKey": "userName",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {},
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "UpdatePassword",
-    "description": "Update password using active session",
-    "enabled": true,
-    "entryNodeId": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "0f0904e6-1da3-4cdb-9abf-0d2545016fab": {
-        "connections": {
-          "false": "a3d97b53-e38a-4b24-aed0-a021050eb744",
-          "true": "20237b34-26cb-4a0b-958f-abb422290d42",
+      "nodes": {
+        "0f0904e6-1da3-4cdb-9abf-0d2545016fab": {
+          "_id": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "AttributePresentDecisionNode",
+            "collection": true,
+            "name": "Attribute Present Decision",
+          },
+          "identityAttribute": "userName",
+          "presentAttribute": "password",
         },
-        "displayName": "Attribute Present Decision",
-        "nodeType": "AttributePresentDecisionNode",
-        "x": 288,
-        "y": 133,
-      },
-      "20237b34-26cb-4a0b-958f-abb422290d42": {
-        "connections": {
-          "outcome": "7d1deabe-cd98-49c8-943f-ca12305775f3",
+        "20237b34-26cb-4a0b-958f-abb422290d42": {
+          "_id": "20237b34-26cb-4a0b-958f-abb422290d42",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "fe2962fc-4db3-4066-8624-553649afc438",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter current password",
+          },
+          "pageHeader": {
+            "en": "Verify Existing Password",
+          },
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 526,
-        "y": 46,
-      },
-      "3990ce1f-cce6-435b-ae1c-f138e89411c1": {
-        "connections": {
-          "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "3990ce1f-cce6-435b-ae1c-f138e89411c1": {
+          "_id": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
+          "_outcomes": [
+            {
+              "displayName": "Patched",
+              "id": "PATCHED",
+            },
+            {
+              "displayName": "Failed",
+              "id": "FAILURE",
+            },
+          ],
+          "_type": {
+            "_id": "PatchObjectNode",
+            "collection": true,
+            "name": "Patch Object",
+          },
+          "identityAttribute": "userName",
+          "identityResource": "managed/alpha_user",
+          "ignoredFields": [
+            "userName",
+          ],
+          "patchAsObject": false,
         },
-        "displayName": "Patch Object",
-        "nodeType": "PatchObjectNode",
-        "x": 1062,
-        "y": 189,
-      },
-      "7d1deabe-cd98-49c8-943f-ca12305775f3": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
+        "7d1deabe-cd98-49c8-943f-ca12305775f3": {
+          "_id": "7d1deabe-cd98-49c8-943f-ca12305775f3",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "DataStoreDecisionNode",
+            "collection": true,
+            "name": "Data Store Decision",
+          },
         },
-        "displayName": "Data Store Decision",
-        "nodeType": "DataStoreDecisionNode",
-        "x": 722,
-        "y": 45,
-      },
-      "a3d97b53-e38a-4b24-aed0-a021050eb744": {
-        "connections": {
-          "outcome": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
+        "a3d97b53-e38a-4b24-aed0-a021050eb744": {
+          "_id": "a3d97b53-e38a-4b24-aed0-a021050eb744",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "EmailSuspendNode",
+            "collection": true,
+            "name": "Email Suspend Node",
+          },
+          "emailAttribute": "mail",
+          "emailSuspendMessage": {
+            "en": "An email has been sent to your address, please verify your email address to update your password. Click the link in that email to proceed.",
+          },
+          "emailTemplateName": "updatePassword",
+          "identityAttribute": "userName",
+          "objectLookup": true,
         },
-        "displayName": "Email Suspend Node",
-        "nodeType": "EmailSuspendNode",
-        "x": 659,
-        "y": 223,
-      },
-      "d018fcd1-4e22-4160-8c41-63bee51c9cb3": {
-        "connections": {
-          "outcome": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
+        "d018fcd1-4e22-4160-8c41-63bee51c9cb3": {
+          "_id": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
+              "displayName": "Platform Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+          ],
+          "pageDescription": {
+            "en": "Enter new password",
+          },
+          "pageHeader": {
+            "en": "Update Password",
+          },
         },
-        "displayName": "Page Node",
-        "nodeType": "PageNode",
-        "x": 943,
-        "y": 30,
-      },
-      "d1b79744-493a-44fe-bc26-7d324a8caa4e": {
-        "connections": {
-          "outcome": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
+        "d1b79744-493a-44fe-bc26-7d324a8caa4e": {
+          "_id": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "SessionDataNode",
+            "collection": true,
+            "name": "Get Session Data",
+          },
+          "sessionDataKey": "UserToken",
+          "sharedStateKey": "userName",
         },
-        "displayName": "Get Session Data",
-        "nodeType": "SessionDataNode",
-        "x": 122,
-        "y": 129,
       },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1212,
-        "y": 128,
+      "saml2Entities": {},
+      "scripts": {},
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "UpdatePassword",
+        "description": "Update password using active session",
+        "enabled": true,
+        "entryNodeId": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "0f0904e6-1da3-4cdb-9abf-0d2545016fab": {
+            "connections": {
+              "false": "a3d97b53-e38a-4b24-aed0-a021050eb744",
+              "true": "20237b34-26cb-4a0b-958f-abb422290d42",
+            },
+            "displayName": "Attribute Present Decision",
+            "nodeType": "AttributePresentDecisionNode",
+            "x": 288,
+            "y": 133,
+          },
+          "20237b34-26cb-4a0b-958f-abb422290d42": {
+            "connections": {
+              "outcome": "7d1deabe-cd98-49c8-943f-ca12305775f3",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 526,
+            "y": 46,
+          },
+          "3990ce1f-cce6-435b-ae1c-f138e89411c1": {
+            "connections": {
+              "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Patch Object",
+            "nodeType": "PatchObjectNode",
+            "x": 1062,
+            "y": 189,
+          },
+          "7d1deabe-cd98-49c8-943f-ca12305775f3": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
+            },
+            "displayName": "Data Store Decision",
+            "nodeType": "DataStoreDecisionNode",
+            "x": 722,
+            "y": 45,
+          },
+          "a3d97b53-e38a-4b24-aed0-a021050eb744": {
+            "connections": {
+              "outcome": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
+            },
+            "displayName": "Email Suspend Node",
+            "nodeType": "EmailSuspendNode",
+            "x": 659,
+            "y": 223,
+          },
+          "d018fcd1-4e22-4160-8c41-63bee51c9cb3": {
+            "connections": {
+              "outcome": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
+            },
+            "displayName": "Page Node",
+            "nodeType": "PageNode",
+            "x": 943,
+            "y": 30,
+          },
+          "d1b79744-493a-44fe-bc26-7d324a8caa4e": {
+            "connections": {
+              "outcome": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
+            },
+            "displayName": "Get Session Data",
+            "nodeType": "SessionDataNode",
+            "x": 122,
+            "y": 129,
+          },
+        },
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1212,
+            "y": 128,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 939,
+            "y": 290,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 25,
+          },
+        },
+        "uiConfig": {
+          "categories": "["Password Reset"]",
+        },
       },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 939,
-        "y": 290,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 25,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Password Reset"]",
     },
   },
 }
@@ -9955,316 +10031,320 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/j00.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
-  "nodes": {
-    "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
-      "_id": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j00": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
+          "_id": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "240d83a3-2268-4ae1-9c20-30b65be6adab": {
-      "_id": "240d83a3-2268-4ae1-9c20-30b65be6adab",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
+        "240d83a3-2268-4ae1-9c20-30b65be6adab": {
+          "_id": "240d83a3-2268-4ae1-9c20-30b65be6adab",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
         },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
+        "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
+          "_id": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
         },
-        {
-          "displayName": "level only",
-          "id": "level only",
+        "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
+          "_id": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
         },
-        {
-          "displayName": "none",
-          "id": "none",
+        "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
+          "_id": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "3cb43516-ae69-433a-8787-501d45db14e9",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
-      "_id": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+        "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
+          "_id": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
-      "_id": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+      "saml2Entities": {},
+      "scripts": {
+        "1b52a7e0-4019-40fa-958a-15a49870e901": {
+          "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set the same shared state variable",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "shared",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
-      "_id": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+        "3cb43516-ae69-433a-8787-501d45db14e9": {
+          "_id": "3cb43516-ae69-433a-8787-501d45db14e9",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Display sharedState, transientState, and headers.",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "debug",
+          "script": ""/* debug\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Display sharedState, transientState, and headers.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - true\\n */\\nvar anchor = \\"anchor-\\".concat(generateNumericToken('xxx'));\\nvar halign = \\"left\\";\\nvar message = \\"<p><b>Shared State</b>:<br/>\\".concat(\\n      sharedState.toString()).concat(\\"</p>\\").concat(\\n    \\"<p><b>Transient State</b>:<br/>\\").concat(\\n      transientState.toString()).concat(\\"</p>\\").concat(\\n    \\"<p><b>Request Headers</b>:<br/>\\").concat(\\n      requestHeaders.toString()).concat(\\"</p>\\")\\nvar script = \\"Array.prototype.slice.call(\\\\n\\".concat(\\n  \\"document.getElementsByClassName('callback-component')).forEach(\\\\n\\").concat(\\n  \\"function (e) {\\\\n\\").concat(\\n  \\"  var message = e.firstElementChild;\\\\n\\").concat(\\n  \\"  if (message.firstChild && message.firstChild.nodeName == '#text' && message.firstChild.nodeValue.trim() == '\\").concat(anchor).concat(\\"') {\\\\n\\").concat(\\n  \\"    message.className = \\\\\\"text-left\\\\\\";\\\\n\\").concat(\\n  \\"    message.align = \\\\\\"\\").concat(halign).concat(\\"\\\\\\";\\\\n\\").concat(\\n  \\"    message.innerHTML = '\\").concat(message).concat(\\"';\\\\n\\").concat(\\n  \\"  }\\\\n\\").concat(\\n  \\"})\\")\\nvar fr = JavaImporter(\\n    org.forgerock.openam.auth.node.api.Action,\\n    javax.security.auth.callback.TextOutputCallback,\\n    com.sun.identity.authentication.callbacks.ScriptTextOutputCallback\\n)\\nif (message.length && callbacks.isEmpty()) {\\n    action = fr.Action.send(\\n        new fr.TextOutputCallback(\\n            fr.TextOutputCallback.INFORMATION,\\n            anchor\\n        ),\\n        new fr.ScriptTextOutputCallback(script)\\n    ).build()\\n}\\nelse {\\n  action = fr.Action.goTo(\\"true\\").build();\\n}\\n\\n /*\\n  * Generate a token in the desired format. All 'x' characters will be replaced with a random number 0-9.\\n  * \\n  * Example:\\n  * 'xxxxx' produces '28535'\\n  * 'xxx-xxx' produces '432-521'\\n  */\\nfunction generateNumericToken(format) {\\n    return format.replace(/[x]/g, function(c) {\\n        var r = Math.random()*10|0;\\n        var v = r;\\n        return v.toString(10);\\n    });\\n}"",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "3cb43516-ae69-433a-8787-501d45db14e9",
-    },
-    "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
-      "_id": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+        "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
+          "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set per level shared state variable",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "level",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {
-    "1b52a7e0-4019-40fa-958a-15a49870e901": {
-      "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set the same shared state variable",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "shared",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
-    },
-    "3cb43516-ae69-433a-8787-501d45db14e9": {
-      "_id": "3cb43516-ae69-433a-8787-501d45db14e9",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Display sharedState, transientState, and headers.",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "debug",
-      "script": ""/* debug\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Display sharedState, transientState, and headers.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - true\\n */\\nvar anchor = \\"anchor-\\".concat(generateNumericToken('xxx'));\\nvar halign = \\"left\\";\\nvar message = \\"<p><b>Shared State</b>:<br/>\\".concat(\\n      sharedState.toString()).concat(\\"</p>\\").concat(\\n    \\"<p><b>Transient State</b>:<br/>\\").concat(\\n      transientState.toString()).concat(\\"</p>\\").concat(\\n    \\"<p><b>Request Headers</b>:<br/>\\").concat(\\n      requestHeaders.toString()).concat(\\"</p>\\")\\nvar script = \\"Array.prototype.slice.call(\\\\n\\".concat(\\n  \\"document.getElementsByClassName('callback-component')).forEach(\\\\n\\").concat(\\n  \\"function (e) {\\\\n\\").concat(\\n  \\"  var message = e.firstElementChild;\\\\n\\").concat(\\n  \\"  if (message.firstChild && message.firstChild.nodeName == '#text' && message.firstChild.nodeValue.trim() == '\\").concat(anchor).concat(\\"') {\\\\n\\").concat(\\n  \\"    message.className = \\\\\\"text-left\\\\\\";\\\\n\\").concat(\\n  \\"    message.align = \\\\\\"\\").concat(halign).concat(\\"\\\\\\";\\\\n\\").concat(\\n  \\"    message.innerHTML = '\\").concat(message).concat(\\"';\\\\n\\").concat(\\n  \\"  }\\\\n\\").concat(\\n  \\"})\\")\\nvar fr = JavaImporter(\\n    org.forgerock.openam.auth.node.api.Action,\\n    javax.security.auth.callback.TextOutputCallback,\\n    com.sun.identity.authentication.callbacks.ScriptTextOutputCallback\\n)\\nif (message.length && callbacks.isEmpty()) {\\n    action = fr.Action.send(\\n        new fr.TextOutputCallback(\\n            fr.TextOutputCallback.INFORMATION,\\n            anchor\\n        ),\\n        new fr.ScriptTextOutputCallback(script)\\n    ).build()\\n}\\nelse {\\n  action = fr.Action.goTo(\\"true\\").build();\\n}\\n\\n /*\\n  * Generate a token in the desired format. All 'x' characters will be replaced with a random number 0-9.\\n  * \\n  * Example:\\n  * 'xxxxx' produces '28535'\\n  * 'xxx-xxx' produces '432-521'\\n  */\\nfunction generateNumericToken(format) {\\n    return format.replace(/[x]/g, function(c) {\\n        var r = Math.random()*10|0;\\n        var v = r;\\n        return v.toString(10);\\n    });\\n}"",
-    },
-    "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
-      "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set per level shared state variable",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "level",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
-    },
-    "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
-      "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Check if mode has already been set.",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "mode",
-      "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
-    },
-  },
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j00",
-    "enabled": true,
-    "entryNodeId": "240d83a3-2268-4ae1-9c20-30b65be6adab",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
-        "connections": {
-          "true": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
+        "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
+          "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Check if mode has already been set.",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "mode",
+          "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
         },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 392,
-        "y": 173.015625,
       },
-      "240d83a3-2268-4ae1-9c20-30b65be6adab": {
-        "connections": {
-          "level only": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
-          "none": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-          "shared and level": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
-          "shared only": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j00",
+        "enabled": true,
+        "entryNodeId": "240d83a3-2268-4ae1-9c20-30b65be6adab",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "1e0789eb-3394-4f7d-9db4-f06cb4d71eab": {
+            "connections": {
+              "true": "b787efaf-f1a6-433a-8194-85b7c3df9c07",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 392,
+            "y": 173.015625,
+          },
+          "240d83a3-2268-4ae1-9c20-30b65be6adab": {
+            "connections": {
+              "level only": "2a9c577f-402a-4fba-94f7-ccf7c479553b",
+              "none": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+              "shared and level": "1e0789eb-3394-4f7d-9db4-f06cb4d71eab",
+              "shared only": "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 167,
+            "y": 210.015625,
+          },
+          "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
+            "connections": {
+              "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 395,
+            "y": 345.015625,
+          },
+          "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
+            "connections": {
+              "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 598,
+            "y": 173.015625,
+          },
+          "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
+            "connections": {
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "debug",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 1033,
+            "y": 261.015625,
+          },
+          "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
+            "connections": {
+              "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 393,
+            "y": 259.015625,
+          },
         },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 167,
-        "y": 210.015625,
-      },
-      "2a9c577f-402a-4fba-94f7-ccf7c479553b": {
-        "connections": {
-          "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1236,
+            "y": 145,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1236,
+            "y": 253,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 250,
+          },
         },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 395,
-        "y": 345.015625,
-      },
-      "b787efaf-f1a6-433a-8194-85b7c3df9c07": {
-        "connections": {
-          "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
+        "uiConfig": {
+          "categories": "[]",
         },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 598,
-        "y": 173.015625,
       },
-      "d1c184a0-5fbb-45a0-b0aa-36932833814c": {
-        "connections": {
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "debug",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 1033,
-        "y": 261.015625,
-      },
-      "d481e647-675e-4d0e-9bd3-dd4d41b7fc2a": {
-        "connections": {
-          "true": "d1c184a0-5fbb-45a0-b0aa-36932833814c",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 393,
-        "y": 259.015625,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1236,
-        "y": 145,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1236,
-        "y": 253,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 250,
-      },
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }
@@ -10272,298 +10352,302 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/j01.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
-  "nodes": {
-    "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
-      "_id": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j01": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
+          "_id": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
+        "aa97f870-d95e-4861-b756-64b6423dd7da": {
+          "_id": "aa97f870-d95e-4861-b756-64b6423dd7da",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "j00",
+        },
+        "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
+          "_id": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+        },
+        "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
+          "_id": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
+        "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
+          "_id": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "fa62ae77-1e86-4939-a773-e428259fac97": {
+          "_id": "fa62ae77-1e86-4939-a773-e428259fac97",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "aa97f870-d95e-4861-b756-64b6423dd7da": {
-      "_id": "aa97f870-d95e-4861-b756-64b6423dd7da",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "saml2Entities": {},
+      "scripts": {
+        "1b52a7e0-4019-40fa-958a-15a49870e901": {
+          "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set the same shared state variable",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "shared",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
+          "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set per level shared state variable",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "level",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
         },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
+        "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
+          "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Check if mode has already been set.",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "mode",
+          "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
+        },
       },
-      "tree": "j00",
-    },
-    "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
-      "_id": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j01",
+        "enabled": true,
+        "entryNodeId": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 395,
+            "y": 345.015625,
+          },
+          "aa97f870-d95e-4861-b756-64b6423dd7da": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "nest",
+            "nodeType": "InnerTreeEvaluatorNode",
+            "x": 816,
+            "y": 233.015625,
+          },
+          "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
+            "connections": {
+              "level only": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
+              "none": "aa97f870-d95e-4861-b756-64b6423dd7da",
+              "shared and level": "fa62ae77-1e86-4939-a773-e428259fac97",
+              "shared only": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 167,
+            "y": 210.015625,
+          },
+          "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 393,
+            "y": 259.015625,
+          },
+          "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 598,
+            "y": 173.015625,
+          },
+          "fa62ae77-1e86-4939-a773-e428259fac97": {
+            "connections": {
+              "true": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 392,
+            "y": 173.015625,
+          },
         },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1236,
+            "y": 145,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1236,
+            "y": 253,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 250,
+          },
         },
-        {
-          "displayName": "level only",
-          "id": "level only",
+        "uiConfig": {
+          "categories": "[]",
         },
-        {
-          "displayName": "none",
-          "id": "none",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
-      "_id": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
-      "_id": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "fa62ae77-1e86-4939-a773-e428259fac97": {
-      "_id": "fa62ae77-1e86-4939-a773-e428259fac97",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {
-    "1b52a7e0-4019-40fa-958a-15a49870e901": {
-      "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set the same shared state variable",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "shared",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
-    },
-    "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
-      "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set per level shared state variable",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "level",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
-    },
-    "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
-      "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Check if mode has already been set.",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "mode",
-      "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
-    },
-  },
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j01",
-    "enabled": true,
-    "entryNodeId": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 395,
-        "y": 345.015625,
-      },
-      "aa97f870-d95e-4861-b756-64b6423dd7da": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "nest",
-        "nodeType": "InnerTreeEvaluatorNode",
-        "x": 816,
-        "y": 233.015625,
-      },
-      "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
-        "connections": {
-          "level only": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
-          "none": "aa97f870-d95e-4861-b756-64b6423dd7da",
-          "shared and level": "fa62ae77-1e86-4939-a773-e428259fac97",
-          "shared only": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
-        },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 167,
-        "y": 210.015625,
-      },
-      "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 393,
-        "y": 259.015625,
-      },
-      "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 598,
-        "y": 173.015625,
-      },
-      "fa62ae77-1e86-4939-a773-e428259fac97": {
-        "connections": {
-          "true": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 392,
-        "y": 173.015625,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1236,
-        "y": 145,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1236,
-        "y": 253,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 250,
-      },
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }
@@ -10571,298 +10655,302 @@ exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3":
 
 exports[`frodo journey export "frodo journey export -NAD journeyTestDirectory3": should export all journeys to separate files in the folder named "journeyTestDirectory3": journeyTestDirectory3/j02.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
-  "nodes": {
-    "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
-      "_id": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j02": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
+          "_id": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
+        "33791a7d-d14a-460f-806b-5fc3113a1e13": {
+          "_id": "33791a7d-d14a-460f-806b-5fc3113a1e13",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+        },
+        "4ee0bb06-5335-403e-810b-72d574247dfe": {
+          "_id": "4ee0bb06-5335-403e-810b-72d574247dfe",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
+          "_id": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "a679285d-8718-4db3-ba08-e743ab7eb086": {
+          "_id": "a679285d-8718-4db3-ba08-e743ab7eb086",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
+        "f192e72d-aa85-447b-af66-592a60f0c6c0": {
+          "_id": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "j01",
+        },
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "33791a7d-d14a-460f-806b-5fc3113a1e13": {
-      "_id": "33791a7d-d14a-460f-806b-5fc3113a1e13",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
+      "saml2Entities": {},
+      "scripts": {
+        "1b52a7e0-4019-40fa-958a-15a49870e901": {
+          "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set the same shared state variable",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "shared",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
         },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
+        "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
+          "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set per level shared state variable",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "level",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
         },
-        {
-          "displayName": "level only",
-          "id": "level only",
+        "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
+          "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Check if mode has already been set.",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "mode",
+          "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
         },
-        {
-          "displayName": "none",
-          "id": "none",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "4ee0bb06-5335-403e-810b-72d574247dfe": {
-      "_id": "4ee0bb06-5335-403e-810b-72d574247dfe",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j02",
+        "enabled": true,
+        "entryNodeId": "33791a7d-d14a-460f-806b-5fc3113a1e13",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 393,
+            "y": 259.015625,
+          },
+          "33791a7d-d14a-460f-806b-5fc3113a1e13": {
+            "connections": {
+              "level only": "4ee0bb06-5335-403e-810b-72d574247dfe",
+              "none": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+              "shared and level": "a679285d-8718-4db3-ba08-e743ab7eb086",
+              "shared only": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 167,
+            "y": 210.015625,
+          },
+          "4ee0bb06-5335-403e-810b-72d574247dfe": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 395,
+            "y": 345.015625,
+          },
+          "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
+            "connections": {
+              "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 598,
+            "y": 173.015625,
+          },
+          "a679285d-8718-4db3-ba08-e743ab7eb086": {
+            "connections": {
+              "true": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 392,
+            "y": 173.015625,
+          },
+          "f192e72d-aa85-447b-af66-592a60f0c6c0": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "nest",
+            "nodeType": "InnerTreeEvaluatorNode",
+            "x": 816,
+            "y": 233.015625,
+          },
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
-      "_id": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1236,
+            "y": 145,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1236,
+            "y": 253,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 250,
+          },
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "a679285d-8718-4db3-ba08-e743ab7eb086": {
-      "_id": "a679285d-8718-4db3-ba08-e743ab7eb086",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+        "uiConfig": {
+          "categories": "[]",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "f192e72d-aa85-447b-af66-592a60f0c6c0": {
-      "_id": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
-        },
-        {
-          "displayName": "False",
-          "id": "false",
-        },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
-      },
-      "tree": "j01",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {
-    "1b52a7e0-4019-40fa-958a-15a49870e901": {
-      "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set the same shared state variable",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "shared",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
-    },
-    "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
-      "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set per level shared state variable",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "level",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
-    },
-    "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
-      "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Check if mode has already been set.",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "mode",
-      "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
-    },
-  },
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j02",
-    "enabled": true,
-    "entryNodeId": "33791a7d-d14a-460f-806b-5fc3113a1e13",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "1fafe9cd-4a2e-42b9-b326-ea1a94325a40": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 393,
-        "y": 259.015625,
-      },
-      "33791a7d-d14a-460f-806b-5fc3113a1e13": {
-        "connections": {
-          "level only": "4ee0bb06-5335-403e-810b-72d574247dfe",
-          "none": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-          "shared and level": "a679285d-8718-4db3-ba08-e743ab7eb086",
-          "shared only": "1fafe9cd-4a2e-42b9-b326-ea1a94325a40",
-        },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 167,
-        "y": 210.015625,
-      },
-      "4ee0bb06-5335-403e-810b-72d574247dfe": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 395,
-        "y": 345.015625,
-      },
-      "5e6d7b3b-e381-4395-ba18-ca807b6adb48": {
-        "connections": {
-          "true": "f192e72d-aa85-447b-af66-592a60f0c6c0",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 598,
-        "y": 173.015625,
-      },
-      "a679285d-8718-4db3-ba08-e743ab7eb086": {
-        "connections": {
-          "true": "5e6d7b3b-e381-4395-ba18-ca807b6adb48",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 392,
-        "y": 173.015625,
-      },
-      "f192e72d-aa85-447b-af66-592a60f0c6c0": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "nest",
-        "nodeType": "InnerTreeEvaluatorNode",
-        "x": 816,
-        "y": 233.015625,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1236,
-        "y": 145,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1236,
-        "y": 253,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 250,
-      },
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }
@@ -16533,22 +16621,25 @@ exports[`frodo journey export "frodo journey export -i FrodoTest": should export
 
 exports[`frodo journey export "frodo journey export -i FrodoTest": should export the journey with journey id "FrodoTest": FrodoTest.journey.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {
-    "welcome": {
-      "_id": "emailTemplate/welcome",
-      "defaultLocale": "en",
-      "displayName": "Welcome",
-      "enabled": true,
-      "from": "saas@forgerock.com",
-      "html": {
-        "en": "<div class="content"><p>Welcome. Your username is '{{object.userName}}'.</p></div>",
-      },
-      "message": {
-        "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>Welcome. Your username is '{{object.userName}}'.</p></div></body></html>",
-      },
-      "mimeType": "text/html",
-      "styles": "body{
+  "meta": Any<Object>,
+  "trees": {
+    "FrodoTest": {
+      "circlesOfTrust": {},
+      "emailTemplates": {
+        "welcome": {
+          "_id": "emailTemplate/welcome",
+          "defaultLocale": "en",
+          "displayName": "Welcome",
+          "enabled": true,
+          "from": "saas@forgerock.com",
+          "html": {
+            "en": "<div class="content"><p>Welcome. Your username is '{{object.userName}}'.</p></div>",
+          },
+          "message": {
+            "en": "<html><head></head><body style="background-color: #324054; color: #5e6d82; padding: 60px; text-align: center;"><div class="content" style="background-color: #fff; border-radius: 4px; margin: 0 auto; padding: 48px; width: 235px;"><p>Welcome. Your username is '{{object.userName}}'.</p></div></body></html>",
+          },
+          "mimeType": "text/html",
+          "styles": "body{
  background-color:#324054;
  color:#5e6d82;
  padding:60px;
@@ -16566,1251 +16657,1252 @@ a{
  width:235px
 }
 ",
-      "subject": {
-        "en": "Your account has been created",
+          "subject": {
+            "en": "Your account has been created",
+          },
+        },
       },
-    },
-  },
-  "innerNodes": {
-    "051c1939-7dd5-4cf1-866e-48f57541b6ac": {
-      "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "28595125-e97a-40e7-aa3c-bebdb6821949": {
-      "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4": {
-      "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "SelectIdPNode",
-        "collection": true,
-        "name": "Select Identity Provider",
-      },
-      "filteredProviders": [],
-      "identityAttribute": "mail",
-      "includeLocalAuthentication": true,
-      "offerOnlyExisting": false,
-      "passwordAttribute": "password",
-    },
-    "ac343c95-8873-410e-823b-0931a71fc0c7": {
-      "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedPasswordNode",
-        "collection": true,
-        "name": "Platform Password",
-      },
-      "passwordAttribute": "password",
-      "validateInput": false,
-    },
-    "fe762924-bc07-4f50-9234-17ab245efff1": {
-      "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
-      "_outcomes": [
-        {
-          "displayName": "Outcome",
-          "id": "outcome",
-        },
-      ],
-      "_type": {
-        "_id": "ValidatedUsernameNode",
-        "collection": true,
-        "name": "Platform Username",
-      },
-      "usernameAttribute": "userName",
-      "validateInput": false,
-    },
-  },
-  "meta": Any<Object>,
-  "nodes": {
-    "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
-      "_id": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "SocialProviderHandlerNode",
-        "collection": true,
-        "name": "Social Provider Handler Node",
-      },
-      "clientType": "BROWSER",
-      "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
-      "usernameAttribute": "userName",
-    },
-    "4951364c-59be-42cd-9cd7-79c9392214db": {
-      "_id": "4951364c-59be-42cd-9cd7-79c9392214db",
-      "_outcomes": [
-        {
-          "displayName": "known",
-          "id": "known",
-        },
-        {
-          "displayName": "unknown",
-          "id": "unknown",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "known",
-        "unknown",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "739bdc48-fd24-4c52-b353-88706d75558a",
-    },
-    "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
-      "_id": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "TRUE",
-        },
-        {
-          "displayName": "False",
-          "id": "FALSE",
-        },
-        {
-          "displayName": "Locked",
-          "id": "LOCKED",
-        },
-        {
-          "displayName": "Cancelled",
-          "id": "CANCELLED",
-        },
-        {
-          "displayName": "Expired",
-          "id": "EXPIRED",
-        },
-      ],
-      "_type": {
-        "_id": "IdentityStoreDecisionNode",
-        "collection": true,
-        "name": "Identity Store Decision",
-      },
-      "minimumPasswordLength": 8,
-      "mixedCaseForPasswordChangeMessages": false,
-      "useUniversalIdForUsername": true,
-    },
-    "650203c3-47f7-439d-a554-669cb7b08c57": {
-      "_id": "650203c3-47f7-439d-a554-669cb7b08c57",
-      "_outcomes": [
-        {
-          "displayName": "Account exists",
-          "id": "ACCOUNT_EXISTS",
-        },
-        {
-          "displayName": "No account exists",
-          "id": "NO_ACCOUNT",
-        },
-      ],
-      "_type": {
-        "_id": "product-Saml2Node",
-        "collection": true,
-        "name": "SAML2 Authentication",
-      },
-      "allowCreate": true,
-      "authComparison": "MINIMUM",
-      "authnContextClassRef": [],
-      "authnContextDeclRef": [],
-      "binding": "HTTP_ARTIFACT",
-      "forceAuthn": false,
-      "idpEntityId": "urn:federation:MicrosoftOnline",
-      "isPassive": false,
-      "metaAlias": "/alpha/iSPAzure",
-      "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-      "requestBinding": "HTTP_REDIRECT",
-    },
-    "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
-      "_id": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
-          "displayName": "Username",
-          "nodeType": "ValidatedUsernameNode",
-        },
-        {
+      "innerNodes": {
+        "051c1939-7dd5-4cf1-866e-48f57541b6ac": {
           "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-        {
+        "28595125-e97a-40e7-aa3c-bebdb6821949": {
           "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
-      "_id": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
-      "_outcomes": [
-        {
-          "displayName": "Social Authentication",
-          "id": "socialAuthentication",
-        },
-        {
-          "displayName": "Local Authentication",
-          "id": "localAuthentication",
-        },
-      ],
-      "_type": {
-        "_id": "PageNode",
-        "collection": true,
-        "name": "Page Node",
-      },
-      "nodes": [
-        {
-          "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
-          "displayName": "Password",
-          "nodeType": "ValidatedPasswordNode",
-        },
-        {
+        "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4": {
           "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
-          "displayName": "Select IDP",
-          "nodeType": "SelectIdPNode",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "SelectIdPNode",
+            "collection": true,
+            "name": "Select Identity Provider",
+          },
+          "filteredProviders": [],
+          "identityAttribute": "mail",
+          "includeLocalAuthentication": true,
+          "offerOnlyExisting": false,
+          "passwordAttribute": "password",
         },
-      ],
-      "pageDescription": {},
-      "pageHeader": {},
-    },
-    "c859d258-79c1-4448-bd52-12e4e414af92": {
-      "_id": "c859d258-79c1-4448-bd52-12e4e414af92",
-      "_outcomes": [
-        {
-          "displayName": "Email Sent",
-          "id": "EMAIL_SENT",
+        "ac343c95-8873-410e-823b-0931a71fc0c7": {
+          "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedPasswordNode",
+            "collection": true,
+            "name": "Platform Password",
+          },
+          "passwordAttribute": "password",
+          "validateInput": false,
         },
-        {
-          "displayName": "Email Not Sent",
-          "id": "EMAIL_NOT_SENT",
+        "fe762924-bc07-4f50-9234-17ab245efff1": {
+          "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
+          "_outcomes": [
+            {
+              "displayName": "Outcome",
+              "id": "outcome",
+            },
+          ],
+          "_type": {
+            "_id": "ValidatedUsernameNode",
+            "collection": true,
+            "name": "Platform Username",
+          },
+          "usernameAttribute": "userName",
+          "validateInput": false,
         },
-      ],
-      "_type": {
-        "_id": "EmailTemplateNode",
-        "collection": true,
-        "name": "Email Template Node",
       },
-      "emailAttribute": "mail",
-      "emailTemplateName": "welcome",
-      "identityAttribute": "userName",
-    },
-  },
-  "saml2Entities": {
-    "aVNQQXp1cmU": {
-      "_id": "aVNQQXp1cmU",
-      "entityId": "iSPAzure",
-      "entityLocation": "hosted",
-      "serviceProvider": {
-        "advanced": {
-          "ecpConfiguration": {
-            "ecpRequestIdpListFinderImpl": "com.sun.identity.saml2.plugins.ECPIDPFinder",
+      "nodes": {
+        "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
+          "_id": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "SocialProviderHandlerNode",
+            "collection": true,
+            "name": "Social Provider Handler Node",
           },
-          "idpProxy": {},
-          "relayStateUrlList": {},
-          "saeConfiguration": {
-            "spUrl": "https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure",
-          },
+          "clientType": "BROWSER",
+          "script": "58c824ae-84ed-4724-82cd-db128fc3f6c",
+          "usernameAttribute": "userName",
         },
-        "assertionContent": {
-          "assertionTimeSkew": 300,
-          "authenticationContext": {
-            "authContextItems": [
-              {
-                "contextReference": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
-                "defaultItem": true,
-                "level": 0,
-              },
-            ],
-            "authenticationComparisonType": "Exact",
-            "authenticationContextMapper": "com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper",
-            "includeRequestedAuthenticationContext": true,
+        "4951364c-59be-42cd-9cd7-79c9392214db": {
+          "_id": "4951364c-59be-42cd-9cd7-79c9392214db",
+          "_outcomes": [
+            {
+              "displayName": "known",
+              "id": "known",
+            },
+            {
+              "displayName": "unknown",
+              "id": "unknown",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
           },
-          "basicAuthentication": {},
-          "nameIdFormat": {
-            "nameIdFormatList": [
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
-            ],
-          },
-          "signingAndEncryption": {
-            "encryption": {},
-            "requestResponseSigning": {},
-            "secretIdAndAlgorithms": {},
-          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "known",
+            "unknown",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "739bdc48-fd24-4c52-b353-88706d75558a",
         },
-        "assertionProcessing": {
-          "accountMapping": {
-            "spAccountMapper": "com.sun.identity.saml2.plugins.DefaultSPAccountMapper",
-            "useNameIDAsSPUserID": true,
+        "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
+          "_id": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "TRUE",
+            },
+            {
+              "displayName": "False",
+              "id": "FALSE",
+            },
+            {
+              "displayName": "Locked",
+              "id": "LOCKED",
+            },
+            {
+              "displayName": "Cancelled",
+              "id": "CANCELLED",
+            },
+            {
+              "displayName": "Expired",
+              "id": "EXPIRED",
+            },
+          ],
+          "_type": {
+            "_id": "IdentityStoreDecisionNode",
+            "collection": true,
+            "name": "Identity Store Decision",
           },
-          "adapter": {
-            "spAdapterScript": "07ee6240-d106-4e25-a781-5fcabc477d22",
-          },
-          "attributeMapper": {
-            "attributeMap": [
-              {
-                "key": "http://schemas.microsoft.com/identity/claims/displayname",
-                "value": "cn",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-                "value": "givenName",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-                "value": "sn",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-                "value": "mail",
-              },
-              {
-                "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
-                "value": "uid",
-              },
-            ],
-            "attributeMapper": "com.sun.identity.saml2.plugins.DefaultSPAttributeMapper",
-          },
-          "autoFederation": {
-            "autoFedEnabled": false,
-          },
-          "responseArtifactMessageEncoding": {
-            "encoding": "URI",
-          },
-          "url": {},
+          "minimumPasswordLength": 8,
+          "mixedCaseForPasswordChangeMessages": false,
+          "useUniversalIdForUsername": true,
         },
-        "services": {
+        "650203c3-47f7-439d-a554-669cb7b08c57": {
+          "_id": "650203c3-47f7-439d-a554-669cb7b08c57",
+          "_outcomes": [
+            {
+              "displayName": "Account exists",
+              "id": "ACCOUNT_EXISTS",
+            },
+            {
+              "displayName": "No account exists",
+              "id": "NO_ACCOUNT",
+            },
+          ],
+          "_type": {
+            "_id": "product-Saml2Node",
+            "collection": true,
+            "name": "SAML2 Authentication",
+          },
+          "allowCreate": true,
+          "authComparison": "MINIMUM",
+          "authnContextClassRef": [],
+          "authnContextDeclRef": [],
+          "binding": "HTTP_ARTIFACT",
+          "forceAuthn": false,
+          "idpEntityId": "urn:federation:MicrosoftOnline",
+          "isPassive": false,
           "metaAlias": "/alpha/iSPAzure",
-          "serviceAttributes": {
-            "assertionConsumerService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
-                "index": 0,
-                "isDefault": true,
-                "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "index": 1,
-                "isDefault": false,
-                "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-                "index": 2,
-                "isDefault": false,
-                "location": "https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure",
-              },
-            ],
-            "nameIdService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                "location": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-                "location": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
-              },
-            ],
-            "singleLogoutService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                "location": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
-                "responseLocation": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
-              },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
-                "location": "https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure",
-              },
-            ],
-          },
+          "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+          "requestBinding": "HTTP_REDIRECT",
         },
-      },
-    },
-    "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l": {
-      "_id": "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l",
-      "base64EntityXML": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI_Pgo8RW50aXR5RGVzY3JpcHRvciBlbnRpdHlJRD0idXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5lIiBJRD0iX2U0NmExMTkzLWU4YTctNDhlZC04MDRmLTE1MTY3MjllY2I1ZiIgeG1sbnM9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDptZXRhZGF0YSIgeG1sbnM6cXVlcnk9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOm1ldGFkYXRhOmV4dDpxdWVyeSIgeG1sbnM6bWRhdHRyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphdHRyaWJ1dGUiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIHhtbG5zOnhlbmM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jIyIgeG1sbnM6eGVuYzExPSJodHRwOi8vd3d3LnczLm9yZy8yMDA5L3htbGVuYzExIyIgeG1sbnM6YWxnPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphbGdzdXBwb3J0IiB4bWxuczp4NTA5cXJ5PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTpYNTA5OnF1ZXJ5IiB4bWxuczpkcz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI-CiAgICA8RXh0ZW5zaW9ucz4KICAgICAgICA8YWxnOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNzaGExIi8-CiAgICAgICAgPGFsZzpTaWduaW5nTWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI3JzYS1zaGExIi8-CiAgICA8L0V4dGVuc2lvbnM-CiAgICA8U1BTU09EZXNjcmlwdG9yIFdhbnRBc3NlcnRpb25zU2lnbmVkPSJ0cnVlIiBwcm90b2NvbFN1cHBvcnRFbnVtZXJhdGlvbj0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRYmdESGZpM3QxSk5HVnF3RDUvN2xtakFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpBeE1qSXhNREF3TURBd1doY05NalV4TWpJeApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFERlQwLzAvMnFRdXJuWWEwTGJKSEY5WVlvemhFSDZyOW1DeFZEQlliZXcKU0c0dEdncldwc2V3US85NnBjY3pHTVFjdE12VStoMmVYMzhIeC9mOUpBSURidVJRelFsc1BoUVM3RERaNldsVFhVK3Q4ZC9nMkM3ZgpwU29MczRLVmRKaWg0eHlqTFVXaitCSy9panNSakJ0NFJpdzlWYkpIL0RkV0t5b1NNYkVDRWlFK3MxUnRMUC9lWW9NbU5meHlRR3FXCmlyQ05xVk5CVGxxellRcDRkZ0YwZm9ZeTRrdG94d21RT1ZvVGNJTUZZcDFJNHBGUEk3Q3h1TUxrZkswWDdhVGJNN1lHcGh2TWZKeEoKa2pyUWR5STdHNWQxdDRETmkzemtFYkJUN0ZHQXI2cVB0M0tuOXJhbHBxSktIZHBFQkE5TjB2TndRbzVYVFlJaFViUFExNklSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCUnM3dFBtZmtrc1NyNjdLdEVsSGpZWmJlYUNUakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCkpxd01aU2pRSjM2eCsxc3R5NkVlTEtRTFFld1F3UGFFQzQ3WnV0KzhiWGVkNlE4ak1aMGJmYS9NTTdYcXVFY2FiYU1aTFF1S0xmdDQKNFlYd1hYUU9mUXJJMnFqUXIzZVRvSkZsRFQ5aFIwcmZwOXdRcXR0RHhkNkFhNlJXd0RUZ281b0tVUUNUS0xIaEV5OHVXelNjSzBlRwp0MmQ3VFdUYURYalJTd05xNnRNN2ZSaFpzMDd0S0JWM3hmaTlFUXkvbWxhdkFNRlJCVm04Nk5TbzdBc09HMUlPTXEwM1Uzb29DV0FYCmg5UGR2dkhOZkhoSDE5ZnV0QW5DL0hlT2p3UkYxUWM1MjdhQk1waFlGUUxkaVRoZm1mbWlFL0FoUXFDd1oyb0U3dUNKaEJ0UitLYjEKWkdoakkzNXBIZnNTcUdpRmE3S3IrNWF2ZTgyMlBEY2tlODlNdmc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRTi9HUGVnblQ4YmxQMkVjU2RNTWJCekFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpFd01qRTRNREF3TURBd1doY05Nall3TWpFNApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEWGRMR1UyTGw1UlBkRFVuS1ErZi9IUzVxaVRheTJjQ2g5VTJBUzZvRE0KNlNPeFZoWUd0b2VKMVZQZWJjTG5wZ0xmaFB4enJ3V29WelhTRUYrVlJRYm5ZSUQySmI0a2hqZ3lFZW9UaGszVnFyVGh3aGFocFNiQgpnMnZvMDZ2SU9wMVRTMlIxQml3SEtUTG9CMWkxSUpuYUlGU0MzQk42cFk0ZmxYV3lMUXQvNUFCWEVsdjJYWkxxWE05RWVmajZKaTQwCm5MSXNpVzRkV3czQkRhL3l3V1cwTXNpVzVvakdxNHZvdmNBZ0VOZS80TlVianU3MGdIUC9XUzVEOWJXNXArT0lRaTcvdW5ybFdlL2gKM0E2anRCYmJSbFhZWGxOK1oyMnVUVHl5Q0QvVzh6ZVhhQUNMdkhhZ3dFTXJRZVBEWEJacWMvaVgya0krb29acjFzQy9IMzlSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCU3JYMmRtM0x3VDlqYi9wK2JBQWRZUXBFKy9OakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCmVxSmZZSG5zQTlxaEd0dFhGZkZwUFc0RFFMaDV3NkpDY2U3dkd2V0lOcjVmcjFEblFkY09yK3d3alEvdHFiY2tBTDJ2NnoxQXFqaFMKNzhrYmZlZ25BUUR3aW9KWjFvbFlZdkxPeEtvYTZIRitiMS9wME1sdWI4WnVrazJuMWIybEtQQkJPaWJPYXNTWTdnUUR3bElaaTd0bAo5bk1UeFVmZFlLK0U1QXh2N0RWbm1VQ3djbm5wVjUvMVNGZE55VzJrV080QzY4cnJqTU92RUNmd3JLa2JmVkpNOGY5a3JFVUJ1b0JGCjhkVER2N0QyWk00UTJidUM3ME5iZmFOV1VYMHlGdktJMEl1VHFrOFJCZkdUUlE0ZlpBYmhNUGF5a0VwQnU2ZE5qVGk1WU9hMGxOcUYKR1M3QXg3bGVDaDV4OWxWOGVsY0xrWHM4eVNvOEFPUUprMGhnSXc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRTi9HUGVnblQ4YmxQMkVjU2RNTWJCekFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpFd01qRTRNREF3TURBd1doY05Nall3TWpFNApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEWGRMR1UyTGw1UlBkRFVuS1ErZi9IUzVxaVRheTJjQ2g5VTJBUzZvRE0KNlNPeFZoWUd0b2VKMVZQZWJjTG5wZ0xmaFB4enJ3V29WelhTRUYrVlJRYm5ZSUQySmI0a2hqZ3lFZW9UaGszVnFyVGh3aGFocFNiQgpnMnZvMDZ2SU9wMVRTMlIxQml3SEtUTG9CMWkxSUpuYUlGU0MzQk42cFk0ZmxYV3lMUXQvNUFCWEVsdjJYWkxxWE05RWVmajZKaTQwCm5MSXNpVzRkV3czQkRhL3l3V1cwTXNpVzVvakdxNHZvdmNBZ0VOZS80TlVianU3MGdIUC9XUzVEOWJXNXArT0lRaTcvdW5ybFdlL2gKM0E2anRCYmJSbFhZWGxOK1oyMnVUVHl5Q0QvVzh6ZVhhQUNMdkhhZ3dFTXJRZVBEWEJacWMvaVgya0krb29acjFzQy9IMzlSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCU3JYMmRtM0x3VDlqYi9wK2JBQWRZUXBFKy9OakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCmVxSmZZSG5zQTlxaEd0dFhGZkZwUFc0RFFMaDV3NkpDY2U3dkd2V0lOcjVmcjFEblFkY09yK3d3alEvdHFiY2tBTDJ2NnoxQXFqaFMKNzhrYmZlZ25BUUR3aW9KWjFvbFlZdkxPeEtvYTZIRitiMS9wME1sdWI4WnVrazJuMWIybEtQQkJPaWJPYXNTWTdnUUR3bElaaTd0bAo5bk1UeFVmZFlLK0U1QXh2N0RWbm1VQ3djbm5wVjUvMVNGZE55VzJrV080QzY4cnJqTU92RUNmd3JLa2JmVkpNOGY5a3JFVUJ1b0JGCjhkVER2N0QyWk00UTJidUM3ME5iZmFOV1VYMHlGdktJMEl1VHFrOFJCZkdUUlE0ZlpBYmhNUGF5a0VwQnU2ZE5qVGk1WU9hMGxOcUYKR1M3QXg3bGVDaDV4OWxWOGVsY0xrWHM4eVNvOEFPUUprMGhnSXc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8U2luZ2xlTG9nb3V0U2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NUIiBMb2NhdGlvbj0iaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2xvZ2luLnNyZiIvPgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6ZW1haWxBZGRyZXNzPC9OYW1lSURGb3JtYXQ-CiAgICAgICAgPE5hbWVJREZvcm1hdD51cm46bWFjZTpzaGliYm9sZXRoOjEuMDpuYW1lSWRlbnRpZmllcjwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQ8L05hbWVJREZvcm1hdD4KICAgICAgICA8TmFtZUlERm9ybWF0PnVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpuYW1laWQtZm9ybWF0OnRyYW5zaWVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6cGVyc2lzdGVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxBc3NlcnRpb25Db25zdW1lclNlcnZpY2UgaW5kZXg9IjAiIGlzRGVmYXVsdD0idHJ1ZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vbG9naW4ubWljcm9zb2Z0b25saW5lLmNvbS9sb2dpbi5zcmYiLz4KICAgICAgICA8QXNzZXJ0aW9uQ29uc3VtZXJTZXJ2aWNlIGluZGV4PSIxIiBpc0RlZmF1bHQ9ImZhbHNlIiBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NULVNpbXBsZVNpZ24iIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICAgICAgPEFzc2VydGlvbkNvbnN1bWVyU2VydmljZSBpbmRleD0iMiIgaXNEZWZhdWx0PSJmYWxzZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOlBBT1MiIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICA8L1NQU1NPRGVzY3JpcHRvcj4KPC9FbnRpdHlEZXNjcmlwdG9yPgoK",
-      "entityId": "urn:federation:MicrosoftOnline",
-      "entityLocation": "remote",
-      "serviceProvider": {
-        "advanced": {
-          "idpProxy": {},
-          "saeConfiguration": {},
-        },
-        "assertionContent": {
-          "basicAuthentication": {},
-          "nameIdFormat": {
-            "nameIdFormatList": [
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-              "urn:mace:shibboleth:1.0:nameIdentifier",
-              "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-              "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-            ],
-          },
-          "signingAndEncryption": {
-            "encryption": {},
-            "requestResponseSigning": {
-              "assertion": true,
+        "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
+          "_id": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
             },
-            "secretIdAndAlgorithms": {},
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "fe762924-bc07-4f50-9234-17ab245efff1",
+              "displayName": "Username",
+              "nodeType": "ValidatedUsernameNode",
+            },
+            {
+              "_id": "051c1939-7dd5-4cf1-866e-48f57541b6ac",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "28595125-e97a-40e7-aa3c-bebdb6821949",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
+        },
+        "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
+          "_id": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
+          "_outcomes": [
+            {
+              "displayName": "Social Authentication",
+              "id": "socialAuthentication",
+            },
+            {
+              "displayName": "Local Authentication",
+              "id": "localAuthentication",
+            },
+          ],
+          "_type": {
+            "_id": "PageNode",
+            "collection": true,
+            "name": "Page Node",
+          },
+          "nodes": [
+            {
+              "_id": "ac343c95-8873-410e-823b-0931a71fc0c7",
+              "displayName": "Password",
+              "nodeType": "ValidatedPasswordNode",
+            },
+            {
+              "_id": "9d19d94c-77b1-4386-9c5d-8a2e39e3f5b4",
+              "displayName": "Select IDP",
+              "nodeType": "SelectIdPNode",
+            },
+          ],
+          "pageDescription": {},
+          "pageHeader": {},
+        },
+        "c859d258-79c1-4448-bd52-12e4e414af92": {
+          "_id": "c859d258-79c1-4448-bd52-12e4e414af92",
+          "_outcomes": [
+            {
+              "displayName": "Email Sent",
+              "id": "EMAIL_SENT",
+            },
+            {
+              "displayName": "Email Not Sent",
+              "id": "EMAIL_NOT_SENT",
+            },
+          ],
+          "_type": {
+            "_id": "EmailTemplateNode",
+            "collection": true,
+            "name": "Email Template Node",
+          },
+          "emailAttribute": "mail",
+          "emailTemplateName": "welcome",
+          "identityAttribute": "userName",
+        },
+      },
+      "saml2Entities": {
+        "aVNQQXp1cmU": {
+          "_id": "aVNQQXp1cmU",
+          "entityId": "iSPAzure",
+          "entityLocation": "hosted",
+          "serviceProvider": {
+            "advanced": {
+              "ecpConfiguration": {
+                "ecpRequestIdpListFinderImpl": "com.sun.identity.saml2.plugins.ECPIDPFinder",
+              },
+              "idpProxy": {},
+              "relayStateUrlList": {},
+              "saeConfiguration": {
+                "spUrl": "https://idc.scheuber.io/am/spsaehandler/metaAlias/alpha/iSPAzure",
+              },
+            },
+            "assertionContent": {
+              "assertionTimeSkew": 300,
+              "authenticationContext": {
+                "authContextItems": [
+                  {
+                    "contextReference": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+                    "defaultItem": true,
+                    "level": 0,
+                  },
+                ],
+                "authenticationComparisonType": "Exact",
+                "authenticationContextMapper": "com.sun.identity.saml2.plugins.DefaultSPAuthnContextMapper",
+                "includeRequestedAuthenticationContext": true,
+              },
+              "basicAuthentication": {},
+              "nameIdFormat": {
+                "nameIdFormatList": [
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
+                ],
+              },
+              "signingAndEncryption": {
+                "encryption": {},
+                "requestResponseSigning": {},
+                "secretIdAndAlgorithms": {},
+              },
+            },
+            "assertionProcessing": {
+              "accountMapping": {
+                "spAccountMapper": "com.sun.identity.saml2.plugins.DefaultSPAccountMapper",
+                "useNameIDAsSPUserID": true,
+              },
+              "adapter": {
+                "spAdapterScript": "07ee6240-d106-4e25-a781-5fcabc477d22",
+              },
+              "attributeMapper": {
+                "attributeMap": [
+                  {
+                    "key": "http://schemas.microsoft.com/identity/claims/displayname",
+                    "value": "cn",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+                    "value": "givenName",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+                    "value": "sn",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+                    "value": "mail",
+                  },
+                  {
+                    "key": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+                    "value": "uid",
+                  },
+                ],
+                "attributeMapper": "com.sun.identity.saml2.plugins.DefaultSPAttributeMapper",
+              },
+              "autoFederation": {
+                "autoFedEnabled": false,
+              },
+              "responseArtifactMessageEncoding": {
+                "encoding": "URI",
+              },
+              "url": {},
+            },
+            "services": {
+              "metaAlias": "/alpha/iSPAzure",
+              "serviceAttributes": {
+                "assertionConsumerService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact",
+                    "index": 0,
+                    "isDefault": true,
+                    "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "index": 1,
+                    "isDefault": false,
+                    "location": "https://idc.scheuber.io/am/AuthConsumer/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
+                    "index": 2,
+                    "isDefault": false,
+                    "location": "https://idc.scheuber.io/am/Consumer/ECP/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+                "nameIdService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "location": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniRedirect/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniPOST/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+                    "location": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPMniSoap/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+                "singleLogoutService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                    "location": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPSloRedirect/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
+                    "responseLocation": "https://idc.scheuber.io/am/SPSloPOST/metaAlias/alpha/iSPAzure",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:SOAP",
+                    "location": "https://idc.scheuber.io/am/SPSloSoap/metaAlias/alpha/iSPAzure",
+                  },
+                ],
+              },
+            },
           },
         },
-        "assertionProcessing": {
-          "attributeMapper": {},
-          "responseArtifactMessageEncoding": {},
-        },
-        "services": {
-          "serviceAttributes": {
-            "assertionConsumerService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "index": 0,
-                "isDefault": true,
-                "location": "https://login.microsoftonline.com/login.srf",
+        "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l": {
+          "_id": "dXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5l",
+          "base64EntityXML": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI_Pgo8RW50aXR5RGVzY3JpcHRvciBlbnRpdHlJRD0idXJuOmZlZGVyYXRpb246TWljcm9zb2Z0T25saW5lIiBJRD0iX2U0NmExMTkzLWU4YTctNDhlZC04MDRmLTE1MTY3MjllY2I1ZiIgeG1sbnM9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDptZXRhZGF0YSIgeG1sbnM6cXVlcnk9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOm1ldGFkYXRhOmV4dDpxdWVyeSIgeG1sbnM6bWRhdHRyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphdHRyaWJ1dGUiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIHhtbG5zOnhlbmM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jIyIgeG1sbnM6eGVuYzExPSJodHRwOi8vd3d3LnczLm9yZy8yMDA5L3htbGVuYzExIyIgeG1sbnM6YWxnPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTphbGdzdXBwb3J0IiB4bWxuczp4NTA5cXJ5PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDptZXRhZGF0YTpYNTA5OnF1ZXJ5IiB4bWxuczpkcz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI-CiAgICA8RXh0ZW5zaW9ucz4KICAgICAgICA8YWxnOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNzaGExIi8-CiAgICAgICAgPGFsZzpTaWduaW5nTWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI3JzYS1zaGExIi8-CiAgICA8L0V4dGVuc2lvbnM-CiAgICA8U1BTU09EZXNjcmlwdG9yIFdhbnRBc3NlcnRpb25zU2lnbmVkPSJ0cnVlIiBwcm90b2NvbFN1cHBvcnRFbnVtZXJhdGlvbj0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRYmdESGZpM3QxSk5HVnF3RDUvN2xtakFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpBeE1qSXhNREF3TURBd1doY05NalV4TWpJeApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFERlQwLzAvMnFRdXJuWWEwTGJKSEY5WVlvemhFSDZyOW1DeFZEQlliZXcKU0c0dEdncldwc2V3US85NnBjY3pHTVFjdE12VStoMmVYMzhIeC9mOUpBSURidVJRelFsc1BoUVM3RERaNldsVFhVK3Q4ZC9nMkM3ZgpwU29MczRLVmRKaWg0eHlqTFVXaitCSy9panNSakJ0NFJpdzlWYkpIL0RkV0t5b1NNYkVDRWlFK3MxUnRMUC9lWW9NbU5meHlRR3FXCmlyQ05xVk5CVGxxellRcDRkZ0YwZm9ZeTRrdG94d21RT1ZvVGNJTUZZcDFJNHBGUEk3Q3h1TUxrZkswWDdhVGJNN1lHcGh2TWZKeEoKa2pyUWR5STdHNWQxdDRETmkzemtFYkJUN0ZHQXI2cVB0M0tuOXJhbHBxSktIZHBFQkE5TjB2TndRbzVYVFlJaFViUFExNklSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCUnM3dFBtZmtrc1NyNjdLdEVsSGpZWmJlYUNUakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCkpxd01aU2pRSjM2eCsxc3R5NkVlTEtRTFFld1F3UGFFQzQ3WnV0KzhiWGVkNlE4ak1aMGJmYS9NTTdYcXVFY2FiYU1aTFF1S0xmdDQKNFlYd1hYUU9mUXJJMnFqUXIzZVRvSkZsRFQ5aFIwcmZwOXdRcXR0RHhkNkFhNlJXd0RUZ281b0tVUUNUS0xIaEV5OHVXelNjSzBlRwp0MmQ3VFdUYURYalJTd05xNnRNN2ZSaFpzMDd0S0JWM3hmaTlFUXkvbWxhdkFNRlJCVm04Nk5TbzdBc09HMUlPTXEwM1Uzb29DV0FYCmg5UGR2dkhOZkhoSDE5ZnV0QW5DL0hlT2p3UkYxUWM1MjdhQk1waFlGUUxkaVRoZm1mbWlFL0FoUXFDd1oyb0U3dUNKaEJ0UitLYjEKWkdoakkzNXBIZnNTcUdpRmE3S3IrNWF2ZTgyMlBEY2tlODlNdmc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRTi9HUGVnblQ4YmxQMkVjU2RNTWJCekFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpFd01qRTRNREF3TURBd1doY05Nall3TWpFNApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEWGRMR1UyTGw1UlBkRFVuS1ErZi9IUzVxaVRheTJjQ2g5VTJBUzZvRE0KNlNPeFZoWUd0b2VKMVZQZWJjTG5wZ0xmaFB4enJ3V29WelhTRUYrVlJRYm5ZSUQySmI0a2hqZ3lFZW9UaGszVnFyVGh3aGFocFNiQgpnMnZvMDZ2SU9wMVRTMlIxQml3SEtUTG9CMWkxSUpuYUlGU0MzQk42cFk0ZmxYV3lMUXQvNUFCWEVsdjJYWkxxWE05RWVmajZKaTQwCm5MSXNpVzRkV3czQkRhL3l3V1cwTXNpVzVvakdxNHZvdmNBZ0VOZS80TlVianU3MGdIUC9XUzVEOWJXNXArT0lRaTcvdW5ybFdlL2gKM0E2anRCYmJSbFhZWGxOK1oyMnVUVHl5Q0QvVzh6ZVhhQUNMdkhhZ3dFTXJRZVBEWEJacWMvaVgya0krb29acjFzQy9IMzlSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCU3JYMmRtM0x3VDlqYi9wK2JBQWRZUXBFKy9OakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCmVxSmZZSG5zQTlxaEd0dFhGZkZwUFc0RFFMaDV3NkpDY2U3dkd2V0lOcjVmcjFEblFkY09yK3d3alEvdHFiY2tBTDJ2NnoxQXFqaFMKNzhrYmZlZ25BUUR3aW9KWjFvbFlZdkxPeEtvYTZIRitiMS9wME1sdWI4WnVrazJuMWIybEtQQkJPaWJPYXNTWTdnUUR3bElaaTd0bAo5bk1UeFVmZFlLK0U1QXh2N0RWbm1VQ3djbm5wVjUvMVNGZE55VzJrV080QzY4cnJqTU92RUNmd3JLa2JmVkpNOGY5a3JFVUJ1b0JGCjhkVER2N0QyWk00UTJidUM3ME5iZmFOV1VYMHlGdktJMEl1VHFrOFJCZkdUUlE0ZlpBYmhNUGF5a0VwQnU2ZE5qVGk1WU9hMGxOcUYKR1M3QXg3bGVDaDV4OWxWOGVsY0xrWHM4eVNvOEFPUUprMGhnSXc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgogICAgICAgICAgICA8ZHM6S2V5SW5mbz4KICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgPGRzOlg1MDlEYXRhPgogICAgICAgICAgICAgICAgICAgIDxkczpYNTA5Q2VydGlmaWNhdGU-Ck1JSUMvVENDQWVXZ0F3SUJBZ0lRTi9HUGVnblQ4YmxQMkVjU2RNTWJCekFOQmdrcWhraUc5dzBCQVFzRkFEQXBNU2N3SlFZRFZRUUQKRXg1TWFYWmxJRWxFSUZOVVV5QlRhV2R1YVc1bklGQjFZbXhwWXlCTFpYa3dIaGNOTWpFd01qRTRNREF3TURBd1doY05Nall3TWpFNApNREF3TURBd1dqQXBNU2N3SlFZRFZRUURFeDVNYVhabElFbEVJRk5VVXlCVGFXZHVhVzVuSUZCMVlteHBZeUJMWlhrd2dnRWlNQTBHCkNTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEWGRMR1UyTGw1UlBkRFVuS1ErZi9IUzVxaVRheTJjQ2g5VTJBUzZvRE0KNlNPeFZoWUd0b2VKMVZQZWJjTG5wZ0xmaFB4enJ3V29WelhTRUYrVlJRYm5ZSUQySmI0a2hqZ3lFZW9UaGszVnFyVGh3aGFocFNiQgpnMnZvMDZ2SU9wMVRTMlIxQml3SEtUTG9CMWkxSUpuYUlGU0MzQk42cFk0ZmxYV3lMUXQvNUFCWEVsdjJYWkxxWE05RWVmajZKaTQwCm5MSXNpVzRkV3czQkRhL3l3V1cwTXNpVzVvakdxNHZvdmNBZ0VOZS80TlVianU3MGdIUC9XUzVEOWJXNXArT0lRaTcvdW5ybFdlL2gKM0E2anRCYmJSbFhZWGxOK1oyMnVUVHl5Q0QvVzh6ZVhhQUNMdkhhZ3dFTXJRZVBEWEJacWMvaVgya0krb29acjFzQy9IMzlSQWdNQgpBQUdqSVRBZk1CMEdBMVVkRGdRV0JCU3JYMmRtM0x3VDlqYi9wK2JBQWRZUXBFKy9OakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBCmVxSmZZSG5zQTlxaEd0dFhGZkZwUFc0RFFMaDV3NkpDY2U3dkd2V0lOcjVmcjFEblFkY09yK3d3alEvdHFiY2tBTDJ2NnoxQXFqaFMKNzhrYmZlZ25BUUR3aW9KWjFvbFlZdkxPeEtvYTZIRitiMS9wME1sdWI4WnVrazJuMWIybEtQQkJPaWJPYXNTWTdnUUR3bElaaTd0bAo5bk1UeFVmZFlLK0U1QXh2N0RWbm1VQ3djbm5wVjUvMVNGZE55VzJrV080QzY4cnJqTU92RUNmd3JLa2JmVkpNOGY5a3JFVUJ1b0JGCjhkVER2N0QyWk00UTJidUM3ME5iZmFOV1VYMHlGdktJMEl1VHFrOFJCZkdUUlE0ZlpBYmhNUGF5a0VwQnU2ZE5qVGk1WU9hMGxOcUYKR1M3QXg3bGVDaDV4OWxWOGVsY0xrWHM4eVNvOEFPUUprMGhnSXc9PQogICAgICAgICAgICAgICAgICAgIDwvZHM6WDUwOUNlcnRpZmljYXRlPgogICAgICAgICAgICAgICAgPC9kczpYNTA5RGF0YT4KICAgICAgICAgICAgPC9kczpLZXlJbmZvPgogICAgICAgIDwvS2V5RGVzY3JpcHRvcj4KICAgICAgICA8U2luZ2xlTG9nb3V0U2VydmljZSBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NUIiBMb2NhdGlvbj0iaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2xvZ2luLnNyZiIvPgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6ZW1haWxBZGRyZXNzPC9OYW1lSURGb3JtYXQ-CiAgICAgICAgPE5hbWVJREZvcm1hdD51cm46bWFjZTpzaGliYm9sZXRoOjEuMDpuYW1lSWRlbnRpZmllcjwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQ8L05hbWVJREZvcm1hdD4KICAgICAgICA8TmFtZUlERm9ybWF0PnVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpuYW1laWQtZm9ybWF0OnRyYW5zaWVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxOYW1lSURGb3JtYXQ-dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6cGVyc2lzdGVudDwvTmFtZUlERm9ybWF0PgogICAgICAgIDxBc3NlcnRpb25Db25zdW1lclNlcnZpY2UgaW5kZXg9IjAiIGlzRGVmYXVsdD0idHJ1ZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vbG9naW4ubWljcm9zb2Z0b25saW5lLmNvbS9sb2dpbi5zcmYiLz4KICAgICAgICA8QXNzZXJ0aW9uQ29uc3VtZXJTZXJ2aWNlIGluZGV4PSIxIiBpc0RlZmF1bHQ9ImZhbHNlIiBCaW5kaW5nPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YmluZGluZ3M6SFRUUC1QT1NULVNpbXBsZVNpZ24iIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICAgICAgPEFzc2VydGlvbkNvbnN1bWVyU2VydmljZSBpbmRleD0iMiIgaXNEZWZhdWx0PSJmYWxzZSIgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOlBBT1MiIExvY2F0aW9uPSJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vbG9naW4uc3JmIi8-CiAgICA8L1NQU1NPRGVzY3JpcHRvcj4KPC9FbnRpdHlEZXNjcmlwdG9yPgoK",
+          "entityId": "urn:federation:MicrosoftOnline",
+          "entityLocation": "remote",
+          "serviceProvider": {
+            "advanced": {
+              "idpProxy": {},
+              "saeConfiguration": {},
+            },
+            "assertionContent": {
+              "basicAuthentication": {},
+              "nameIdFormat": {
+                "nameIdFormatList": [
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+                  "urn:mace:shibboleth:1.0:nameIdentifier",
+                  "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+                  "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+                ],
               },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
-                "index": 1,
-                "isDefault": false,
-                "location": "https://login.microsoftonline.com/login.srf",
+              "signingAndEncryption": {
+                "encryption": {},
+                "requestResponseSigning": {
+                  "assertion": true,
+                },
+                "secretIdAndAlgorithms": {},
               },
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
-                "index": 2,
-                "isDefault": false,
-                "location": "https://login.microsoftonline.com/login.srf",
+            },
+            "assertionProcessing": {
+              "attributeMapper": {},
+              "responseArtifactMessageEncoding": {},
+            },
+            "services": {
+              "serviceAttributes": {
+                "assertionConsumerService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "index": 0,
+                    "isDefault": true,
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign",
+                    "index": 1,
+                    "isDefault": false,
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:PAOS",
+                    "index": 2,
+                    "isDefault": false,
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                ],
+                "singleLogoutService": [
+                  {
+                    "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    "location": "https://login.microsoftonline.com/login.srf",
+                  },
+                ],
               },
-            ],
-            "singleLogoutService": [
-              {
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                "location": "https://login.microsoftonline.com/login.srf",
-              },
-            ],
+            },
           },
         },
       },
-    },
-  },
-  "scripts": {
-    "23143919-6b78-40c3-b25e-beca19b229e0": {
-      "_id": "23143919-6b78-40c3-b25e-beca19b229e0",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from GitHub",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "GitHub Profile Normalization (VS)",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"GitHub rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
-    },
-    "484e6246-dbc6-4288-97e6-54e55431402e": {
-      "_id": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Apple",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Apple Profile Normalization",
-      "script": ""/*\\n * Copyright 2021-2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n *\\n * In some common default configurations, the following keys are required to be not empty:\\n * username, givenName, familyName, email.\\n *\\n * From RFC4517: A value of the Directory String syntax is a string of one or more\\n * arbitrary characters from the Universal Character Set (UCS).\\n * A zero-length character string is not permitted.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nString email = \\"change@me.com\\"\\nString subjectId = rawProfile.sub\\nString firstName = \\" \\"\\nString lastName = \\" \\"\\nString username = subjectId\\nString name\\n\\nif (rawProfile.isDefined(\\"email\\") && rawProfile.email.isNotNull()){ // User can elect to not share their email\\n    email = rawProfile.email.asString()\\n    username = email\\n}\\nif (rawProfile.isDefined(\\"name\\") && rawProfile.name.isNotNull()) {\\n    if (rawProfile.name.isDefined(\\"firstName\\") && rawProfile.name.firstName.isNotNull()) {\\n        firstName = rawProfile.name.firstName.asString()\\n    }\\n    if (rawProfile.name.isDefined(\\"lastName\\") && rawProfile.name.lastName.isNotNull()) {\\n        lastName = rawProfile.name.lastName.asString()\\n    }\\n}\\n\\nname = (firstName?.trim() ? firstName : \\"\\") + (lastName?.trim() ? ((firstName?.trim() ? \\" \\" : \\"\\") + lastName) : \\"\\")\\nname =  (!name?.trim()) ? \\" \\" : name\\n\\nreturn json(object(\\n        field(\\"id\\", subjectId),\\n        field(\\"displayName\\", name),\\n        field(\\"email\\", email),\\n        field(\\"givenName\\", firstName),\\n        field(\\"familyName\\", lastName),\\n        field(\\"username\\", username)))"",
-    },
-    "58c824ae-84ed-4724-82cd-db128fc3f6c": {
-      "_id": "58c824ae-84ed-4724-82cd-db128fc3f6c",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Converts a normalized social profile into a managed user",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Normalized Profile to Managed User",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nimport org.forgerock.json.JsonValue\\n\\nJsonValue managedUser = json(object(\\n        field(\\"givenName\\", normalizedProfile.givenName),\\n        field(\\"sn\\", normalizedProfile.familyName),\\n        field(\\"mail\\", normalizedProfile.email),\\n        field(\\"userName\\", normalizedProfile.username)))\\n\\nif (normalizedProfile.postalAddress.isNotNull()) managedUser.put(\\"postalAddress\\", normalizedProfile.postalAddress)\\nif (normalizedProfile.addressLocality.isNotNull()) managedUser.put(\\"city\\", normalizedProfile.addressLocality)\\nif (normalizedProfile.addressRegion.isNotNull()) managedUser.put(\\"stateProvince\\", normalizedProfile.addressRegion)\\nif (normalizedProfile.postalCode.isNotNull()) managedUser.put(\\"postalCode\\", normalizedProfile.postalCode)\\nif (normalizedProfile.country.isNotNull()) managedUser.put(\\"country\\", normalizedProfile.country)\\nif (normalizedProfile.phone.isNotNull()) managedUser.put(\\"telephoneNumber\\", normalizedProfile.phone)\\n\\n// if the givenName and familyName is null or empty\\n// then add a boolean flag to the shared state to indicate names are not present\\n// this could be used elsewhere\\n// for eg. this could be used in a scripted decision node to by-pass patching\\n// the user object with blank values when givenName  and familyName is not present\\nboolean noGivenName = normalizedProfile.givenName.isNull() || (!normalizedProfile.givenName.asString()?.trim())\\nboolean noFamilyName = normalizedProfile.familyName.isNull() || (!normalizedProfile.familyName.asString()?.trim())\\nsharedState.put(\\"nameEmptyOrNull\\", noGivenName && noFamilyName)\\n\\nreturn managedUser\\n"",
-    },
-    "58d29080-4563-480b-89bb-1e7719776a21": {
-      "_id": "58d29080-4563-480b-89bb-1e7719776a21",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Google",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Google Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.sub),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.given_name),\\n        field(\\"familyName\\", rawProfile.family_name),\\n        field(\\"photoUrl\\", rawProfile.picture),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email),\\n        field(\\"locale\\", rawProfile.locale)))"",
-    },
-    "6325cf19-a49b-471e-8d26-7e4df76df0e2": {
-      "_id": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from GitHub",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Okta Profile Normalization",
-      "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"Okta rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.preferred_username)))"",
-    },
-    "739bdc48-fd24-4c52-b353-88706d75558a": {
-      "_id": "739bdc48-fd24-4c52-b353-88706d75558a",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Check if username has already been collected.",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Check Username",
-      "script": ""/* Check Username\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Check if username has already been collected.\\n * Return \\"known\\" if yes, \\"unknown\\" otherwise.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - known\\n * - unknown\\n */\\n(function () {\\n    if (null != sharedState.get(\\"username\\")) {\\n        outcome = \\"known\\";\\n    }\\n    else {\\n        outcome = \\"unknown\\";\\n    }\\n}());"",
-    },
-    "73cecbfc-dad0-4395-be6a-6858ee3a80e5": {
-      "_id": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Microsoft",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Microsoft Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n{\\n    \\"@odata.context\\": \\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\\",\\n    \\"@odata.id\\": \\"https://graph.microsoft.com/v2/711ffa9c-5972-4713-ace3-688c9732614a/directoryObjects/7d7759e2-36d8-4e64-b173-3f890d7d46d6/Microsoft.DirectoryServices.User\\",\\n    \\"businessPhones\\": [\\n        \\"18014735451\\"\\n    ],\\n    \\"displayName\\": \\"Volker Scheuber\\",\\n    \\"givenName\\": \\"Volker\\",\\n    \\"jobTitle\\": null,\\n    \\"mail\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"mobilePhone\\": null,\\n    \\"officeLocation\\": null,\\n    \\"preferredLanguage\\": null,\\n    \\"surname\\": \\"Scheuber\\",\\n    \\"userPrincipalName\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"id\\": \\"7d7759e2-36d8-4e64-b173-3f890d7d46d6\\"\\n}\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.message(\\"Kauai Microsoft Profile Normalization: rawProfile={}\\", rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.displayName),\\n        field(\\"givenName\\", rawProfile.givenName),\\n        field(\\"familyName\\", rawProfile.surname),\\n        field(\\"email\\", rawProfile.userPrincipalName),\\n        field(\\"username\\", rawProfile.userPrincipalName),\\n        field(\\"groups\\", rawProfile.groups)))"",
-    },
-    "bae1d54a-e97d-4997-aa5d-c027f21af82c": {
-      "_id": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": true,
-      "description": "Normalizes raw profile data from Facebook",
-      "evaluatorVersion": "1.0",
-      "language": "GROOVY",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "Facebook Profile Normalization",
-      "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
-    },
-    "dbe0bf9a-72aa-49d5-8483-9db147985a47": {
-      "_id": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
-      "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Normalizes raw profile data from ADFS",
-      "evaluatorVersion": "1.0",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "ADFS Profile Normalization (JS)",
-      "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n * This script returns the social identity profile information for the authenticating user\\n * in a standard form expected by the Social Provider Handler Node.\\n *\\n * Defined variables:\\n * rawProfile - The social identity provider profile information for the authenticating user.\\n *              JsonValue (1).\\n * logger - The debug logger instance:\\n *          https://backstage.forgerock.com/docs/am/7/scripting-guide/scripting-api-global-logger.html#scripting-api-global-logger.\\n * realm - String (primitive).\\n *         The name of the realm the user is authenticating to.\\n * requestHeaders - TreeMap (2).\\n *                  The object that provides methods for accessing headers in the login request:\\n *                  https://backstage.forgerock.com/docs/am/7/authentication-guide/scripting-api-node.html#scripting-api-node-requestHeaders.\\n * requestParameters - TreeMap (2).\\n *                     The object that contains the authentication request parameters.\\n * selectedIdp - String (primitive).\\n *               The social identity provider name. For example: google.\\n * sharedState - LinkedHashMap (3).\\n *               The object that holds the state of the authentication tree and allows data exchange between the stateless nodes:\\n *               https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n * transientState - LinkedHashMap (3).\\n *                  The object for storing sensitive information that must not leave the server unencrypted,\\n *                  and that may not need to persist between authentication requests during the authentication session:\\n *                  https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n *\\n * Return - a JsonValue (1).\\n *          The result of the last statement in the script is returned to the server.\\n *          Currently, the Immediately Invoked Function Expression (also known as Self-Executing Anonymous Function)\\n *          is the last (and only) statement in this script, and its return value will become the script result.\\n *          Do not use \\"return variable\\" statement outside of a function definition.\\n *\\n *          This script's last statement should result in a JsonValue (1) with the following keys:\\n *          {\\n *              {\\"displayName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"email\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"familyName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"givenName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"id\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"locale\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"photoUrl\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"username\\": \\"corresponding-social-identity-provider-value\\"}\\n *          }\\n *\\n *          The consumer of this data defines which keys are required and which are optional.\\n *          For example, the script associated with the Social Provider Handler Node and,\\n *          ultimately, the managed object created/updated with this data\\n *          will expect certain keys to be populated.\\n *          In some common default configurations, the following keys are required to be not empty:\\n *          username, givenName, familyName, email.\\n *\\n *          From RFC4517: A value of the Directory String syntax is a string of one or more\\n *          arbitrary characters from the Universal Character Set (UCS).\\n *          A zero-length character string is not permitted.\\n *\\n * (1) JsonValue - https://backstage.forgerock.com/docs/am/7/apidocs/org/forgerock/json/JsonValue.html.\\n * (2) TreeMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/TreeMap.html.\\n * (3) LinkedHashMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/LinkedHashMap.html.\\n */\\n\\n(function () {\\n    var frJava = JavaImporter(\\n        org.forgerock.json.JsonValue\\n    );\\n\\n    var normalizedProfileData = frJava.JsonValue.json(frJava.JsonValue.object());\\n  \\n  \\t//logger.message('Seguin rawProfile: '+rawProfile);\\n\\n    normalizedProfileData.put('id', rawProfile.get('sub').asString());\\n    normalizedProfileData.put('displayName', rawProfile.get('givenName').asString() + ' ' + rawProfile.get('sn').asString());\\n    normalizedProfileData.put('email', rawProfile.get('mail').asString());\\n    normalizedProfileData.put('givenName', rawProfile.get('givenName').asString());\\n    normalizedProfileData.put('familyName', rawProfile.get('sn').asString());\\n    normalizedProfileData.put('username', rawProfile.get('upn').asString());\\n    normalizedProfileData.put('roles', rawProfile.get('roles').asString());\\n  \\n  \\t//logger.message('Seguin normalizedProfileData: '+normalizedProfileData);\\n\\n    return normalizedProfileData;\\n}());"",
-    },
-  },
-  "socialIdentityProviders": {
-    "adfs": {
-      "_id": "adfs",
-      "_type": {
-        "_id": "oidcConfig",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OpenID Connect specification.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "aa9a179e-cdba-4db8-8477-3d1069d5ec04",
-      "clientSecret": null,
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://adfs.mytestrun.com/adfs",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://adfs.mytestrun.com/adfs/discovery/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "RS256",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/token",
-      "transform": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonDisplayName": "Microsoft ADFS",
-        "buttonImage": "/login/images/microsoft-logo.png",
-        "iconBackground": "#0078d7",
-        "iconClass": "fa-windows",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://adfs.mytestrun.com/adfs/.well-known/openid-configuration",
-    },
-    "apple-stoyan": {
-      "_id": "apple-stoyan",
-      "_type": {
-        "_id": "appleConfig",
-        "collection": true,
-        "name": "Client configuration for Apple.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "CHANGE ME",
-      "clientSecret": null,
-      "enableNativeNonce": true,
-      "enabled": false,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://appleid.apple.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectAfterFormPostURI": "https://openam-volker-dev.forgeblocks.com/login",
-      "redirectURI": "https://openam-volker-dev.forgeblocks.com/am/oauth2/alpha/client/form_post/apple-stoyan",
-      "requestNativeAppForUserInfo": false,
-      "responseMode": "FORM_POST",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "name",
-        "email",
-      ],
-      "tokenEndpoint": "https://appleid.apple.com/auth/token",
-      "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonDisplayName": "Apple",
-        "buttonImage": "/login/images/apple-logo.png",
-        "iconBackground": "#000000",
-        "iconClass": "fa-apple",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
-    },
-    "apple_web": {
-      "_id": "apple_web",
-      "_type": {
-        "_id": "appleConfig",
-        "collection": true,
-        "name": "Client configuration for Apple.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "io.scheuber.idc.signinWithApple.service",
-      "clientSecret": null,
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://appleid.apple.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectAfterFormPostURI": "https://idc.scheuber.io/login",
-      "redirectURI": "https://idc.scheuber.io/am/oauth2/client/form_post/apple_web",
-      "requestNativeAppForUserInfo": false,
-      "responseMode": "FORM_POST",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "name",
-        "email",
-      ],
-      "tokenEndpoint": "https://appleid.apple.com/auth/token",
-      "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
-        "buttonDisplayName": "Apple",
-        "buttonImage": "/login/images/apple-logo.png",
-        "iconBackground": "#000000",
-        "iconClass": "fa-apple",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
-    },
-    "azure": {
-      "_id": "azure",
-      "_type": {
-        "_id": "microsoftConfig",
-        "collection": true,
-        "name": "Client configuration for Microsoft.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "c42a3dc8-f276-496b-a722-269f131cc21c",
-      "clientSecret": null,
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "User.Read",
-        "openid",
-      ],
-      "tokenEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/token",
-      "transform": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
-        "buttonDisplayName": "Microsoft Azure",
-        "buttonImage": "/login/images/microsoft-logo.png",
-        "iconBackground": "#0078d7",
-        "iconClass": "fa-windows",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://graph.microsoft.com/v1.0/me",
-    },
-    "facebook": {
-      "_id": "facebook",
-      "_type": {
-        "_id": "oauth2Config",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OAuth2 specification.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://www.facebook.com/dialog/oauth",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "123741918345526",
-      "clientSecret": null,
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 3600,
-      "redirectURI": "https://idc.scheuber.io/am/XUI/?realm=%2Falpha",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "email",
-      ],
-      "tokenEndpoint": "https://graph.facebook.com/v2.7/oauth/access_token",
-      "transform": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
-      "uiConfig": {
-        "buttonClass": "fa-facebook-official",
-        "buttonCustomStyle": "background-color: #3b5998; border-color: #3b5998; color: white;",
-        "buttonCustomStyleHover": "background-color: #334b7d; border-color: #334b7d; color: white;",
-        "buttonDisplayName": "Facebook",
-        "buttonImage": "",
-        "iconBackground": "#3b5998",
-        "iconClass": "fa-facebook",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://graph.facebook.com/me?fields=id,name,picture,email,first_name,last_name,locale",
-    },
-    "github": {
-      "_id": "github",
-      "_type": {
-        "_id": "oauth2Config",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OAuth2 specification.",
-      },
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://github.com/login/oauth/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "bdae6d141d4dcf95a630",
-      "clientSecret": null,
-      "enabled": true,
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "user",
-      ],
-      "tokenEndpoint": "https://ig.mytestrun.com/login/oauth/access_token",
-      "transform": "23143919-6b78-40c3-b25e-beca19b229e0",
-      "uiConfig": {
-        "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
-        "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
-        "buttonDisplayName": "GitHub",
-        "buttonImage": "https://cdn-icons-png.flaticon.com/512/25/25231.png",
-        "iconBackground": "#4184f3",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://ig.mytestrun.com/user",
-    },
-    "google": {
-      "_id": "google",
-      "_type": {
-        "_id": "googleConfig",
-        "collection": true,
-        "name": "Client configuration for Google.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "sub",
-      "authorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "297338177925-mho17cgnm540s2gre8h27feb6sbs1msd.apps.googleusercontent.com",
-      "clientSecret": null,
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://accounts.google.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://www.googleapis.com/oauth2/v4/token",
-      "transform": "58d29080-4563-480b-89bb-1e7719776a21",
-      "uiConfig": {
-        "buttonClass": "",
-        "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
-        "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
-        "buttonDisplayName": "Google",
-        "buttonImage": "images/g-logo.png",
-        "iconBackground": "#4184f3",
-        "iconClass": "fa-google",
-        "iconFontColor": "white",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://www.googleapis.com/oauth2/v3/userinfo",
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://accounts.google.com/.well-known/openid-configuration",
-    },
-    "okta-trial-5735851": {
-      "_id": "okta-trial-5735851",
-      "_type": {
-        "_id": "oidcConfig",
-        "collection": true,
-        "name": "Client configuration for providers that implement the OpenID Connect specification.",
-      },
-      "acrValues": [],
-      "authenticationIdKey": "id",
-      "authorizationEndpoint": "https://trial-5735851.okta.com/oauth2/v1/authorize",
-      "clientAuthenticationMethod": "CLIENT_SECRET_POST",
-      "clientId": "0oa13r2cp29Rynmyw697",
-      "clientSecret": null,
-      "enableNativeNonce": true,
-      "enabled": true,
-      "encryptJwtRequestParameter": false,
-      "encryptedIdTokens": false,
-      "issuer": "https://trial-5735851.okta.com",
-      "issuerComparisonCheckType": "EXACT",
-      "jwtEncryptionAlgorithm": "NONE",
-      "jwtEncryptionMethod": "NONE",
-      "jwtRequestParameterOption": "NONE",
-      "jwtSigningAlgorithm": "NONE",
-      "pkceMethod": "S256",
-      "privateKeyJwtExpTime": 600,
-      "redirectURI": "https://idc.scheuber.io/login",
-      "responseMode": "DEFAULT",
-      "revocationCheckOptions": [],
-      "scopeDelimiter": " ",
-      "scopes": [
-        "openid",
-        "profile",
-        "email",
-      ],
-      "tokenEndpoint": "https://trial-5735851.okta.com/oauth2/v1/token",
-      "transform": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
-      "uiConfig": {
-        "buttonDisplayName": "Okta",
-      },
-      "useCustomTrustStore": false,
-      "userInfoEndpoint": "https://trial-5735851.okta.com/oauth2/v1/userinfo",
-      "userInfoResponseType": "JSON",
-      "wellKnownEndpoint": "https://trial-5735851.okta.com/.well-known/openid-configuration",
-    },
-  },
-  "themes": [
-    {
-      "_id": "63e19668-909f-479e-83d7-be7a01cd8187",
-      "accountCardBackgroundColor": "#ffffff",
-      "accountCardHeaderColor": "#23282e",
-      "accountCardInnerBorderColor": "#e7eef4",
-      "accountCardInputBackgroundColor": "#ffffff",
-      "accountCardInputBorderColor": "#c0c9d5",
-      "accountCardInputLabelColor": "#5e6d82",
-      "accountCardInputSelectColor": "#e4f4fd",
-      "accountCardInputTextColor": "#23282e",
-      "accountCardOuterBorderColor": "#e7eef4",
-      "accountCardShadow": 3,
-      "accountCardTabActiveBorderColor": "#109cf1",
-      "accountCardTabActiveColor": "#e4f4fd",
-      "accountCardTextColor": "#5e6d82",
-      "accountFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
-<a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
-      "accountFooterEnabled": false,
-      "accountNavigationBackgroundColor": "#ffffff",
-      "accountNavigationTextColor": "#455469",
-      "accountNavigationToggleBorderColor": "#e7eef4",
-      "accountPageSections": {
-        "accountControls": {
-          "enabled": false,
+      "scripts": {
+        "23143919-6b78-40c3-b25e-beca19b229e0": {
+          "_id": "23143919-6b78-40c3-b25e-beca19b229e0",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from GitHub",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "GitHub Profile Normalization (VS)",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"GitHub rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
         },
-        "accountSecurity": {
+        "484e6246-dbc6-4288-97e6-54e55431402e": {
+          "_id": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Apple",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Apple Profile Normalization",
+          "script": ""/*\\n * Copyright 2021-2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n *\\n * In some common default configurations, the following keys are required to be not empty:\\n * username, givenName, familyName, email.\\n *\\n * From RFC4517: A value of the Directory String syntax is a string of one or more\\n * arbitrary characters from the Universal Character Set (UCS).\\n * A zero-length character string is not permitted.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nString email = \\"change@me.com\\"\\nString subjectId = rawProfile.sub\\nString firstName = \\" \\"\\nString lastName = \\" \\"\\nString username = subjectId\\nString name\\n\\nif (rawProfile.isDefined(\\"email\\") && rawProfile.email.isNotNull()){ // User can elect to not share their email\\n    email = rawProfile.email.asString()\\n    username = email\\n}\\nif (rawProfile.isDefined(\\"name\\") && rawProfile.name.isNotNull()) {\\n    if (rawProfile.name.isDefined(\\"firstName\\") && rawProfile.name.firstName.isNotNull()) {\\n        firstName = rawProfile.name.firstName.asString()\\n    }\\n    if (rawProfile.name.isDefined(\\"lastName\\") && rawProfile.name.lastName.isNotNull()) {\\n        lastName = rawProfile.name.lastName.asString()\\n    }\\n}\\n\\nname = (firstName?.trim() ? firstName : \\"\\") + (lastName?.trim() ? ((firstName?.trim() ? \\" \\" : \\"\\") + lastName) : \\"\\")\\nname =  (!name?.trim()) ? \\" \\" : name\\n\\nreturn json(object(\\n        field(\\"id\\", subjectId),\\n        field(\\"displayName\\", name),\\n        field(\\"email\\", email),\\n        field(\\"givenName\\", firstName),\\n        field(\\"familyName\\", lastName),\\n        field(\\"username\\", username)))"",
+        },
+        "58c824ae-84ed-4724-82cd-db128fc3f6c": {
+          "_id": "58c824ae-84ed-4724-82cd-db128fc3f6c",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Converts a normalized social profile into a managed user",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Normalized Profile to Managed User",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nimport org.forgerock.json.JsonValue\\n\\nJsonValue managedUser = json(object(\\n        field(\\"givenName\\", normalizedProfile.givenName),\\n        field(\\"sn\\", normalizedProfile.familyName),\\n        field(\\"mail\\", normalizedProfile.email),\\n        field(\\"userName\\", normalizedProfile.username)))\\n\\nif (normalizedProfile.postalAddress.isNotNull()) managedUser.put(\\"postalAddress\\", normalizedProfile.postalAddress)\\nif (normalizedProfile.addressLocality.isNotNull()) managedUser.put(\\"city\\", normalizedProfile.addressLocality)\\nif (normalizedProfile.addressRegion.isNotNull()) managedUser.put(\\"stateProvince\\", normalizedProfile.addressRegion)\\nif (normalizedProfile.postalCode.isNotNull()) managedUser.put(\\"postalCode\\", normalizedProfile.postalCode)\\nif (normalizedProfile.country.isNotNull()) managedUser.put(\\"country\\", normalizedProfile.country)\\nif (normalizedProfile.phone.isNotNull()) managedUser.put(\\"telephoneNumber\\", normalizedProfile.phone)\\n\\n// if the givenName and familyName is null or empty\\n// then add a boolean flag to the shared state to indicate names are not present\\n// this could be used elsewhere\\n// for eg. this could be used in a scripted decision node to by-pass patching\\n// the user object with blank values when givenName  and familyName is not present\\nboolean noGivenName = normalizedProfile.givenName.isNull() || (!normalizedProfile.givenName.asString()?.trim())\\nboolean noFamilyName = normalizedProfile.familyName.isNull() || (!normalizedProfile.familyName.asString()?.trim())\\nsharedState.put(\\"nameEmptyOrNull\\", noGivenName && noFamilyName)\\n\\nreturn managedUser\\n"",
+        },
+        "58d29080-4563-480b-89bb-1e7719776a21": {
+          "_id": "58d29080-4563-480b-89bb-1e7719776a21",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Google",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Google Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.sub),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.given_name),\\n        field(\\"familyName\\", rawProfile.family_name),\\n        field(\\"photoUrl\\", rawProfile.picture),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email),\\n        field(\\"locale\\", rawProfile.locale)))"",
+        },
+        "6325cf19-a49b-471e-8d26-7e4df76df0e2": {
+          "_id": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from GitHub",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Okta Profile Normalization",
+          "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.warning(\\"Okta rawProfile: \\"+rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.preferred_username)))"",
+        },
+        "739bdc48-fd24-4c52-b353-88706d75558a": {
+          "_id": "739bdc48-fd24-4c52-b353-88706d75558a",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Check if username has already been collected.",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Check Username",
+          "script": ""/* Check Username\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Check if username has already been collected.\\n * Return \\"known\\" if yes, \\"unknown\\" otherwise.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - known\\n * - unknown\\n */\\n(function () {\\n    if (null != sharedState.get(\\"username\\")) {\\n        outcome = \\"known\\";\\n    }\\n    else {\\n        outcome = \\"unknown\\";\\n    }\\n}());"",
+        },
+        "73cecbfc-dad0-4395-be6a-6858ee3a80e5": {
+          "_id": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Microsoft",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Microsoft Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n{\\n    \\"@odata.context\\": \\"https://graph.microsoft.com/v1.0/$metadata#users/$entity\\",\\n    \\"@odata.id\\": \\"https://graph.microsoft.com/v2/711ffa9c-5972-4713-ace3-688c9732614a/directoryObjects/7d7759e2-36d8-4e64-b173-3f890d7d46d6/Microsoft.DirectoryServices.User\\",\\n    \\"businessPhones\\": [\\n        \\"18014735451\\"\\n    ],\\n    \\"displayName\\": \\"Volker Scheuber\\",\\n    \\"givenName\\": \\"Volker\\",\\n    \\"jobTitle\\": null,\\n    \\"mail\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"mobilePhone\\": null,\\n    \\"officeLocation\\": null,\\n    \\"preferredLanguage\\": null,\\n    \\"surname\\": \\"Scheuber\\",\\n    \\"userPrincipalName\\": \\"vscheuber@vscheuber.onmicrosoft.com\\",\\n    \\"id\\": \\"7d7759e2-36d8-4e64-b173-3f890d7d46d6\\"\\n}\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nlogger.message(\\"Kauai Microsoft Profile Normalization: rawProfile={}\\", rawProfile)\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.displayName),\\n        field(\\"givenName\\", rawProfile.givenName),\\n        field(\\"familyName\\", rawProfile.surname),\\n        field(\\"email\\", rawProfile.userPrincipalName),\\n        field(\\"username\\", rawProfile.userPrincipalName),\\n        field(\\"groups\\", rawProfile.groups)))"",
+        },
+        "bae1d54a-e97d-4997-aa5d-c027f21af82c": {
+          "_id": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": true,
+          "description": "Normalizes raw profile data from Facebook",
+          "evaluatorVersion": "1.0",
+          "language": "GROOVY",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "Facebook Profile Normalization",
+          "script": ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nreturn json(object(\\n        field(\\"id\\", rawProfile.id),\\n        field(\\"displayName\\", rawProfile.name),\\n        field(\\"givenName\\", rawProfile.first_name),\\n        field(\\"familyName\\", rawProfile.last_name),\\n        field(\\"photoUrl\\", rawProfile.picture.data.url),\\n        field(\\"email\\", rawProfile.email),\\n        field(\\"username\\", rawProfile.email)))"",
+        },
+        "dbe0bf9a-72aa-49d5-8483-9db147985a47": {
+          "_id": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
+          "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Normalizes raw profile data from ADFS",
+          "evaluatorVersion": "1.0",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "ADFS Profile Normalization (JS)",
+          "script": ""/*\\n * Copyright 2022 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\n/*\\n * This script returns the social identity profile information for the authenticating user\\n * in a standard form expected by the Social Provider Handler Node.\\n *\\n * Defined variables:\\n * rawProfile - The social identity provider profile information for the authenticating user.\\n *              JsonValue (1).\\n * logger - The debug logger instance:\\n *          https://backstage.forgerock.com/docs/am/7/scripting-guide/scripting-api-global-logger.html#scripting-api-global-logger.\\n * realm - String (primitive).\\n *         The name of the realm the user is authenticating to.\\n * requestHeaders - TreeMap (2).\\n *                  The object that provides methods for accessing headers in the login request:\\n *                  https://backstage.forgerock.com/docs/am/7/authentication-guide/scripting-api-node.html#scripting-api-node-requestHeaders.\\n * requestParameters - TreeMap (2).\\n *                     The object that contains the authentication request parameters.\\n * selectedIdp - String (primitive).\\n *               The social identity provider name. For example: google.\\n * sharedState - LinkedHashMap (3).\\n *               The object that holds the state of the authentication tree and allows data exchange between the stateless nodes:\\n *               https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n * transientState - LinkedHashMap (3).\\n *                  The object for storing sensitive information that must not leave the server unencrypted,\\n *                  and that may not need to persist between authentication requests during the authentication session:\\n *                  https://backstage.forgerock.com/docs/am/7/auth-nodes/core-action.html#accessing-tree-state.\\n *\\n * Return - a JsonValue (1).\\n *          The result of the last statement in the script is returned to the server.\\n *          Currently, the Immediately Invoked Function Expression (also known as Self-Executing Anonymous Function)\\n *          is the last (and only) statement in this script, and its return value will become the script result.\\n *          Do not use \\"return variable\\" statement outside of a function definition.\\n *\\n *          This script's last statement should result in a JsonValue (1) with the following keys:\\n *          {\\n *              {\\"displayName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"email\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"familyName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"givenName\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"id\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"locale\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"photoUrl\\": \\"corresponding-social-identity-provider-value\\"},\\n *              {\\"username\\": \\"corresponding-social-identity-provider-value\\"}\\n *          }\\n *\\n *          The consumer of this data defines which keys are required and which are optional.\\n *          For example, the script associated with the Social Provider Handler Node and,\\n *          ultimately, the managed object created/updated with this data\\n *          will expect certain keys to be populated.\\n *          In some common default configurations, the following keys are required to be not empty:\\n *          username, givenName, familyName, email.\\n *\\n *          From RFC4517: A value of the Directory String syntax is a string of one or more\\n *          arbitrary characters from the Universal Character Set (UCS).\\n *          A zero-length character string is not permitted.\\n *\\n * (1) JsonValue - https://backstage.forgerock.com/docs/am/7/apidocs/org/forgerock/json/JsonValue.html.\\n * (2) TreeMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/TreeMap.html.\\n * (3) LinkedHashMap - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/LinkedHashMap.html.\\n */\\n\\n(function () {\\n    var frJava = JavaImporter(\\n        org.forgerock.json.JsonValue\\n    );\\n\\n    var normalizedProfileData = frJava.JsonValue.json(frJava.JsonValue.object());\\n  \\n  \\t//logger.message('Seguin rawProfile: '+rawProfile);\\n\\n    normalizedProfileData.put('id', rawProfile.get('sub').asString());\\n    normalizedProfileData.put('displayName', rawProfile.get('givenName').asString() + ' ' + rawProfile.get('sn').asString());\\n    normalizedProfileData.put('email', rawProfile.get('mail').asString());\\n    normalizedProfileData.put('givenName', rawProfile.get('givenName').asString());\\n    normalizedProfileData.put('familyName', rawProfile.get('sn').asString());\\n    normalizedProfileData.put('username', rawProfile.get('upn').asString());\\n    normalizedProfileData.put('roles', rawProfile.get('roles').asString());\\n  \\n  \\t//logger.message('Seguin normalizedProfileData: '+normalizedProfileData);\\n\\n    return normalizedProfileData;\\n}());"",
+        },
+      },
+      "socialIdentityProviders": {
+        "adfs": {
+          "_id": "adfs",
+          "_type": {
+            "_id": "oidcConfig",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OpenID Connect specification.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "aa9a179e-cdba-4db8-8477-3d1069d5ec04",
+          "clientSecret": null,
+          "enableNativeNonce": true,
           "enabled": true,
-          "subsections": {
-            "password": {
-              "enabled": true,
-            },
-            "securityQuestions": {
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://adfs.mytestrun.com/adfs",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://adfs.mytestrun.com/adfs/discovery/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "RS256",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://adfs.mytestrun.com/adfs/oauth2/token",
+          "transform": "dbe0bf9a-72aa-49d5-8483-9db147985a47",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonDisplayName": "Microsoft ADFS",
+            "buttonImage": "/login/images/microsoft-logo.png",
+            "iconBackground": "#0078d7",
+            "iconClass": "fa-windows",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://adfs.mytestrun.com/adfs/.well-known/openid-configuration",
+        },
+        "apple-stoyan": {
+          "_id": "apple-stoyan",
+          "_type": {
+            "_id": "appleConfig",
+            "collection": true,
+            "name": "Client configuration for Apple.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "CHANGE ME",
+          "clientSecret": null,
+          "enableNativeNonce": true,
+          "enabled": false,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://appleid.apple.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectAfterFormPostURI": "https://openam-volker-dev.forgeblocks.com/login",
+          "redirectURI": "https://openam-volker-dev.forgeblocks.com/am/oauth2/alpha/client/form_post/apple-stoyan",
+          "requestNativeAppForUserInfo": false,
+          "responseMode": "FORM_POST",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "name",
+            "email",
+          ],
+          "tokenEndpoint": "https://appleid.apple.com/auth/token",
+          "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonDisplayName": "Apple",
+            "buttonImage": "/login/images/apple-logo.png",
+            "iconBackground": "#000000",
+            "iconClass": "fa-apple",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
+        },
+        "apple_web": {
+          "_id": "apple_web",
+          "_type": {
+            "_id": "appleConfig",
+            "collection": true,
+            "name": "Client configuration for Apple.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://appleid.apple.com/auth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "io.scheuber.idc.signinWithApple.service",
+          "clientSecret": null,
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://appleid.apple.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwksUriEndpoint": "https://appleid.apple.com/auth/keys",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectAfterFormPostURI": "https://idc.scheuber.io/login",
+          "redirectURI": "https://idc.scheuber.io/am/oauth2/client/form_post/apple_web",
+          "requestNativeAppForUserInfo": false,
+          "responseMode": "FORM_POST",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "name",
+            "email",
+          ],
+          "tokenEndpoint": "https://appleid.apple.com/auth/token",
+          "transform": "484e6246-dbc6-4288-97e6-54e55431402e",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonCustomStyleHover": "background-color: #000000; color: #ffffff; border-color: #000000;",
+            "buttonDisplayName": "Apple",
+            "buttonImage": "/login/images/apple-logo.png",
+            "iconBackground": "#000000",
+            "iconClass": "fa-apple",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://appleid.apple.com/.well-known/openid-configuration",
+        },
+        "azure": {
+          "_id": "azure",
+          "_type": {
+            "_id": "microsoftConfig",
+            "collection": true,
+            "name": "Client configuration for Microsoft.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "c42a3dc8-f276-496b-a722-269f131cc21c",
+          "clientSecret": null,
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "User.Read",
+            "openid",
+          ],
+          "tokenEndpoint": "https://login.microsoftonline.com/711ffa9c-5972-4713-ace3-688c9732614a/oauth2/v2.0/token",
+          "transform": "73cecbfc-dad0-4395-be6a-6858ee3a80e5",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonCustomStyleHover": "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+            "buttonDisplayName": "Microsoft Azure",
+            "buttonImage": "/login/images/microsoft-logo.png",
+            "iconBackground": "#0078d7",
+            "iconClass": "fa-windows",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://graph.microsoft.com/v1.0/me",
+        },
+        "facebook": {
+          "_id": "facebook",
+          "_type": {
+            "_id": "oauth2Config",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OAuth2 specification.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://www.facebook.com/dialog/oauth",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "123741918345526",
+          "clientSecret": null,
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 3600,
+          "redirectURI": "https://idc.scheuber.io/am/XUI/?realm=%2Falpha",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "email",
+          ],
+          "tokenEndpoint": "https://graph.facebook.com/v2.7/oauth/access_token",
+          "transform": "bae1d54a-e97d-4997-aa5d-c027f21af82c",
+          "uiConfig": {
+            "buttonClass": "fa-facebook-official",
+            "buttonCustomStyle": "background-color: #3b5998; border-color: #3b5998; color: white;",
+            "buttonCustomStyleHover": "background-color: #334b7d; border-color: #334b7d; color: white;",
+            "buttonDisplayName": "Facebook",
+            "buttonImage": "",
+            "iconBackground": "#3b5998",
+            "iconClass": "fa-facebook",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://graph.facebook.com/me?fields=id,name,picture,email,first_name,last_name,locale",
+        },
+        "github": {
+          "_id": "github",
+          "_type": {
+            "_id": "oauth2Config",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OAuth2 specification.",
+          },
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://github.com/login/oauth/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "bdae6d141d4dcf95a630",
+          "clientSecret": null,
+          "enabled": true,
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "user",
+          ],
+          "tokenEndpoint": "https://ig.mytestrun.com/login/oauth/access_token",
+          "transform": "23143919-6b78-40c3-b25e-beca19b229e0",
+          "uiConfig": {
+            "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
+            "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
+            "buttonDisplayName": "GitHub",
+            "buttonImage": "https://cdn-icons-png.flaticon.com/512/25/25231.png",
+            "iconBackground": "#4184f3",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://ig.mytestrun.com/user",
+        },
+        "google": {
+          "_id": "google",
+          "_type": {
+            "_id": "googleConfig",
+            "collection": true,
+            "name": "Client configuration for Google.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "sub",
+          "authorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "297338177925-mho17cgnm540s2gre8h27feb6sbs1msd.apps.googleusercontent.com",
+          "clientSecret": null,
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://accounts.google.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://www.googleapis.com/oauth2/v4/token",
+          "transform": "58d29080-4563-480b-89bb-1e7719776a21",
+          "uiConfig": {
+            "buttonClass": "",
+            "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
+            "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
+            "buttonDisplayName": "Google",
+            "buttonImage": "images/g-logo.png",
+            "iconBackground": "#4184f3",
+            "iconClass": "fa-google",
+            "iconFontColor": "white",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://www.googleapis.com/oauth2/v3/userinfo",
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://accounts.google.com/.well-known/openid-configuration",
+        },
+        "okta-trial-5735851": {
+          "_id": "okta-trial-5735851",
+          "_type": {
+            "_id": "oidcConfig",
+            "collection": true,
+            "name": "Client configuration for providers that implement the OpenID Connect specification.",
+          },
+          "acrValues": [],
+          "authenticationIdKey": "id",
+          "authorizationEndpoint": "https://trial-5735851.okta.com/oauth2/v1/authorize",
+          "clientAuthenticationMethod": "CLIENT_SECRET_POST",
+          "clientId": "0oa13r2cp29Rynmyw697",
+          "clientSecret": null,
+          "enableNativeNonce": true,
+          "enabled": true,
+          "encryptJwtRequestParameter": false,
+          "encryptedIdTokens": false,
+          "issuer": "https://trial-5735851.okta.com",
+          "issuerComparisonCheckType": "EXACT",
+          "jwtEncryptionAlgorithm": "NONE",
+          "jwtEncryptionMethod": "NONE",
+          "jwtRequestParameterOption": "NONE",
+          "jwtSigningAlgorithm": "NONE",
+          "pkceMethod": "S256",
+          "privateKeyJwtExpTime": 600,
+          "redirectURI": "https://idc.scheuber.io/login",
+          "responseMode": "DEFAULT",
+          "revocationCheckOptions": [],
+          "scopeDelimiter": " ",
+          "scopes": [
+            "openid",
+            "profile",
+            "email",
+          ],
+          "tokenEndpoint": "https://trial-5735851.okta.com/oauth2/v1/token",
+          "transform": "6325cf19-a49b-471e-8d26-7e4df76df0e2",
+          "uiConfig": {
+            "buttonDisplayName": "Okta",
+          },
+          "useCustomTrustStore": false,
+          "userInfoEndpoint": "https://trial-5735851.okta.com/oauth2/v1/userinfo",
+          "userInfoResponseType": "JSON",
+          "wellKnownEndpoint": "https://trial-5735851.okta.com/.well-known/openid-configuration",
+        },
+      },
+      "themes": [
+        {
+          "_id": "63e19668-909f-479e-83d7-be7a01cd8187",
+          "accountCardBackgroundColor": "#ffffff",
+          "accountCardHeaderColor": "#23282e",
+          "accountCardInnerBorderColor": "#e7eef4",
+          "accountCardInputBackgroundColor": "#ffffff",
+          "accountCardInputBorderColor": "#c0c9d5",
+          "accountCardInputLabelColor": "#5e6d82",
+          "accountCardInputSelectColor": "#e4f4fd",
+          "accountCardInputTextColor": "#23282e",
+          "accountCardOuterBorderColor": "#e7eef4",
+          "accountCardShadow": 3,
+          "accountCardTabActiveBorderColor": "#109cf1",
+          "accountCardTabActiveColor": "#e4f4fd",
+          "accountCardTextColor": "#5e6d82",
+          "accountFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
+<a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
+          "accountFooterEnabled": false,
+          "accountNavigationBackgroundColor": "#ffffff",
+          "accountNavigationTextColor": "#455469",
+          "accountNavigationToggleBorderColor": "#e7eef4",
+          "accountPageSections": {
+            "accountControls": {
               "enabled": false,
             },
-            "twoStepVerification": {
+            "accountSecurity": {
+              "enabled": true,
+              "subsections": {
+                "password": {
+                  "enabled": true,
+                },
+                "securityQuestions": {
+                  "enabled": false,
+                },
+                "twoStepVerification": {
+                  "enabled": true,
+                },
+                "username": {
+                  "enabled": true,
+                },
+              },
+            },
+            "consent": {
+              "enabled": false,
+            },
+            "oauthApplications": {
+              "enabled": false,
+            },
+            "personalInformation": {
               "enabled": true,
             },
-            "username": {
+            "preferences": {
+              "enabled": true,
+            },
+            "social": {
+              "enabled": false,
+            },
+            "trustedDevices": {
               "enabled": true,
             },
           },
-        },
-        "consent": {
-          "enabled": false,
-        },
-        "oauthApplications": {
-          "enabled": false,
-        },
-        "personalInformation": {
-          "enabled": true,
-        },
-        "preferences": {
-          "enabled": true,
-        },
-        "social": {
-          "enabled": false,
-        },
-        "trustedDevices": {
-          "enabled": true,
-        },
-      },
-      "accountTableRowHoverColor": "#f6f8fa",
-      "backgroundColor": "#FFFFFF",
-      "backgroundImage": "",
-      "bodyText": "#000000",
-      "boldLinks": false,
-      "buttonRounded": "0",
-      "dangerColor": "#f7685b",
-      "favicon": "",
-      "fontFamily": "Open Sans",
-      "isDefault": false,
-      "journeyCardBackgroundColor": "#ffffff",
-      "journeyCardShadow": 3,
-      "journeyCardTextColor": "#5e6d82",
-      "journeyCardTitleColor": "#23282e",
-      "journeyFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
+          "accountTableRowHoverColor": "#f6f8fa",
+          "backgroundColor": "#FFFFFF",
+          "backgroundImage": "",
+          "bodyText": "#000000",
+          "boldLinks": false,
+          "buttonRounded": "0",
+          "dangerColor": "#f7685b",
+          "favicon": "",
+          "fontFamily": "Open Sans",
+          "isDefault": false,
+          "journeyCardBackgroundColor": "#ffffff",
+          "journeyCardShadow": 3,
+          "journeyCardTextColor": "#5e6d82",
+          "journeyCardTitleColor": "#23282e",
+          "journeyFooter": "<div class="d-flex justify-content-center py-4 w-100"><span class="pr-1">© 2021</span>
 <a href="#"target="_blank"class="text-body">My Company, Inc</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Privacy Policy</a><a href="#"target="_blank"style="color:#0000ee"class="pl-3 text-body">Terms & Conditions</a></div>",
-      "journeyFooterEnabled": false,
-      "journeyHeader": "<div class="d-flex justify-content-center py-4 flex-grow-1">Header Content</div>",
-      "journeyHeaderEnabled": false,
-      "journeyInputBackgroundColor": "#ffffff",
-      "journeyInputBorderColor": "#c0c9d5",
-      "journeyInputLabelColor": "#5e6d82",
-      "journeyInputSelectColor": "#e4f4fd",
-      "journeyInputTextColor": "#23282e",
-      "journeyJustifiedContent": "",
-      "journeyJustifiedContentEnabled": false,
-      "journeyLayout": "card",
-      "journeyTheaterMode": false,
-      "linkActiveColor": "#000000",
-      "linkColor": "#000000",
-      "linkedTrees": [
-        "FrodoTest",
-        "AA-FrodoTest",
+          "journeyFooterEnabled": false,
+          "journeyHeader": "<div class="d-flex justify-content-center py-4 flex-grow-1">Header Content</div>",
+          "journeyHeaderEnabled": false,
+          "journeyInputBackgroundColor": "#ffffff",
+          "journeyInputBorderColor": "#c0c9d5",
+          "journeyInputLabelColor": "#5e6d82",
+          "journeyInputSelectColor": "#e4f4fd",
+          "journeyInputTextColor": "#23282e",
+          "journeyJustifiedContent": "",
+          "journeyJustifiedContentEnabled": false,
+          "journeyLayout": "card",
+          "journeyTheaterMode": false,
+          "linkActiveColor": "#000000",
+          "linkColor": "#000000",
+          "linkedTrees": [
+            "FrodoTest",
+            "AA-FrodoTest",
+          ],
+          "logo": "https://cdn.forgerock.com/platform/themes/contrast/logo-contrast.svg",
+          "logoAltText": "Contrast",
+          "logoEnabled": false,
+          "logoHeight": "72",
+          "logoProfile": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
+          "logoProfileAltText": "Contrast",
+          "logoProfileCollapsed": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
+          "logoProfileCollapsedAltText": "",
+          "logoProfileCollapsedHeight": "22",
+          "logoProfileHeight": "22",
+          "name": "NoAccess",
+          "pageTitle": "#23282e",
+          "primaryColor": "#000000",
+          "primaryOffColor": "#000000",
+          "profileBackgroundColor": "#FFFFFF",
+          "profileMenuHighlightColor": "#FFFFFF",
+          "profileMenuHoverColor": "#FFFFFF",
+          "profileMenuHoverTextColor": "#000000",
+          "profileMenuTextHighlightColor": "#455469",
+          "secondaryColor": "#69788b",
+          "switchBackgroundColor": "#c0c9d5",
+          "textColor": "#ffffff",
+          "topBarBackgroundColor": "#ffffff",
+          "topBarBorderColor": "#e7eef4",
+          "topBarHeaderColor": "#23282e",
+          "topBarTextColor": "#69788b",
+        },
       ],
-      "logo": "https://cdn.forgerock.com/platform/themes/contrast/logo-contrast.svg",
-      "logoAltText": "Contrast",
-      "logoEnabled": false,
-      "logoHeight": "72",
-      "logoProfile": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
-      "logoProfileAltText": "Contrast",
-      "logoProfileCollapsed": "data:image/svg+xml,%0A%3Csvg width='46' height='46' viewBox='0 0 46 46' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24.3477 13.5664H43.9438C43.5192 12.6317 43.0319 11.734 42.4905 10.8711H24.3477V13.5664Z' fill='black'/%3E%3Cpath d='M24.3477 8.17578H40.5261C39.6996 7.2052 38.7974 6.30182 37.8224 5.48047H24.3477V8.17578Z' fill='black'/%3E%3Cpath d='M24.3477 40.5195H37.8224C38.7975 39.6982 39.6996 38.7948 40.5261 37.8242H24.3477V40.5195Z' fill='black'/%3E%3Cpath d='M24.3477 2.78516H33.8482C31.0136 1.27039 27.7313 0.198195 24.3477 0V2.78516Z' fill='black'/%3E%3Cpath d='M24.3477 18.957H45.6208C45.4566 18.0405 45.2557 17.1372 44.9856 16.2617H24.3477V18.957Z' fill='black'/%3E%3Cpath d='M24.3477 21.6523V24.3477H45.9317C45.958 23.8992 46 23.4549 46 23C46 22.5451 45.958 22.1008 45.9317 21.6523H24.3477Z' fill='black'/%3E%3Cpath d='M0 23C0 35.1781 9.64778 45.2964 21.6523 46V0C9.64778 0.703566 0 10.8219 0 23Z' fill='black'/%3E%3Cpath d='M24.3477 46C27.7313 45.8018 31.0136 44.7296 33.8482 43.2148H24.3477V46Z' fill='black'/%3E%3Cpath d='M45.6208 27.043H24.3477V29.7383H44.9857C45.2557 28.8628 45.4566 27.9595 45.6208 27.043V27.043Z' fill='black'/%3E%3Cpath d='M24.3477 35.1289H42.4905C43.0319 34.266 43.5192 33.3683 43.9438 32.4336H24.3477V35.1289Z' fill='black'/%3E%3C/svg%3E%0A",
-      "logoProfileCollapsedAltText": "",
-      "logoProfileCollapsedHeight": "22",
-      "logoProfileHeight": "22",
-      "name": "NoAccess",
-      "pageTitle": "#23282e",
-      "primaryColor": "#000000",
-      "primaryOffColor": "#000000",
-      "profileBackgroundColor": "#FFFFFF",
-      "profileMenuHighlightColor": "#FFFFFF",
-      "profileMenuHoverColor": "#FFFFFF",
-      "profileMenuHoverTextColor": "#000000",
-      "profileMenuTextHighlightColor": "#455469",
-      "secondaryColor": "#69788b",
-      "switchBackgroundColor": "#c0c9d5",
-      "textColor": "#ffffff",
-      "topBarBackgroundColor": "#ffffff",
-      "topBarBorderColor": "#e7eef4",
-      "topBarHeaderColor": "#23282e",
-      "topBarTextColor": "#69788b",
-    },
-  ],
-  "tree": {
-    "_id": "FrodoTest",
-    "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
-    "enabled": true,
-    "entryNodeId": "4951364c-59be-42cd-9cd7-79c9392214db",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "c859d258-79c1-4448-bd52-12e4e414af92",
+      "tree": {
+        "_id": "FrodoTest",
+        "description": "Frodo test journey utilizing a variety of nodes and dependencies to test support for complex journeys.",
+        "enabled": true,
+        "entryNodeId": "4951364c-59be-42cd-9cd7-79c9392214db",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "234526e1-48cf-477e-8ecb-abf15fcd5c67": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "c859d258-79c1-4448-bd52-12e4e414af92",
+            },
+            "displayName": "Social Login",
+            "nodeType": "SocialProviderHandlerNode",
+            "x": 702,
+            "y": 116.015625,
+          },
+          "4951364c-59be-42cd-9cd7-79c9392214db": {
+            "connections": {
+              "known": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
+              "unknown": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+            },
+            "displayName": "Check Username",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 200,
+            "y": 235.015625,
+          },
+          "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
+            "connections": {
+              "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+            },
+            "displayName": "Validate Creds",
+            "nodeType": "IdentityStoreDecisionNode",
+            "x": 702,
+            "y": 292.015625,
+          },
+          "650203c3-47f7-439d-a554-669cb7b08c57": {
+            "connections": {
+              "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+              "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "SAML2 Authentication",
+            "nodeType": "product-Saml2Node",
+            "x": 1196,
+            "y": 188.015625,
+          },
+          "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
+            "connections": {
+              "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+              "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+            "x": 444,
+            "y": 273.015625,
+          },
+          "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
+            "connections": {
+              "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
+              "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
+            },
+            "displayName": "Login Page",
+            "nodeType": "PageNode",
+            "x": 443,
+            "y": 26.015625,
+          },
+          "c859d258-79c1-4448-bd52-12e4e414af92": {
+            "connections": {
+              "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "EMAIL_SENT": "650203c3-47f7-439d-a554-669cb7b08c57",
+            },
+            "displayName": "Email Template Node",
+            "nodeType": "EmailTemplateNode",
+            "x": 967,
+            "y": 222.015625,
+          },
         },
-        "displayName": "Social Login",
-        "nodeType": "SocialProviderHandlerNode",
-        "x": 702,
-        "y": 116.015625,
-      },
-      "4951364c-59be-42cd-9cd7-79c9392214db": {
-        "connections": {
-          "known": "c0bbd39a-ff6b-45d7-af8a-0685e810bc11",
-          "unknown": "795108e9-0b4d-4849-80fa-fb8518c6e3b0",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1434,
+            "y": 60,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1433,
+            "y": 459,
+          },
+          "startNode": {
+            "x": 63,
+            "y": 252,
+          },
         },
-        "displayName": "Check Username",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 200,
-        "y": 235.015625,
-      },
-      "58ab3ae6-cb79-445f-9a52-170e9b7f1339": {
-        "connections": {
-          "CANCELLED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "EXPIRED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "FALSE": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "LOCKED": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "TRUE": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "uiConfig": {
+          "categories": "["Frodo","Prototype"]",
         },
-        "displayName": "Validate Creds",
-        "nodeType": "IdentityStoreDecisionNode",
-        "x": 702,
-        "y": 292.015625,
       },
-      "650203c3-47f7-439d-a554-669cb7b08c57": {
-        "connections": {
-          "ACCOUNT_EXISTS": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "NO_ACCOUNT": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "SAML2 Authentication",
-        "nodeType": "product-Saml2Node",
-        "x": 1196,
-        "y": 188.015625,
-      },
-      "795108e9-0b4d-4849-80fa-fb8518c6e3b0": {
-        "connections": {
-          "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-          "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
-        },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-        "x": 444,
-        "y": 273.015625,
-      },
-      "c0bbd39a-ff6b-45d7-af8a-0685e810bc11": {
-        "connections": {
-          "localAuthentication": "58ab3ae6-cb79-445f-9a52-170e9b7f1339",
-          "socialAuthentication": "234526e1-48cf-477e-8ecb-abf15fcd5c67",
-        },
-        "displayName": "Login Page",
-        "nodeType": "PageNode",
-        "x": 443,
-        "y": 26.015625,
-      },
-      "c859d258-79c1-4448-bd52-12e4e414af92": {
-        "connections": {
-          "EMAIL_NOT_SENT": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "EMAIL_SENT": "650203c3-47f7-439d-a554-669cb7b08c57",
-        },
-        "displayName": "Email Template Node",
-        "nodeType": "EmailTemplateNode",
-        "x": 967,
-        "y": 222.015625,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1434,
-        "y": 60,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1433,
-        "y": 459,
-      },
-      "startNode": {
-        "x": 63,
-        "y": 252,
-      },
-    },
-    "uiConfig": {
-      "categories": "["Frodo","Prototype"]",
     },
   },
 }
@@ -17820,296 +17912,300 @@ exports[`frodo journey export "frodo journey export -i j01 -f my-j01.json": shou
 
 exports[`frodo journey export "frodo journey export -i j01 -f my-j01.json": should export the journey with journey id "j01" into file named my-j01.json: my-j01.json 1`] = `
 {
-  "circlesOfTrust": {},
-  "emailTemplates": {},
-  "innerNodes": {},
   "meta": Any<Object>,
-  "nodes": {
-    "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
-      "_id": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
+  "trees": {
+    "j01": {
+      "circlesOfTrust": {},
+      "emailTemplates": {},
+      "innerNodes": {},
+      "nodes": {
+        "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
+          "_id": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
         },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
+        "aa97f870-d95e-4861-b756-64b6423dd7da": {
+          "_id": "aa97f870-d95e-4861-b756-64b6423dd7da",
+          "_outcomes": [
+            {
+              "displayName": "True",
+              "id": "true",
+            },
+            {
+              "displayName": "False",
+              "id": "false",
+            },
+          ],
+          "_type": {
+            "_id": "InnerTreeEvaluatorNode",
+            "collection": true,
+            "name": "Inner Tree Evaluator",
+          },
+          "tree": "j00",
+        },
+        "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
+          "_id": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
+          "_outcomes": [
+            {
+              "displayName": "shared and level",
+              "id": "shared and level",
+            },
+            {
+              "displayName": "shared only",
+              "id": "shared only",
+            },
+            {
+              "displayName": "level only",
+              "id": "level only",
+            },
+            {
+              "displayName": "none",
+              "id": "none",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "outcomes": [
+            "shared and level",
+            "shared only",
+            "level only",
+            "none",
+          ],
+          "outputs": [
+            "*",
+            "mode",
+            "level",
+          ],
+          "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+        },
+        "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
+          "_id": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
+        "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
+          "_id": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+        },
+        "fa62ae77-1e86-4939-a773-e428259fac97": {
+          "_id": "fa62ae77-1e86-4939-a773-e428259fac97",
+          "_outcomes": [
+            {
+              "displayName": "true",
+              "id": "true",
+            },
+          ],
+          "_type": {
+            "_id": "ScriptedDecisionNode",
+            "collection": true,
+            "name": "Scripted Decision",
+          },
+          "inputs": [
+            "*",
+          ],
+          "outcomes": [
+            "true",
+          ],
+          "outputs": [
+            "*",
+          ],
+          "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
+        },
       },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "aa97f870-d95e-4861-b756-64b6423dd7da": {
-      "_id": "aa97f870-d95e-4861-b756-64b6423dd7da",
-      "_outcomes": [
-        {
-          "displayName": "True",
-          "id": "true",
+      "saml2Entities": {},
+      "scripts": {
+        "1b52a7e0-4019-40fa-958a-15a49870e901": {
+          "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set the same shared state variable",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "shared",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
         },
-        {
-          "displayName": "False",
-          "id": "false",
+        "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
+          "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "set per level shared state variable",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "level",
+          "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
         },
-      ],
-      "_type": {
-        "_id": "InnerTreeEvaluatorNode",
-        "collection": true,
-        "name": "Inner Tree Evaluator",
+        "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
+          "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
+          "context": "AUTHENTICATION_TREE_DECISION_NODE",
+          "createdBy": "null",
+          "creationDate": 0,
+          "default": false,
+          "description": "Check if mode has already been set.",
+          "language": "JAVASCRIPT",
+          "lastModifiedBy": "null",
+          "lastModifiedDate": 0,
+          "name": "mode",
+          "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
+        },
       },
-      "tree": "j00",
-    },
-    "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
-      "_id": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
-      "_outcomes": [
-        {
-          "displayName": "shared and level",
-          "id": "shared and level",
+      "socialIdentityProviders": {},
+      "themes": [],
+      "tree": {
+        "_id": "j01",
+        "enabled": true,
+        "entryNodeId": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
+        "identityResource": "managed/alpha_user",
+        "innerTreeOnly": false,
+        "nodes": {
+          "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 395,
+            "y": 345.015625,
+          },
+          "aa97f870-d95e-4861-b756-64b6423dd7da": {
+            "connections": {
+              "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+              "true": "e301438c-0bd0-429c-ab0c-66126501069a",
+            },
+            "displayName": "nest",
+            "nodeType": "InnerTreeEvaluatorNode",
+            "x": 816,
+            "y": 233.015625,
+          },
+          "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
+            "connections": {
+              "level only": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
+              "none": "aa97f870-d95e-4861-b756-64b6423dd7da",
+              "shared and level": "fa62ae77-1e86-4939-a773-e428259fac97",
+              "shared only": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
+            },
+            "displayName": "mode",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 167,
+            "y": 210.015625,
+          },
+          "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 393,
+            "y": 259.015625,
+          },
+          "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
+            "connections": {
+              "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
+            },
+            "displayName": "level",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 598,
+            "y": 173.015625,
+          },
+          "fa62ae77-1e86-4939-a773-e428259fac97": {
+            "connections": {
+              "true": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
+            },
+            "displayName": "shared",
+            "nodeType": "ScriptedDecisionNode",
+            "x": 392,
+            "y": 173.015625,
+          },
         },
-        {
-          "displayName": "shared only",
-          "id": "shared only",
+        "staticNodes": {
+          "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1236,
+            "y": 145,
+          },
+          "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1236,
+            "y": 253,
+          },
+          "startNode": {
+            "x": 50,
+            "y": 250,
+          },
         },
-        {
-          "displayName": "level only",
-          "id": "level only",
+        "uiConfig": {
+          "categories": "[]",
         },
-        {
-          "displayName": "none",
-          "id": "none",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
       },
-      "inputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "outcomes": [
-        "shared and level",
-        "shared only",
-        "level only",
-        "none",
-      ],
-      "outputs": [
-        "*",
-        "mode",
-        "level",
-      ],
-      "script": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-    },
-    "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
-      "_id": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-    "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
-      "_id": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-    },
-    "fa62ae77-1e86-4939-a773-e428259fac97": {
-      "_id": "fa62ae77-1e86-4939-a773-e428259fac97",
-      "_outcomes": [
-        {
-          "displayName": "true",
-          "id": "true",
-        },
-      ],
-      "_type": {
-        "_id": "ScriptedDecisionNode",
-        "collection": true,
-        "name": "Scripted Decision",
-      },
-      "inputs": [
-        "*",
-      ],
-      "outcomes": [
-        "true",
-      ],
-      "outputs": [
-        "*",
-      ],
-      "script": "1b52a7e0-4019-40fa-958a-15a49870e901",
-    },
-  },
-  "saml2Entities": {},
-  "scripts": {
-    "1b52a7e0-4019-40fa-958a-15a49870e901": {
-      "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set the same shared state variable",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "shared",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('sharedValue', 'Level ' + level + ': This is a longer string value shared across all nested journeys. It contains an indicator in which level it was last set.');\\n}());"",
-    },
-    "41c24257-d7fc-4654-8b46-c2666dc5b56d": {
-      "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "set per level shared state variable",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "level",
-      "script": ""(function () {\\n  outcome = 'true';\\n  var level = nodeState.get('level').asInteger();\\n  sharedState.put('level' + level + 'Value', 'Level ' + level + ': This is a longer string value set at each level of the nested journeys. It contains an indicator in which level it was set.');\\n}());"",
-    },
-    "5bbdaeff-ddee-44b9-b608-8d413d7d65a6": {
-      "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
-      "context": "AUTHENTICATION_TREE_DECISION_NODE",
-      "createdBy": "null",
-      "creationDate": 0,
-      "default": false,
-      "description": "Check if mode has already been set.",
-      "language": "JAVASCRIPT",
-      "lastModifiedBy": "null",
-      "lastModifiedDate": 0,
-      "name": "mode",
-      "script": ""/* mode\\n *\\n * Author: volker.scheuber@forgerock.com\\n * \\n * Collect mode if not already set and set outcome to mode.\\n * \\n * This script does not need to be parametrized. It will work properly as is.\\n * \\n * The Scripted Decision Node needs the following outcomes defined:\\n * - 'shared and level'\\n * - 'shared only'\\n * - 'level only'\\n * - 'none'\\n */\\n(function () {\\n  var mode = nodeState.get('mode');\\n  if (mode) {\\n    outcome = mode.asString();\\n    var level = nodeState.get('level').asInteger() + 1;\\n    logger.error('mode: mode=' + mode.asString() + ', level=' + level);\\n    sharedState.put('level', level);\\n  }\\n  else {\\n    var choices = ['shared and level', 'shared only', 'level only', 'none'];\\n  \\n    var fr = JavaImporter(\\n      org.forgerock.openam.auth.node.api.Action,\\n      javax.security.auth.callback.ChoiceCallback\\n    )\\n\\n    if (callbacks.isEmpty()) {\\n      action = fr.Action.send([\\n        new fr.ChoiceCallback('Choose test mode', choices, 0, false)\\n      ]).build();\\n    } else {\\n      var choice = parseInt(callbacks.get(0).getSelectedIndexes()[0]);\\n      nodeState.putShared('mode', choices[choice]);\\n      nodeState.putShared('level', 0);\\n      action = fr.Action.goTo(choices[choice]).build();\\n    }\\n  }\\n}());"",
-    },
-  },
-  "socialIdentityProviders": {},
-  "themes": [],
-  "tree": {
-    "_id": "j01",
-    "enabled": true,
-    "entryNodeId": "b9c26251-9d4d-4499-b8e9-518f35111dbf",
-    "identityResource": "managed/alpha_user",
-    "innerTreeOnly": false,
-    "nodes": {
-      "7e975947-efba-4a50-97ea-7cbe3fbf7416": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 395,
-        "y": 345.015625,
-      },
-      "aa97f870-d95e-4861-b756-64b6423dd7da": {
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "e301438c-0bd0-429c-ab0c-66126501069a",
-        },
-        "displayName": "nest",
-        "nodeType": "InnerTreeEvaluatorNode",
-        "x": 816,
-        "y": 233.015625,
-      },
-      "b9c26251-9d4d-4499-b8e9-518f35111dbf": {
-        "connections": {
-          "level only": "7e975947-efba-4a50-97ea-7cbe3fbf7416",
-          "none": "aa97f870-d95e-4861-b756-64b6423dd7da",
-          "shared and level": "fa62ae77-1e86-4939-a773-e428259fac97",
-          "shared only": "ba0ed11d-850f-4b4a-81bc-0d4ad07736df",
-        },
-        "displayName": "mode",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 167,
-        "y": 210.015625,
-      },
-      "ba0ed11d-850f-4b4a-81bc-0d4ad07736df": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 393,
-        "y": 259.015625,
-      },
-      "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787": {
-        "connections": {
-          "true": "aa97f870-d95e-4861-b756-64b6423dd7da",
-        },
-        "displayName": "level",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 598,
-        "y": 173.015625,
-      },
-      "fa62ae77-1e86-4939-a773-e428259fac97": {
-        "connections": {
-          "true": "d2c7ef78-6b25-40d6-b58e-6ddca3c1f787",
-        },
-        "displayName": "shared",
-        "nodeType": "ScriptedDecisionNode",
-        "x": 392,
-        "y": 173.015625,
-      },
-    },
-    "staticNodes": {
-      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1236,
-        "y": 145,
-      },
-      "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1236,
-        "y": 253,
-      },
-      "startNode": {
-        "x": 50,
-        "y": 250,
-      },
-    },
-    "uiConfig": {
-      "categories": "[]",
     },
   },
 }


### PR DESCRIPTION
When using the `frodo journey export` command, journeys weren't being exported correctly, causing errors during import (see [this issue](https://github.com/rockcarver/frodo-cli/issues/498)). This PR is meant to replace [this PR](https://github.com/rockcarver/frodo-cli/pull/471) as the real fix for the issue, since the fix in that PR affects the imports where the real problem was with the exports not being right to begin with. Note that journey exports done with the `frodo config export` command are already in the correct format, so no changes were made there.