### PR TITLE
feat: Add config-manager push authentication command

### DIFF
--- a/src/cli/config-manager/config-manager-push/config-manager-push-authentication.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push-authentication.ts
@@ -1,0 +1,58 @@
+import { frodo } from '@rockcarver/frodo-lib';
+import { Option } from 'commander';
+
+import { configManagerImportAuthentication } from '../../../configManagerOps/FrConfigAuthenticationOps';
+import { getTokens } from '../../../ops/AuthenticateOps';
+import { printMessage, verboseMessage } from '../../../utils/Console';
+import { FrodoCommand } from '../../FrodoCommand';
+
+const { CLOUD_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+
+const deploymentTypes = [
+  CLOUD_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
+
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo config-manager push authentication',
+    [],
+    deploymentTypes
+  );
+
+  program
+    .description('Import authentication objects.')
+    .addOption(
+      new Option(
+        '-r, --realm <realm>',
+        'Specifies the realm to import from. Only the configuration from this realm will be imported.'
+      )
+    )
+    .action(async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
+      );
+      if (await getTokens(false, true, deploymentTypes)) {
+        verboseMessage('Importing config entity authentication');
+        const outcome = await configManagerImportAuthentication(options.realm);
+        if (!outcome) process.exitCode = 1;
+      }
+      // unrecognized combination of options or no options
+      else {
+        printMessage(
+          'Unrecognized combination of options or no options...',
+          'error'
+        );
+        program.help();
+        process.exitCode = 1;
+      }
+    });
+
+  return program;
+}

--- a/src/cli/config-manager/config-manager-push/config-manager-push.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push.ts
@@ -1,6 +1,7 @@
 import { FrodoStubCommand } from '../../FrodoCommand';
 import AccessConfig from './config-manager-push-access-config';
 import Audit from './config-manager-push-audit';
+import Authentication from './config-manager-push-authentication';
 import CookieDomains from './config-manager-push-cookie-domain';
 import EmailProvider from './config-manager-push-email-provider';
 import EmailTemplates from './config-manager-push-email-templates';
@@ -39,6 +40,7 @@ export default function setup() {
   program.addCommand(CookieDomains().name('cookie-domains'));
   program.addCommand(ServiceObjects().name('service-objects'));
   program.addCommand(UiConfig().name('ui-config'));
+  program.addCommand(Authentication().name('authentication'));
 
   return program;
 }

--- a/src/configManagerOps/FrConfigAuthenticationOps.ts
+++ b/src/configManagerOps/FrConfigAuthenticationOps.ts
@@ -1,10 +1,14 @@
 import { frodo, state } from '@rockcarver/frodo-lib';
+import { AuthenticationSettingsExportInterface } from '@rockcarver/frodo-lib/types/ops/AuthenticationSettingsOps';
+import fs from 'fs';
 
 import { printError } from '../utils/Console';
 import { realmList } from '../utils/FrConfig';
 
-const { readAuthenticationSettings: _readAuthenticationSettings } =
-  frodo.authn.settings;
+const {
+  readAuthenticationSettings: _readAuthenticationSettings,
+  importAuthenticationSettings,
+} = frodo.authn.settings;
 const { getFilePath, saveJsonToFile } = frodo.utils;
 
 /**
@@ -44,6 +48,62 @@ export async function configManagerExportAuthentication(
     return true;
   } catch (error) {
     printError(error, `Error exporting config entity ui-configuration`);
+  }
+  return false;
+}
+
+/**
+ * Import authentication configuration from the fr-config-manager format.
+ * @param {string} realm The realm of the authentication configuration being imported. If not supplied, will import all authentication configuration.
+ * @return {Promise<boolean>} a promise that resolves to true if successful, false otherwise
+ */
+export async function configManagerImportAuthentication(
+  realm?: string
+): Promise<boolean> {
+  try {
+    if (realm) {
+      const filePath = getFilePath(
+        `realms/${realm}/realm-config/authentication.json`
+      );
+      const fileContent = fs.readFileSync(filePath, 'utf-8');
+      const authData = JSON.parse(fileContent);
+      delete authData._rev;
+      const importData: AuthenticationSettingsExportInterface = {
+        authentication: authData,
+      };
+
+      await importAuthenticationSettings(importData, false);
+    } else {
+      const realmsPath = getFilePath(`realms/`);
+      const realmDirs = fs.readdirSync(realmsPath);
+      for (const realmName of realmDirs) {
+        await state.setRealm(realmName);
+        let realmPath;
+
+        if (realmName === 'realm-config') {
+          await state.setRealm('/');
+          realmPath = getFilePath(`realms/realm-config/authentication.json`);
+        } else {
+          await state.setRealm(realmName);
+          realmPath = getFilePath(
+            `realms/${realmName}/realm-config/authentication.json`
+          );
+        }
+
+        const fileContent = fs.readFileSync(realmPath, 'utf-8');
+        const authData = JSON.parse(fileContent);
+        delete authData._rev;
+        const importData: AuthenticationSettingsExportInterface = {
+          authentication: authData,
+        };
+
+        await importAuthenticationSettings(importData, false);
+      }
+    }
+
+    return true;
+  } catch (error) {
+    printError(error, `Error importing authentication settings`);
   }
   return false;
 }

--- a/test/client_cli/en/__snapshots__/config-manager-push-authentication.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-authentication.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI help interface for 'config-manager push authentication' should be expected english 1`] = `
+"Usage: frodo config-manager push authentication [options] [host] [realm] [username] [password]
+
+[Experimental] Import authentication objects.
+
+Arguments:
+  host                 AM base URL, e.g.: https://cdk.iam.example.com/am. To use
+                       a connection profile, just specify a unique substring or
+                       alias.
+  realm                Realm. Specify realm as '/' for the root realm or 'realm'
+                       or '/parent/child' otherwise. (default: "alpha" for
+                       Identity Cloud tenants, "/" otherwise.)
+  username             Username to login with. Must be an admin user with
+                       appropriate rights to manage authentication
+                       journeys/trees.
+  password             Password.
+
+Options:
+  -r, --realm <realm>  Specifies the realm to import from. Only the
+                       configuration from this realm will be imported.
+  -h, --help           Help
+  -hh, --help-more     Help with all options.
+  -hhh, --help-all     Help with all options, environment variables, and usage
+                       examples.
+"
+`;

--- a/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
@@ -15,6 +15,7 @@ Options:
 Commands:
   access-config         [Experimental] Import access configuration.
   audit                 [Experimental] Import audit configuration.
+  authentication        [Experimental] Import authentication objects.
   cookie-domains        [Experimental] Import cookie domains.
   email-provider        [Experimental] Import email provider configuration.
   email-templates       [Experimental] Import email template objects.

--- a/test/client_cli/en/config-manager-push-authentication.test.js
+++ b/test/client_cli/en/config-manager-push-authentication.test.js
@@ -1,0 +1,10 @@
+import cp from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(cp.exec);
+const CMD = 'frodo config-manager push authentication --help';
+const { stdout } = await exec(CMD);
+
+test("CLI help interface for 'config-manager push authentication' should be expected english", async () => {
+    expect(stdout).toMatchSnapshot();
+});

--- a/test/e2e/__snapshots__/config-manager-push-authentication.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/config-manager-push-authentication.e2e.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo config-manager pulls authentication "frodo config-manager push authentication -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import the authentication into forgeops" 1`] = `""`;
+
+exports[`frodo config-manager pulls authentication "frodo config-manager push authentication -r alpha -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import an authentication config by realm into forgeops" 1`] = `""`;

--- a/test/e2e/config-manager-push-authentication.e2e.test.js
+++ b/test/e2e/config-manager-push-authentication.e2e.test.js
@@ -1,0 +1,78 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+// ForgeOps
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push authentication -D test/e2e/exports/fr-config-manager/forgeops -m forgeops
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push authentication -r alpha -D test/e2e/exports/fr-config-manager/forgeops -m forgeops
+*/
+
+import cp from 'child_process';
+import { promisify } from 'util';
+import { getEnv, removeAnsiEscapeCodes } from './utils/TestUtils';
+import { forgeops_connection as fc } from './utils/TestConfig';
+
+const exec = promisify(cp.exec);
+
+process.env['FRODO_MOCK'] = '1';
+const forgeopsEnv = getEnv(fc);
+
+const allDirectory = "test/e2e/exports/fr-config-manager/forgeops";
+
+describe('frodo config-manager pulls authentication', () => {
+    test(`"frodo config-manager push authentication -D ${allDirectory} -m forgeops": should import the authentication into forgeops"`, async () => {
+        const CMD = `frodo config-manager push authentication -D ${allDirectory} -m forgeops`;
+        const { stdout } = await exec(CMD, forgeopsEnv);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+    test(`"frodo config-manager push authentication -r alpha -D ${allDirectory} -m forgeops": should import an authentication config by realm into forgeops"`, async () => {
+        const CMD = `frodo config-manager push authentication -r alpha -D ${allDirectory} -m forgeops`;
+        const { stdout } = await exec(CMD, forgeopsEnv);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+    });
+});

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/realm-config/authentication.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/realm-config/authentication.json
@@ -1,0 +1,66 @@
+{
+  "_id": "",
+  "_rev": "1552144906",
+  "_type": {
+    "_id": "EMPTY",
+    "collection": false,
+    "name": "Core"
+  },
+  "accountlockout": {
+    "lockoutDuration": 0,
+    "lockoutDurationMultiplier": 1,
+    "lockoutWarnUserCount": 0,
+    "loginFailureCount": 5,
+    "loginFailureDuration": 300,
+    "loginFailureLockoutMode": false,
+    "storeInvalidAttemptsInDataStore": true
+  },
+  "core": {
+    "adminAuthModule": "ldapService",
+    "orgConfig": "ldapService"
+  },
+  "general": {
+    "defaultAuthLevel": 0,
+    "identityType": [
+      "agent",
+      "user"
+    ],
+    "locale": "en_US",
+    "statelessSessionsEnabled": false,
+    "twoFactorRequired": false,
+    "userStatusCallbackPlugins": []
+  },
+  "postauthprocess": {
+    "loginFailureUrl": [],
+    "loginPostProcessClass": [],
+    "loginSuccessUrl": [
+      "/am/console"
+    ],
+    "userAttributeSessionMapping": [],
+    "usernameGeneratorClass": "com.sun.identity.authentication.spi.DefaultUserIDGenerator",
+    "usernameGeneratorEnabled": true
+  },
+  "security": {
+    "addClearSiteDataHeader": true,
+    "keyAlias": "test",
+    "moduleBasedAuthEnabled": true,
+    "sharedSecret": null,
+    "zeroPageLoginAllowedWithoutReferrer": true,
+    "zeroPageLoginEnabled": false,
+    "zeroPageLoginReferrerWhiteList": []
+  },
+  "trees": {
+    "authenticationSessionsMaxDuration": 5,
+    "authenticationSessionsStateManagement": "JWT",
+    "authenticationSessionsWhitelist": false,
+    "authenticationTreeCookieHttpOnly": true,
+    "suspendedAuthenticationTimeout": 5
+  },
+  "userprofile": {
+    "aliasAttributeName": [
+      "uid"
+    ],
+    "defaultRole": [],
+    "dynamicProfileCreation": "false"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/bravo/realm-config/authentication.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/bravo/realm-config/authentication.json
@@ -1,0 +1,66 @@
+{
+  "_id": "",
+  "_rev": "1552144906",
+  "_type": {
+    "_id": "EMPTY",
+    "collection": false,
+    "name": "Core"
+  },
+  "accountlockout": {
+    "lockoutDuration": 0,
+    "lockoutDurationMultiplier": 1,
+    "lockoutWarnUserCount": 0,
+    "loginFailureCount": 5,
+    "loginFailureDuration": 300,
+    "loginFailureLockoutMode": false,
+    "storeInvalidAttemptsInDataStore": true
+  },
+  "core": {
+    "adminAuthModule": "ldapService",
+    "orgConfig": "ldapService"
+  },
+  "general": {
+    "defaultAuthLevel": 0,
+    "identityType": [
+      "agent",
+      "user"
+    ],
+    "locale": "en_US",
+    "statelessSessionsEnabled": false,
+    "twoFactorRequired": false,
+    "userStatusCallbackPlugins": []
+  },
+  "postauthprocess": {
+    "loginFailureUrl": [],
+    "loginPostProcessClass": [],
+    "loginSuccessUrl": [
+      "/am/console"
+    ],
+    "userAttributeSessionMapping": [],
+    "usernameGeneratorClass": "com.sun.identity.authentication.spi.DefaultUserIDGenerator",
+    "usernameGeneratorEnabled": true
+  },
+  "security": {
+    "addClearSiteDataHeader": true,
+    "keyAlias": "test",
+    "moduleBasedAuthEnabled": true,
+    "sharedSecret": null,
+    "zeroPageLoginAllowedWithoutReferrer": true,
+    "zeroPageLoginEnabled": false,
+    "zeroPageLoginReferrerWhiteList": []
+  },
+  "trees": {
+    "authenticationSessionsMaxDuration": 5,
+    "authenticationSessionsStateManagement": "JWT",
+    "authenticationSessionsWhitelist": false,
+    "authenticationTreeCookieHttpOnly": true,
+    "suspendedAuthenticationTimeout": 5
+  },
+  "userprofile": {
+    "aliasAttributeName": [
+      "uid"
+    ],
+    "defaultRole": [],
+    "dynamicProfileCreation": "false"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_D_m_314327836/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_D_m_314327836/am_1076162899/recording.har
@@ -1,0 +1,945 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/authentication/0_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 370,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 587,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 587,
+            "text": "{\"_id\":\"*\",\"_rev\":\"2075994313\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "587"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"2075994313\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.024Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "amadmin"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "41ghjnKpNFAFU/HXw82HbFbitYNOOJ0g"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 497,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 693,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.042Z",
+        "time": 21,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 21
+        }
+      },
+      {
+        "_id": "6a3744385d3fd7416ea7089e610fa7e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 424,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-03-31T22:24:59Z\",\"maxIdleExpirationTime\":\"2026-03-31T22:54:59Z\",\"maxSessionExpirationTime\":\"2026-04-01T00:24:58Z\",\"properties\":{\"AMCtxId\":\"87bd5796-6c1a-4d13-8c2b-a1619ca81517-49302\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.070Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 520,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-466575464\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.083Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "17daf6be3ac8f188ac301329a0f5d553",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1296,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1296"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"\",\"_type\":{\"_id\":\"EMPTY\",\"collection\":false,\"name\":\"Core\"},\"accountlockout\":{\"lockoutDuration\":0,\"lockoutDurationMultiplier\":1,\"lockoutWarnUserCount\":0,\"loginFailureCount\":5,\"loginFailureDuration\":300,\"loginFailureLockoutMode\":false,\"storeInvalidAttemptsInDataStore\":true},\"core\":{\"adminAuthModule\":\"ldapService\",\"orgConfig\":\"ldapService\"},\"general\":{\"defaultAuthLevel\":0,\"identityType\":[\"agent\",\"user\"],\"locale\":\"en_US\",\"statelessSessionsEnabled\":false,\"twoFactorRequired\":false,\"userStatusCallbackPlugins\":[]},\"postauthprocess\":{\"loginFailureUrl\":[],\"loginPostProcessClass\":[],\"loginSuccessUrl\":[\"/am/console\"],\"userAttributeSessionMapping\":[],\"usernameGeneratorClass\":\"com.sun.identity.authentication.spi.DefaultUserIDGenerator\",\"usernameGeneratorEnabled\":true},\"security\":{\"addClearSiteDataHeader\":true,\"keyAlias\":\"test\",\"moduleBasedAuthEnabled\":true,\"sharedSecret\":null,\"zeroPageLoginAllowedWithoutReferrer\":true,\"zeroPageLoginEnabled\":false,\"zeroPageLoginReferrerWhiteList\":[]},\"trees\":{\"authenticationSessionsMaxDuration\":5,\"authenticationSessionsStateManagement\":\"JWT\",\"authenticationSessionsWhitelist\":false,\"authenticationTreeCookieHttpOnly\":true,\"suspendedAuthenticationTimeout\":5},\"userprofile\":{\"aliasAttributeName\":[\"uid\"],\"defaultRole\":[],\"dynamicProfileCreation\":\"false\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication"
+        },
+        "response": {
+          "bodySize": 1437,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1437,
+            "text": "{\"_id\":\"\",\"_rev\":\"-754038573\",\"security\":{\"zeroPageLoginReferrerWhiteList\":[],\"moduleBasedAuthEnabled\":true,\"zeroPageLoginEnabled\":false,\"zeroPageLoginAllowedWithoutReferrer\":true,\"sharedSecret\":null,\"addClearSiteDataHeader\":true,\"keyAlias\":\"test\"},\"postauthprocess\":{\"loginPostProcessClass\":[],\"userAttributeSessionMapping\":[],\"usernameGeneratorClass\":\"com.sun.identity.authentication.spi.DefaultUserIDGenerator\",\"usernameGeneratorEnabled\":true,\"loginSuccessUrl\":[\"/am/console\"],\"loginFailureUrl\":[]},\"trees\":{\"suspendedAuthenticationTimeout\":5,\"authenticationSessionsStateManagement\":\"JWT\",\"authenticationSessionsMaxDuration\":5,\"authenticationTreeCookieHttpOnly\":true,\"authenticationSessionsWhitelist\":false},\"accountlockout\":{\"loginFailureLockoutMode\":false,\"storeInvalidAttemptsInDataStore\":true,\"invalidAttemptsDataAttributeName\":\"fr-attr-str4\",\"lockoutDurationMultiplier\":1,\"lockoutWarnUserCount\":0,\"loginFailureDuration\":300,\"lockoutDuration\":0,\"lockoutAttributeValue\":\"locked\",\"lockoutAttributeName\":\"fr-attr-str3\",\"loginFailureCount\":5},\"core\":{\"adminAuthModule\":\"ldapService\",\"orgConfig\":\"ldapService\"},\"general\":{\"userStatusCallbackPlugins\":[],\"locale\":\"en_US\",\"identityType\":[\"agent\",\"user\"],\"defaultAuthLevel\":0,\"statelessSessionsEnabled\":false,\"twoFactorRequired\":false},\"userprofile\":{\"defaultRole\":[],\"dynamicProfileCreation\":\"false\",\"aliasAttributeName\":[\"uid\"]},\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Core\",\"collection\":false}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1437"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-754038573\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.163Z",
+        "time": 23,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 23
+        }
+      },
+      {
+        "_id": "f7992e3fab7717565414df08c45fd4e1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1296,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1296"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"\",\"_type\":{\"_id\":\"EMPTY\",\"collection\":false,\"name\":\"Core\"},\"accountlockout\":{\"lockoutDuration\":0,\"lockoutDurationMultiplier\":1,\"lockoutWarnUserCount\":0,\"loginFailureCount\":5,\"loginFailureDuration\":300,\"loginFailureLockoutMode\":false,\"storeInvalidAttemptsInDataStore\":true},\"core\":{\"adminAuthModule\":\"ldapService\",\"orgConfig\":\"ldapService\"},\"general\":{\"defaultAuthLevel\":0,\"identityType\":[\"agent\",\"user\"],\"locale\":\"en_US\",\"statelessSessionsEnabled\":false,\"twoFactorRequired\":false,\"userStatusCallbackPlugins\":[]},\"postauthprocess\":{\"loginFailureUrl\":[],\"loginPostProcessClass\":[],\"loginSuccessUrl\":[\"/am/console\"],\"userAttributeSessionMapping\":[],\"usernameGeneratorClass\":\"com.sun.identity.authentication.spi.DefaultUserIDGenerator\",\"usernameGeneratorEnabled\":true},\"security\":{\"addClearSiteDataHeader\":true,\"keyAlias\":\"test\",\"moduleBasedAuthEnabled\":true,\"sharedSecret\":null,\"zeroPageLoginAllowedWithoutReferrer\":true,\"zeroPageLoginEnabled\":false,\"zeroPageLoginReferrerWhiteList\":[]},\"trees\":{\"authenticationSessionsMaxDuration\":5,\"authenticationSessionsStateManagement\":\"JWT\",\"authenticationSessionsWhitelist\":false,\"authenticationTreeCookieHttpOnly\":true,\"suspendedAuthenticationTimeout\":5},\"userprofile\":{\"aliasAttributeName\":[\"uid\"],\"defaultRole\":[],\"dynamicProfileCreation\":\"false\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/bravo/realm-config/authentication"
+        },
+        "response": {
+          "bodySize": 1316,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1316,
+            "text": "{\"_id\":\"\",\"_rev\":\"1552144906\",\"security\":{\"zeroPageLoginReferrerWhiteList\":[],\"moduleBasedAuthEnabled\":true,\"zeroPageLoginEnabled\":false,\"zeroPageLoginAllowedWithoutReferrer\":true,\"sharedSecret\":null,\"addClearSiteDataHeader\":true,\"keyAlias\":\"test\"},\"postauthprocess\":{\"loginPostProcessClass\":[],\"userAttributeSessionMapping\":[],\"usernameGeneratorClass\":\"com.sun.identity.authentication.spi.DefaultUserIDGenerator\",\"usernameGeneratorEnabled\":true,\"loginSuccessUrl\":[\"/am/console\"],\"loginFailureUrl\":[]},\"trees\":{\"suspendedAuthenticationTimeout\":5,\"authenticationSessionsStateManagement\":\"JWT\",\"authenticationSessionsMaxDuration\":5,\"authenticationTreeCookieHttpOnly\":true,\"authenticationSessionsWhitelist\":false},\"accountlockout\":{\"loginFailureLockoutMode\":false,\"storeInvalidAttemptsInDataStore\":true,\"lockoutDurationMultiplier\":1,\"lockoutWarnUserCount\":0,\"loginFailureDuration\":300,\"lockoutDuration\":0,\"loginFailureCount\":5},\"core\":{\"adminAuthModule\":\"ldapService\",\"orgConfig\":\"ldapService\"},\"general\":{\"userStatusCallbackPlugins\":[],\"locale\":\"en_US\",\"identityType\":[\"agent\",\"user\"],\"defaultAuthLevel\":0,\"statelessSessionsEnabled\":false,\"twoFactorRequired\":false},\"userprofile\":{\"defaultRole\":[],\"dynamicProfileCreation\":\"false\",\"aliasAttributeName\":[\"uid\"]},\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Core\",\"collection\":false}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1316"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1552144906\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.193Z",
+        "time": 28,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 28
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_D_m_314327836/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_D_m_314327836/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/authentication/0_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 565,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=tmKwRw_U1gq05TIYQSyccHN_t-U.*AAJTSQACMDIAAlNLABx2eGUvQlE4Z3l6aE1sSFFlN2hocW1LSUVNNWM9AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=6mcJkTgbKo2KA8USaV3S9I4GjS5k_FzrahNdCRK_DVA&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=m1m-n79INh8eS7qkWTYkG6tEn5A&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 673,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=m1m-n79INh8eS7qkWTYkG6tEn5A&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.095Z",
+        "time": 15,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 15
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-ffed6347-21d6-4e64-b264-eccbdd4728c7"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 424,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=m1m-n79INh8eS7qkWTYkG6tEn5A&code_verifier=NDDfnD28R1HlpQNTDA60vVr6TUfJHw74e5tnObREwuo"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:24:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:24:59.116Z",
+        "time": 38,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 38
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_r_D_m_3443305505/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_r_D_m_3443305505/am_1076162899/recording.har
@@ -1,0 +1,788 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/authentication/0_r_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-457f5259-e4c9-4228-81e4-1613da674deb"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 370,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 587,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 587,
+            "text": "{\"_id\":\"*\",\"_rev\":\"2075994313\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:25:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "587"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"2075994313\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:25:27.911Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-457f5259-e4c9-4228-81e4-1613da674deb"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "amadmin"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "41ghjnKpNFAFU/HXw82HbFbitYNOOJ0g"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 497,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:25:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 693,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:25:27.931Z",
+        "time": 25,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 25
+        }
+      },
+      {
+        "_id": "7a2803b95b7b030f104baf5a89ef50c3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-457f5259-e4c9-4228-81e4-1613da674deb"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-03-31T22:25:28Z\",\"maxIdleExpirationTime\":\"2026-03-31T22:55:28Z\",\"maxSessionExpirationTime\":\"2026-04-01T00:25:27Z\",\"properties\":{\"AMCtxId\":\"87bd5796-6c1a-4d13-8c2b-a1619ca81517-49379\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:25:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:25:27.966Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-457f5259-e4c9-4228-81e4-1613da674deb"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 520,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:25:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-466575464\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:25:27.981Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "17daf6be3ac8f188ac301329a0f5d553",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1296,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-457f5259-e4c9-4228-81e4-1613da674deb"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1296"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"\",\"_type\":{\"_id\":\"EMPTY\",\"collection\":false,\"name\":\"Core\"},\"accountlockout\":{\"lockoutDuration\":0,\"lockoutDurationMultiplier\":1,\"lockoutWarnUserCount\":0,\"loginFailureCount\":5,\"loginFailureDuration\":300,\"loginFailureLockoutMode\":false,\"storeInvalidAttemptsInDataStore\":true},\"core\":{\"adminAuthModule\":\"ldapService\",\"orgConfig\":\"ldapService\"},\"general\":{\"defaultAuthLevel\":0,\"identityType\":[\"agent\",\"user\"],\"locale\":\"en_US\",\"statelessSessionsEnabled\":false,\"twoFactorRequired\":false,\"userStatusCallbackPlugins\":[]},\"postauthprocess\":{\"loginFailureUrl\":[],\"loginPostProcessClass\":[],\"loginSuccessUrl\":[\"/am/console\"],\"userAttributeSessionMapping\":[],\"usernameGeneratorClass\":\"com.sun.identity.authentication.spi.DefaultUserIDGenerator\",\"usernameGeneratorEnabled\":true},\"security\":{\"addClearSiteDataHeader\":true,\"keyAlias\":\"test\",\"moduleBasedAuthEnabled\":true,\"sharedSecret\":null,\"zeroPageLoginAllowedWithoutReferrer\":true,\"zeroPageLoginEnabled\":false,\"zeroPageLoginReferrerWhiteList\":[]},\"trees\":{\"authenticationSessionsMaxDuration\":5,\"authenticationSessionsStateManagement\":\"JWT\",\"authenticationSessionsWhitelist\":false,\"authenticationTreeCookieHttpOnly\":true,\"suspendedAuthenticationTimeout\":5},\"userprofile\":{\"aliasAttributeName\":[\"uid\"],\"defaultRole\":[],\"dynamicProfileCreation\":\"false\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication"
+        },
+        "response": {
+          "bodySize": 1437,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1437,
+            "text": "{\"_id\":\"\",\"_rev\":\"-754038573\",\"security\":{\"zeroPageLoginReferrerWhiteList\":[],\"moduleBasedAuthEnabled\":true,\"zeroPageLoginEnabled\":false,\"zeroPageLoginAllowedWithoutReferrer\":true,\"sharedSecret\":null,\"addClearSiteDataHeader\":true,\"keyAlias\":\"test\"},\"postauthprocess\":{\"loginPostProcessClass\":[],\"userAttributeSessionMapping\":[],\"usernameGeneratorClass\":\"com.sun.identity.authentication.spi.DefaultUserIDGenerator\",\"usernameGeneratorEnabled\":true,\"loginSuccessUrl\":[\"/am/console\"],\"loginFailureUrl\":[]},\"trees\":{\"suspendedAuthenticationTimeout\":5,\"authenticationSessionsStateManagement\":\"JWT\",\"authenticationSessionsMaxDuration\":5,\"authenticationTreeCookieHttpOnly\":true,\"authenticationSessionsWhitelist\":false},\"accountlockout\":{\"loginFailureLockoutMode\":false,\"storeInvalidAttemptsInDataStore\":true,\"invalidAttemptsDataAttributeName\":\"fr-attr-str4\",\"lockoutDurationMultiplier\":1,\"lockoutWarnUserCount\":0,\"loginFailureDuration\":300,\"lockoutDuration\":0,\"lockoutAttributeValue\":\"locked\",\"lockoutAttributeName\":\"fr-attr-str3\",\"loginFailureCount\":5},\"core\":{\"adminAuthModule\":\"ldapService\",\"orgConfig\":\"ldapService\"},\"general\":{\"userStatusCallbackPlugins\":[],\"locale\":\"en_US\",\"identityType\":[\"agent\",\"user\"],\"defaultAuthLevel\":0,\"statelessSessionsEnabled\":false,\"twoFactorRequired\":false},\"userprofile\":{\"defaultRole\":[],\"dynamicProfileCreation\":\"false\",\"aliasAttributeName\":[\"uid\"]},\"_type\":{\"_id\":\"EMPTY\",\"name\":\"Core\",\"collection\":false}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:25:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1437"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-754038573\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:25:28.057Z",
+        "time": 20,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 20
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_r_D_m_3443305505/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/authentication_2600143457/0_r_D_m_3443305505/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/authentication/0_r_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-457f5259-e4c9-4228-81e4-1613da674deb"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 565,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=OZfkb1NUb_XVoTTcEaJ4WHv7FnY.*AAJTSQACMDIAAlNLABxkRm42M2RWQktFSTZINVVuWkIvZHZ6bUNpT0U9AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=j-UazCtn5hubmtIgxPB8Ydo4dtalzWdqPKEdBwTNYYs&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:25:28 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=s2w7bsBUElJVW93AosqQmdpnDfI&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=s2w7bsBUElJVW93AosqQmdpnDfI&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-03-31T22:25:27.995Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-457f5259-e4c9-4228-81e4-1613da674deb"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 424,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=s2w7bsBUElJVW93AosqQmdpnDfI&code_verifier=l6yWrk5ubXogQUIzmPHuDA22-NScXnRd7eOWuXa5UP8"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 31 Mar 2026 22:25:28 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 403,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-03-31T22:25:28.015Z",
+        "time": 35,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 35
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
I added a function to import authentication configurations for the frodo config-manager push authentication command.

I also added the command implementation file to enable the command.