### PR TITLE
feat: Add config-manager push connector-definitions command

### DIFF
--- a/src/cli/config-manager/config-manager-push/config-manager-push-connector-definitions.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push-connector-definitions.ts
@@ -1,0 +1,52 @@
+import { frodo } from '@rockcarver/frodo-lib';
+import { Option } from 'commander';
+
+import { configManagerImportConnectors } from '../../../configManagerOps/FrConfigConnectorDefinitionsOps';
+import { getTokens } from '../../../ops/AuthenticateOps';
+import { verboseMessage } from '../../../utils/Console';
+import { FrodoCommand } from '../../FrodoCommand';
+
+const { CLOUD_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+
+const deploymentTypes = [
+  CLOUD_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
+
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo config-manager push connector-definitions',
+    [],
+    deploymentTypes
+  );
+
+  program
+    .description('Import connector definitions.')
+    .addOption(
+      new Option(
+        '-n, --name <name>',
+        'Connector definition name; imports only the specified connector definition.'
+      )
+    )
+    .action(async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
+      );
+
+      if (await getTokens(false, true, deploymentTypes)) {
+        verboseMessage('Importing connector definitions');
+        const outcome = await configManagerImportConnectors(options.name);
+        if (!outcome) process.exitCode = 1;
+      } else {
+        process.exitCode = 1;
+      }
+    });
+
+  return program;
+}

--- a/src/cli/config-manager/config-manager-push/config-manager-push.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push.ts
@@ -1,6 +1,7 @@
 import { FrodoStubCommand } from '../../FrodoCommand';
 import AccessConfig from './config-manager-push-access-config';
 import Audit from './config-manager-push-audit';
+import ConnectorDefinitions from './config-manager-push-connector-definitions';
 import CookieDomains from './config-manager-push-cookie-domain';
 import EmailProvider from './config-manager-push-email-provider';
 import EmailTemplates from './config-manager-push-email-templates';
@@ -39,6 +40,7 @@ export default function setup() {
   program.addCommand(CookieDomains().name('cookie-domains'));
   program.addCommand(ServiceObjects().name('service-objects'));
   program.addCommand(UiConfig().name('ui-config'));
+  program.addCommand(ConnectorDefinitions().name('connector-definitions'));
 
   return program;
 }

--- a/src/configManagerOps/FrConfigConnectorDefinitionsOps.ts
+++ b/src/configManagerOps/FrConfigConnectorDefinitionsOps.ts
@@ -1,10 +1,12 @@
 import { frodo } from '@rockcarver/frodo-lib';
 import { ConnectorSkeleton } from '@rockcarver/frodo-lib/types/ops/ConnectorOps';
+import fs from 'fs';
 
 import { printError, verboseMessage } from '../utils/Console';
 
 const { connector } = frodo.idm;
 const { getFilePath, saveJsonToFile } = frodo.utils;
+const { importConfigEntities } = frodo.idm.config;
 type ByName = { connectorName: string };
 type BySkeleton = { c: ConnectorSkeleton };
 
@@ -73,4 +75,45 @@ export async function configManagerExportConnectorDefinitionsAll(): Promise<bool
   } catch (error) {
     printError(error);
   }
+}
+
+/**
+ * Import all connectors in fr-config-manager format
+ * @param {string} name optional name of connector definition to import
+ * @returns {Promise<boolean>} true if successful, false otherwise
+ */
+export async function configManagerImportConnectors(
+  name?: string
+): Promise<boolean> {
+  try {
+    const connMappingDir = getFilePath('sync/connectors/');
+    const connMappingFiles = fs.readdirSync(connMappingDir);
+    const connMappingImportData = { idm: {} };
+
+    if (name) {
+      const filePath = getFilePath(`sync/connectors/${name}.json`);
+      const fileData = fs.readFileSync(filePath, 'utf8');
+      const importData = JSON.parse(fileData);
+      const id = importData._id;
+      connMappingImportData.idm[id] = importData;
+      await importConfigEntities(connMappingImportData);
+    } else {
+      for (const connMappingFile of connMappingFiles) {
+        const filePath = getFilePath(`sync/connectors/`);
+        const fileData = fs.readFileSync(
+          `${filePath}/${connMappingFile}`,
+          'utf-8'
+        );
+        const importData = JSON.parse(fileData);
+        const id = importData._id;
+        connMappingImportData.idm[id] = importData;
+      }
+      await importConfigEntities(connMappingImportData);
+    }
+
+    return true;
+  } catch (error) {
+    printError(error, `Error exporting mappings to files`);
+  }
+  return false;
 }

--- a/test/client_cli/en/__snapshots__/config-manager-push-connector-definitions.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-connector-definitions.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI help interface for 'config-manager push connector-definitions' should be expected english 1`] = `
+"Usage: frodo config-manager push connector-definitions [options] [host] [realm] [username] [password]
+
+[Experimental] Import connector definitions.
+
+Arguments:
+  host               AM base URL, e.g.: https://cdk.iam.example.com/am. To use a
+                     connection profile, just specify a unique substring or
+                     alias.
+  realm              Realm. Specify realm as '/' for the root realm or 'realm'
+                     or '/parent/child' otherwise. (default: "alpha" for
+                     Identity Cloud tenants, "/" otherwise.)
+  username           Username to login with. Must be an admin user with
+                     appropriate rights to manage authentication journeys/trees.
+  password           Password.
+
+Options:
+  -n, --name <name>  Connector definition name; imports only the specified
+                     connector definition.
+  -h, --help         Help
+  -hh, --help-more   Help with all options.
+  -hhh, --help-all   Help with all options, environment variables, and usage
+                     examples.
+"
+`;

--- a/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
@@ -7,29 +7,30 @@ exports[`CLI help interface for 'config-manager push' should be expected english
 compatible with fr-config-manager).
 
 Options:
-  -h, --help            Help
-  -hh, --help-more      Help with all options.
-  -hhh, --help-all      Help with all options, environment variables, and usage
-                        examples.
+  -h, --help             Help
+  -hh, --help-more       Help with all options.
+  -hhh, --help-all       Help with all options, environment variables, and usage
+                         examples.
 
 Commands:
-  access-config         [Experimental] Import access configuration.
-  audit                 [Experimental] Import audit configuration.
-  cookie-domains        [Experimental] Import cookie domains.
-  email-provider        [Experimental] Import email provider configuration.
-  email-templates       [Experimental] Import email template objects.
-  endpoints             [Experimental] Import custom endpoints objects.
-  help                  display help for command
-  internal-roles        [Experimental] Import internal roles.
-  kba                   [Experimental] Import kba configuration.
-  locales               [Experimental] Import custom locales objects.
-  managed-objects       [Experimental] Import managed objects.
-  org-privileges        [Experimental] Import organization privileges config.
-  password-policy       [Experimental] Import password-policy objects.
-  schedules             [Experimental] Import schedules.
-  service-objects       [Experimental] Import service objects.
-  terms-and-conditions  [Experimental] Import terms and conditions.
-  themes                [Experimental] Import themes.
-  ui-config             [Experimental] Import UI configuration.
+  access-config          [Experimental] Import access configuration.
+  audit                  [Experimental] Import audit configuration.
+  connector-definitions  [Experimental] Import connector definitions.
+  cookie-domains         [Experimental] Import cookie domains.
+  email-provider         [Experimental] Import email provider configuration.
+  email-templates        [Experimental] Import email template objects.
+  endpoints              [Experimental] Import custom endpoints objects.
+  help                   display help for command
+  internal-roles         [Experimental] Import internal roles.
+  kba                    [Experimental] Import kba configuration.
+  locales                [Experimental] Import custom locales objects.
+  managed-objects        [Experimental] Import managed objects.
+  org-privileges         [Experimental] Import organization privileges config.
+  password-policy        [Experimental] Import password-policy objects.
+  schedules              [Experimental] Import schedules.
+  service-objects        [Experimental] Import service objects.
+  terms-and-conditions   [Experimental] Import terms and conditions.
+  themes                 [Experimental] Import themes.
+  ui-config              [Experimental] Import UI configuration.
 "
 `;

--- a/test/client_cli/en/config-manager-push-connector-definitions.test.js
+++ b/test/client_cli/en/config-manager-push-connector-definitions.test.js
@@ -1,0 +1,10 @@
+import cp from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(cp.exec);
+const CMD = 'frodo config-manager push connector-definitions --help';
+const { stdout } = await exec(CMD);
+
+test("CLI help interface for 'config-manager push connector-definitions' should be expected english", async () => {
+    expect(stdout).toMatchSnapshot();
+});

--- a/test/e2e/__snapshots__/config-manager-push-connector-definitions.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/config-manager-push-connector-definitions.e2e.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo config-manager push connector-definitions "frodo config-manager push connector-definitions -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import the connector definitions into forgeops" 1`] = `""`;
+
+exports[`frodo config-manager push connector-definitions "frodo config-manager push connector-definitions -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import the connector definitions into forgeops" 2`] = `
+"Experimental feature in use: 'frodo config-manager push connector-definitions'. This feature may change without notice.
+"
+`;
+
+exports[`frodo config-manager push connector-definitions "frodo config-manager push connector-definitions -n csv -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import the csv connector definition into forgeops" 1`] = `""`;
+
+exports[`frodo config-manager push connector-definitions "frodo config-manager push connector-definitions -n csv -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import the csv connector definition into forgeops" 2`] = `
+"Experimental feature in use: 'frodo config-manager push connector-definitions'. This feature may change without notice.
+"
+`;

--- a/test/e2e/config-manager-push-connector-definitions.e2e.test.js
+++ b/test/e2e/config-manager-push-connector-definitions.e2e.test.js
@@ -1,0 +1,80 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+// ForgeOps
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push connector-definitions -D test/e2e/exports/fr-config-manager/forgeops -m forgeops 
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push connector-definitions -n csv -D test/e2e/exports/fr-config-manager/forgeops -m forgeops
+*/
+
+import cp from 'child_process';
+import { promisify } from 'util';
+import { getEnv, removeAnsiEscapeCodes } from './utils/TestUtils';
+import { forgeops_connection as fc } from './utils/TestConfig';
+
+const exec = promisify(cp.exec);
+
+process.env['FRODO_MOCK'] = '1';
+const forgeopsEnv = getEnv(fc);
+
+const allDirectory = "test/e2e/exports/fr-config-manager/forgeops";
+
+describe('frodo config-manager push connector-definitions', () => {
+    test(`"frodo config-manager push connector-definitions -D ${allDirectory} -m forgeops": should import the connector definitions into forgeops"`, async () => {
+        const CMD = `frodo config-manager push connector-definitions -D ${allDirectory} -m forgeops`;
+        const { stdout, stderr } = await exec(CMD, forgeopsEnv);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+        expect(removeAnsiEscapeCodes(stderr)).toMatchSnapshot();
+    });
+    test(`"frodo config-manager push connector-definitions -n csv -D ${allDirectory} -m forgeops": should import the csv connector definition into forgeops"`, async () => {
+        const CMD = `frodo config-manager push connector-definitions -n csv -D ${allDirectory} -m forgeops`;
+        const { stdout, stderr } = await exec(CMD, forgeopsEnv);
+        expect(removeAnsiEscapeCodes(stdout)).toMatchSnapshot();
+        expect(removeAnsiEscapeCodes(stderr)).toMatchSnapshot();
+    });
+});

--- a/test/e2e/exports/fr-config-manager/forgeops/sync/connectors/csv.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/sync/connectors/csv.json
@@ -1,0 +1,91 @@
+{
+  "_id": "provisioner.openicf/csv",
+  "configurationProperties": {
+    "csvFile": "/home/trivir/Work/frodo-cli/test.csv",
+    "escapeCharacter": "\\",
+    "fieldDelimiter": ",",
+    "headerPassword": "password",
+    "headerUid": "userName",
+    "newlineString": "\\n",
+    "quoteCharacter": "\"",
+    "spaceReplacementString": "_",
+    "syncFileRetentionCount": "3"
+  },
+  "connectorRef": {
+    "bundleName": "org.forgerock.openicf.connectors.csvfile-connector",
+    "bundleVersion": "1.5.20.34",
+    "connectorHostRef": "rcs",
+    "connectorName": "org.forgerock.openicf.csvfile.CSVFileConnector",
+    "displayName": "CSV File Connector",
+    "systemType": "provisioner.openicf"
+  },
+  "enabled": false,
+  "objectTypes": {
+    "__ACCOUNT__": {
+      "$schema": "http://json-schema.org/draft-03/schema",
+      "id": "__ACCOUNT__",
+      "nativeType": "__ACCOUNT__",
+      "properties": {
+        "__NAME__": {
+          "nativeName": "__NAME__",
+          "nativeType": "string",
+          "type": "string"
+        },
+        "activeDate": {
+          "nativeName": "activeDate",
+          "nativeType": "string",
+          "type": "string"
+        },
+        "email": {
+          "nativeName": "email",
+          "nativeType": "string",
+          "type": "string"
+        },
+        "firstName": {
+          "nativeName": "firstName",
+          "nativeType": "string",
+          "type": "string"
+        },
+        "lastName": {
+          "nativeName": "lastName",
+          "nativeType": "string",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "operationTimeout": {
+    "AUTHENTICATE": -1,
+    "CREATE": -1,
+    "DELETE": -1,
+    "GET": -1,
+    "RESOLVEUSERNAME": -1,
+    "SCHEMA": -1,
+    "SCRIPT_ON_CONNECTOR": -1,
+    "SCRIPT_ON_RESOURCE": -1,
+    "SEARCH": -1,
+    "SYNC": -1,
+    "TEST": -1,
+    "UPDATE": -1,
+    "VALIDATE": -1
+  },
+  "resultsHandlerConfig": {
+    "enableAttributesToGetSearchResultsHandler": true,
+    "enableCaseInsensitiveFilter": false,
+    "enableFilteredResultsHandler": false,
+    "enableNormalizingResultsHandler": false
+  },
+  "syncFailureHandler": {
+    "maxRetries": 0,
+    "postRetryAction": {
+      "script": {
+        "globals": {
+          "message": "hello world!"
+        },
+        "source": "/*\n* This is a test script\n*/\nconsole.log(message);",
+        "type": "text/javascript"
+      }
+    }
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/sync/connectors/salesforce.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/sync/connectors/salesforce.json
@@ -1,0 +1,91 @@
+{
+  "_id": "provisioner.openicf/salesforce",
+  "configurationProperties": {
+    "clientId": "key",
+    "clientSecret": {
+      "$crypto": {
+        "type": "x-simple-encryption",
+        "value": {
+          "cipher": "AES/CBC/PKCS5Padding",
+          "data": "40bgEWtIvhh9z41Q7AkSDA==",
+          "iv": "A1alWb/ADDU71HIEbeYHCw==",
+          "keySize": 16,
+          "mac": "QnaZr/1qtYufWX1eJ+hU6g==",
+          "purpose": "idm.config.encryption",
+          "salt": "e90Jq3pJVPbLVu5jVnt9rQ==",
+          "stableId": "openidm-sym-default"
+        }
+      }
+    },
+    "connectTimeout": 120000,
+    "grantType": "refresh_token",
+    "instanceUrl": "",
+    "loginUrl": "https://test.salesforce.com/services/oauth2/token",
+    "maximumConnections": 10,
+    "proxyHost": null,
+    "proxyPassword": null,
+    "proxyPort": 3128,
+    "proxyUri": null,
+    "proxyUsername": null,
+    "refreshToken": null,
+    "supportedFeatureLicenses": [
+      "UserPermissionsChatterAnswersUser",
+      "UserPermissionsInteractionUser",
+      "UserPermissionsKnowledgeUser",
+      "UserPermissionsLiveAgentUser",
+      "UserPermissionsMarketingUser",
+      "UserPermissionsOfflineUser",
+      "UserPermissionsSFContentUser",
+      "UserPermissionsSupportUser",
+      "UserPermissionsSiteforceContributorUser",
+      "UserPermissionsSiteforcePublisherUser",
+      "UserPermissionsWorkDotComUserFeature"
+    ],
+    "supportedObjectTypes": [
+      "User"
+    ],
+    "version": 48
+  },
+  "connectorRef": {
+    "bundleName": "org.forgerock.openicf.connectors.salesforce-connector",
+    "bundleVersion": "1.5.20.28",
+    "connectorHostRef": "",
+    "connectorName": "org.forgerock.openicf.connectors.salesforce.SalesforceConnector",
+    "displayName": "Salesforce Connector",
+    "systemType": "provisioner.openicf"
+  },
+  "enabled": false,
+  "operationTimeout": {
+    "AUTHENTICATE": -1,
+    "CREATE": -1,
+    "DELETE": -1,
+    "GET": -1,
+    "RESOLVEUSERNAME": -1,
+    "SCHEMA": -1,
+    "SCRIPT_ON_CONNECTOR": -1,
+    "SCRIPT_ON_RESOURCE": -1,
+    "SEARCH": -1,
+    "SYNC": -1,
+    "TEST": -1,
+    "UPDATE": -1,
+    "VALIDATE": -1
+  },
+  "resultsHandlerConfig": {
+    "enableAttributesToGetSearchResultsHandler": true,
+    "enableCaseInsensitiveFilter": false,
+    "enableFilteredResultsHandler": false,
+    "enableNormalizingResultsHandler": false
+  },
+  "syncFailureHandler": {
+    "maxRetries": 5,
+    "postRetryAction": {
+      "script": {
+        "globals": {
+          "message": "hello world!"
+        },
+        "source": "/*\n* This is a test script\n*/\nprintln \"$message\"",
+        "type": "groovy"
+      }
+    }
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_D_m_314327836/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_D_m_314327836/am_1076162899/recording.har
@@ -1,0 +1,631 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/connector-definitions/0_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 370,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 585,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 585,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-2120245986\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"true\",\"forgotUsername\":\"true\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"true\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "585"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-2120245986\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.072Z",
+        "time": 41,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 41
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "amadmin"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "41ghjnKpNFAFU/HXw82HbFbitYNOOJ0g"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 497,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 693,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.122Z",
+        "time": 20,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 20
+        }
+      },
+      {
+        "_id": "6a3744385d3fd7416ea7089e610fa7e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 424,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-04-09T22:46:04Z\",\"maxIdleExpirationTime\":\"2026-04-09T23:16:04Z\",\"maxSessionExpirationTime\":\"2026-04-10T00:46:03Z\",\"properties\":{\"AMCtxId\":\"c092b79d-e82d-486c-a671-af3d7b4f2f6e-54023\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.152Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 520,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-466575464\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.165Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_D_m_314327836/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_D_m_314327836/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/connector-definitions/0_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 565,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=19kOoFSbfAzmbsz6rjZs3YhQQjc.*AAJTSQACMDIAAlNLABw4MXR2c1BvRUVuY1hyUUlRNWNNZjV2bHljaFU9AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=CZWRX6zc7Kw1qO4gHBZnddanfONKHIc_KXQYl7xk1wQ&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=UjQtXznELNNnj1kKmu1Q-qLbHSU&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 673,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=UjQtXznELNNnj1kKmu1Q-qLbHSU&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.180Z",
+        "time": 15,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 15
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 424,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=UjQtXznELNNnj1kKmu1Q-qLbHSU&code_verifier=kac5BLY2em_RB8ph_X4lyn0_-Ue6xFp1dVChPGRm5Sw"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.204Z",
+        "time": 35,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 35
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_D_m_314327836/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_D_m_314327836/openidm_3290118515/recording.har
@@ -1,0 +1,328 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/connector-definitions/0_D_m/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b917ac2d5128951ef6e28dea20ebe6f6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1725,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "1725"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 427,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"provisioner.openicf/csv\",\"configurationProperties\":{\"csvFile\":\"/home/trivir/Work/frodo-cli/test.csv\",\"escapeCharacter\":\"\\\\\",\"fieldDelimiter\":\",\",\"headerPassword\":\"password\",\"headerUid\":\"userName\",\"newlineString\":\"\\\\n\",\"quoteCharacter\":\"\\\"\",\"spaceReplacementString\":\"_\",\"syncFileRetentionCount\":\"3\"},\"connectorRef\":{\"bundleName\":\"org.forgerock.openicf.connectors.csvfile-connector\",\"bundleVersion\":\"1.5.20.34\",\"connectorHostRef\":\"rcs\",\"connectorName\":\"org.forgerock.openicf.csvfile.CSVFileConnector\",\"displayName\":\"CSV File Connector\",\"systemType\":\"provisioner.openicf\"},\"enabled\":false,\"objectTypes\":{\"__ACCOUNT__\":{\"$schema\":\"http://json-schema.org/draft-03/schema\",\"id\":\"__ACCOUNT__\",\"nativeType\":\"__ACCOUNT__\",\"properties\":{\"__NAME__\":{\"nativeName\":\"__NAME__\",\"nativeType\":\"string\",\"type\":\"string\"},\"activeDate\":{\"nativeName\":\"activeDate\",\"nativeType\":\"string\",\"type\":\"string\"},\"email\":{\"nativeName\":\"email\",\"nativeType\":\"string\",\"type\":\"string\"},\"firstName\":{\"nativeName\":\"firstName\",\"nativeType\":\"string\",\"type\":\"string\"},\"lastName\":{\"nativeName\":\"lastName\",\"nativeType\":\"string\",\"type\":\"string\"}},\"type\":\"object\"}},\"operationTimeout\":{\"AUTHENTICATE\":-1,\"CREATE\":-1,\"DELETE\":-1,\"GET\":-1,\"RESOLVEUSERNAME\":-1,\"SCHEMA\":-1,\"SCRIPT_ON_CONNECTOR\":-1,\"SCRIPT_ON_RESOURCE\":-1,\"SEARCH\":-1,\"SYNC\":-1,\"TEST\":-1,\"UPDATE\":-1,\"VALIDATE\":-1},\"resultsHandlerConfig\":{\"enableAttributesToGetSearchResultsHandler\":true,\"enableCaseInsensitiveFilter\":false,\"enableFilteredResultsHandler\":false,\"enableNormalizingResultsHandler\":false},\"syncFailureHandler\":{\"maxRetries\":0,\"postRetryAction\":{\"script\":{\"globals\":{\"message\":\"hello world!\"},\"source\":\"/*\\n* This is a test script\\n*/\\nconsole.log(message);\",\"type\":\"text/javascript\"}}}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/openidm/config/provisioner.openicf/csv"
+        },
+        "response": {
+          "bodySize": 1725,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1725,
+            "text": "{\"_id\":\"provisioner.openicf/csv\",\"configurationProperties\":{\"csvFile\":\"/home/trivir/Work/frodo-cli/test.csv\",\"escapeCharacter\":\"\\\\\",\"fieldDelimiter\":\",\",\"headerPassword\":\"password\",\"headerUid\":\"userName\",\"newlineString\":\"\\\\n\",\"quoteCharacter\":\"\\\"\",\"spaceReplacementString\":\"_\",\"syncFileRetentionCount\":\"3\"},\"connectorRef\":{\"bundleName\":\"org.forgerock.openicf.connectors.csvfile-connector\",\"bundleVersion\":\"1.5.20.34\",\"connectorHostRef\":\"rcs\",\"connectorName\":\"org.forgerock.openicf.csvfile.CSVFileConnector\",\"displayName\":\"CSV File Connector\",\"systemType\":\"provisioner.openicf\"},\"enabled\":false,\"objectTypes\":{\"__ACCOUNT__\":{\"$schema\":\"http://json-schema.org/draft-03/schema\",\"id\":\"__ACCOUNT__\",\"nativeType\":\"__ACCOUNT__\",\"properties\":{\"__NAME__\":{\"nativeName\":\"__NAME__\",\"nativeType\":\"string\",\"type\":\"string\"},\"activeDate\":{\"nativeName\":\"activeDate\",\"nativeType\":\"string\",\"type\":\"string\"},\"email\":{\"nativeName\":\"email\",\"nativeType\":\"string\",\"type\":\"string\"},\"firstName\":{\"nativeName\":\"firstName\",\"nativeType\":\"string\",\"type\":\"string\"},\"lastName\":{\"nativeName\":\"lastName\",\"nativeType\":\"string\",\"type\":\"string\"}},\"type\":\"object\"}},\"operationTimeout\":{\"AUTHENTICATE\":-1,\"CREATE\":-1,\"DELETE\":-1,\"GET\":-1,\"RESOLVEUSERNAME\":-1,\"SCHEMA\":-1,\"SCRIPT_ON_CONNECTOR\":-1,\"SCRIPT_ON_RESOURCE\":-1,\"SEARCH\":-1,\"SYNC\":-1,\"TEST\":-1,\"UPDATE\":-1,\"VALIDATE\":-1},\"resultsHandlerConfig\":{\"enableAttributesToGetSearchResultsHandler\":true,\"enableCaseInsensitiveFilter\":false,\"enableFilteredResultsHandler\":false,\"enableNormalizingResultsHandler\":false},\"syncFailureHandler\":{\"maxRetries\":0,\"postRetryAction\":{\"script\":{\"globals\":{\"message\":\"hello world!\"},\"source\":\"/*\\n* This is a test script\\n*/\\nconsole.log(message);\",\"type\":\"text/javascript\"}}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/openidm",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1725"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/openidm; Secure; HttpOnly"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/openidm/config/provisioner.openicf/provisioner.openicf/csv"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 740,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/openidm/config/provisioner.openicf/provisioner.openicf/csv",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.248Z",
+        "time": 20,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 20
+        }
+      },
+      {
+        "_id": "1e943a38444f37a9f96bef6a27bc6f23",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2004,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-769f72f1-200e-48b2-86a8-a6245e6cbe31"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "2004"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 434,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"provisioner.openicf/salesforce\",\"configurationProperties\":{\"clientId\":\"key\",\"clientSecret\":{\"$crypto\":{\"type\":\"x-simple-encryption\",\"value\":{\"cipher\":\"AES/CBC/PKCS5Padding\",\"data\":\"40bgEWtIvhh9z41Q7AkSDA==\",\"iv\":\"A1alWb/ADDU71HIEbeYHCw==\",\"keySize\":16,\"mac\":\"QnaZr/1qtYufWX1eJ+hU6g==\",\"purpose\":\"idm.config.encryption\",\"salt\":\"e90Jq3pJVPbLVu5jVnt9rQ==\",\"stableId\":\"openidm-sym-default\"}}},\"connectTimeout\":120000,\"grantType\":\"refresh_token\",\"instanceUrl\":\"\",\"loginUrl\":\"https://test.salesforce.com/services/oauth2/token\",\"maximumConnections\":10,\"proxyHost\":null,\"proxyPassword\":null,\"proxyPort\":3128,\"proxyUri\":null,\"proxyUsername\":null,\"refreshToken\":null,\"supportedFeatureLicenses\":[\"UserPermissionsChatterAnswersUser\",\"UserPermissionsInteractionUser\",\"UserPermissionsKnowledgeUser\",\"UserPermissionsLiveAgentUser\",\"UserPermissionsMarketingUser\",\"UserPermissionsOfflineUser\",\"UserPermissionsSFContentUser\",\"UserPermissionsSupportUser\",\"UserPermissionsSiteforceContributorUser\",\"UserPermissionsSiteforcePublisherUser\",\"UserPermissionsWorkDotComUserFeature\"],\"supportedObjectTypes\":[\"User\"],\"version\":48},\"connectorRef\":{\"bundleName\":\"org.forgerock.openicf.connectors.salesforce-connector\",\"bundleVersion\":\"1.5.20.28\",\"connectorHostRef\":\"\",\"connectorName\":\"org.forgerock.openicf.connectors.salesforce.SalesforceConnector\",\"displayName\":\"Salesforce Connector\",\"systemType\":\"provisioner.openicf\"},\"enabled\":false,\"operationTimeout\":{\"AUTHENTICATE\":-1,\"CREATE\":-1,\"DELETE\":-1,\"GET\":-1,\"RESOLVEUSERNAME\":-1,\"SCHEMA\":-1,\"SCRIPT_ON_CONNECTOR\":-1,\"SCRIPT_ON_RESOURCE\":-1,\"SEARCH\":-1,\"SYNC\":-1,\"TEST\":-1,\"UPDATE\":-1,\"VALIDATE\":-1},\"resultsHandlerConfig\":{\"enableAttributesToGetSearchResultsHandler\":true,\"enableCaseInsensitiveFilter\":false,\"enableFilteredResultsHandler\":false,\"enableNormalizingResultsHandler\":false},\"syncFailureHandler\":{\"maxRetries\":5,\"postRetryAction\":{\"script\":{\"globals\":{\"message\":\"hello world!\"},\"source\":\"/*\\n* This is a test script\\n*/\\nprintln \\\"$message\\\"\",\"type\":\"groovy\"}}}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/openidm/config/provisioner.openicf/salesforce"
+        },
+        "response": {
+          "bodySize": 2004,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 2004,
+            "text": "{\"_id\":\"provisioner.openicf/salesforce\",\"configurationProperties\":{\"clientId\":\"key\",\"clientSecret\":{\"$crypto\":{\"type\":\"x-simple-encryption\",\"value\":{\"cipher\":\"AES/CBC/PKCS5Padding\",\"data\":\"40bgEWtIvhh9z41Q7AkSDA==\",\"iv\":\"A1alWb/ADDU71HIEbeYHCw==\",\"keySize\":16,\"mac\":\"QnaZr/1qtYufWX1eJ+hU6g==\",\"purpose\":\"idm.config.encryption\",\"salt\":\"e90Jq3pJVPbLVu5jVnt9rQ==\",\"stableId\":\"openidm-sym-default\"}}},\"connectTimeout\":120000,\"grantType\":\"refresh_token\",\"instanceUrl\":\"\",\"loginUrl\":\"https://test.salesforce.com/services/oauth2/token\",\"maximumConnections\":10,\"proxyHost\":null,\"proxyPassword\":null,\"proxyPort\":3128,\"proxyUri\":null,\"proxyUsername\":null,\"refreshToken\":null,\"supportedFeatureLicenses\":[\"UserPermissionsChatterAnswersUser\",\"UserPermissionsInteractionUser\",\"UserPermissionsKnowledgeUser\",\"UserPermissionsLiveAgentUser\",\"UserPermissionsMarketingUser\",\"UserPermissionsOfflineUser\",\"UserPermissionsSFContentUser\",\"UserPermissionsSupportUser\",\"UserPermissionsSiteforceContributorUser\",\"UserPermissionsSiteforcePublisherUser\",\"UserPermissionsWorkDotComUserFeature\"],\"supportedObjectTypes\":[\"User\"],\"version\":48},\"connectorRef\":{\"bundleName\":\"org.forgerock.openicf.connectors.salesforce-connector\",\"bundleVersion\":\"1.5.20.28\",\"connectorHostRef\":\"\",\"connectorName\":\"org.forgerock.openicf.connectors.salesforce.SalesforceConnector\",\"displayName\":\"Salesforce Connector\",\"systemType\":\"provisioner.openicf\"},\"enabled\":false,\"operationTimeout\":{\"AUTHENTICATE\":-1,\"CREATE\":-1,\"DELETE\":-1,\"GET\":-1,\"RESOLVEUSERNAME\":-1,\"SCHEMA\":-1,\"SCRIPT_ON_CONNECTOR\":-1,\"SCRIPT_ON_RESOURCE\":-1,\"SEARCH\":-1,\"SYNC\":-1,\"TEST\":-1,\"UPDATE\":-1,\"VALIDATE\":-1},\"resultsHandlerConfig\":{\"enableAttributesToGetSearchResultsHandler\":true,\"enableCaseInsensitiveFilter\":false,\"enableFilteredResultsHandler\":false,\"enableNormalizingResultsHandler\":false},\"syncFailureHandler\":{\"maxRetries\":5,\"postRetryAction\":{\"script\":{\"globals\":{\"message\":\"hello world!\"},\"source\":\"/*\\n* This is a test script\\n*/\\nprintln \\\"$message\\\"\",\"type\":\"groovy\"}}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/openidm",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:46:04 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2004"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/openidm; Secure; HttpOnly"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/openidm/config/provisioner.openicf/provisioner.openicf/salesforce"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 746,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/openidm/config/provisioner.openicf/provisioner.openicf/salesforce",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2026-04-09T22:46:04.277Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_n_D_m_1348920437/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_n_D_m_1348920437/am_1076162899/recording.har
@@ -1,0 +1,631 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/connector-definitions/0_n_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-1eb66775-02b1-404c-b002-64df83027df6"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 370,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 585,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 585,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-2120245986\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"true\",\"forgotUsername\":\"true\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"true\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:50:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "585"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-2120245986\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:50:57.571Z",
+        "time": 32,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 32
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-1eb66775-02b1-404c-b002-64df83027df6"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "amadmin"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "41ghjnKpNFAFU/HXw82HbFbitYNOOJ0g"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 497,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:50:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 693,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:50:57.610Z",
+        "time": 17,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 17
+        }
+      },
+      {
+        "_id": "6a3744385d3fd7416ea7089e610fa7e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-1eb66775-02b1-404c-b002-64df83027df6"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 424,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-04-09T22:50:57Z\",\"maxIdleExpirationTime\":\"2026-04-09T23:20:57Z\",\"maxSessionExpirationTime\":\"2026-04-10T00:50:56Z\",\"properties\":{\"AMCtxId\":\"c092b79d-e82d-486c-a671-af3d7b4f2f6e-54355\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:50:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 609,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:50:57.634Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-1eb66775-02b1-404c-b002-64df83027df6"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 520,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:50:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-466575464\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:50:57.649Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_n_D_m_1348920437/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_n_D_m_1348920437/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/connector-definitions/0_n_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-1eb66775-02b1-404c-b002-64df83027df6"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 565,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=JCWraMhpBVR0A0ZtutKj8R57Bqs.*AAJTSQACMDIAAlNLABxlN3hxWEsveGUwdkRsQStuMXNVemtmYytyNlk9AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=B5kXEUyMEXrMiVdasvTOIy5ecRLaEHw3hMvuoxei59c&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:50:57 GMT"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=lp4GBc7C75FOdEdJ46WWNu4uL-4&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 673,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=lp4GBc7C75FOdEdJ46WWNu4uL-4&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-04-09T22:50:57.663Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-1eb66775-02b1-404c-b002-64df83027df6"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 424,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=lp4GBc7C75FOdEdJ46WWNu4uL-4&code_verifier=uReCui_i8iq7mViQKf4a9IlDx8t2raOVDoNKClzSmXg"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:50:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:50:57.683Z",
+        "time": 33,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 33
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_n_D_m_1348920437/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/connector-definitions_449858571/0_n_D_m_1348920437/openidm_3290118515/recording.har
@@ -1,0 +1,167 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/connector-definitions/0_n_D_m/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b917ac2d5128951ef6e28dea20ebe6f6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1725,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-36"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-1eb66775-02b1-404c-b002-64df83027df6"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "1725"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 427,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"provisioner.openicf/csv\",\"configurationProperties\":{\"csvFile\":\"/home/trivir/Work/frodo-cli/test.csv\",\"escapeCharacter\":\"\\\\\",\"fieldDelimiter\":\",\",\"headerPassword\":\"password\",\"headerUid\":\"userName\",\"newlineString\":\"\\\\n\",\"quoteCharacter\":\"\\\"\",\"spaceReplacementString\":\"_\",\"syncFileRetentionCount\":\"3\"},\"connectorRef\":{\"bundleName\":\"org.forgerock.openicf.connectors.csvfile-connector\",\"bundleVersion\":\"1.5.20.34\",\"connectorHostRef\":\"rcs\",\"connectorName\":\"org.forgerock.openicf.csvfile.CSVFileConnector\",\"displayName\":\"CSV File Connector\",\"systemType\":\"provisioner.openicf\"},\"enabled\":false,\"objectTypes\":{\"__ACCOUNT__\":{\"$schema\":\"http://json-schema.org/draft-03/schema\",\"id\":\"__ACCOUNT__\",\"nativeType\":\"__ACCOUNT__\",\"properties\":{\"__NAME__\":{\"nativeName\":\"__NAME__\",\"nativeType\":\"string\",\"type\":\"string\"},\"activeDate\":{\"nativeName\":\"activeDate\",\"nativeType\":\"string\",\"type\":\"string\"},\"email\":{\"nativeName\":\"email\",\"nativeType\":\"string\",\"type\":\"string\"},\"firstName\":{\"nativeName\":\"firstName\",\"nativeType\":\"string\",\"type\":\"string\"},\"lastName\":{\"nativeName\":\"lastName\",\"nativeType\":\"string\",\"type\":\"string\"}},\"type\":\"object\"}},\"operationTimeout\":{\"AUTHENTICATE\":-1,\"CREATE\":-1,\"DELETE\":-1,\"GET\":-1,\"RESOLVEUSERNAME\":-1,\"SCHEMA\":-1,\"SCRIPT_ON_CONNECTOR\":-1,\"SCRIPT_ON_RESOURCE\":-1,\"SEARCH\":-1,\"SYNC\":-1,\"TEST\":-1,\"UPDATE\":-1,\"VALIDATE\":-1},\"resultsHandlerConfig\":{\"enableAttributesToGetSearchResultsHandler\":true,\"enableCaseInsensitiveFilter\":false,\"enableFilteredResultsHandler\":false,\"enableNormalizingResultsHandler\":false},\"syncFailureHandler\":{\"maxRetries\":0,\"postRetryAction\":{\"script\":{\"globals\":{\"message\":\"hello world!\"},\"source\":\"/*\\n* This is a test script\\n*/\\nconsole.log(message);\",\"type\":\"text/javascript\"}}}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/openidm/config/provisioner.openicf/csv"
+        },
+        "response": {
+          "bodySize": 1725,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1725,
+            "text": "{\"_id\":\"provisioner.openicf/csv\",\"configurationProperties\":{\"csvFile\":\"/home/trivir/Work/frodo-cli/test.csv\",\"escapeCharacter\":\"\\\\\",\"fieldDelimiter\":\",\",\"headerPassword\":\"password\",\"headerUid\":\"userName\",\"newlineString\":\"\\\\n\",\"quoteCharacter\":\"\\\"\",\"spaceReplacementString\":\"_\",\"syncFileRetentionCount\":\"3\"},\"connectorRef\":{\"bundleName\":\"org.forgerock.openicf.connectors.csvfile-connector\",\"bundleVersion\":\"1.5.20.34\",\"connectorHostRef\":\"rcs\",\"connectorName\":\"org.forgerock.openicf.csvfile.CSVFileConnector\",\"displayName\":\"CSV File Connector\",\"systemType\":\"provisioner.openicf\"},\"enabled\":false,\"objectTypes\":{\"__ACCOUNT__\":{\"$schema\":\"http://json-schema.org/draft-03/schema\",\"id\":\"__ACCOUNT__\",\"nativeType\":\"__ACCOUNT__\",\"properties\":{\"__NAME__\":{\"nativeName\":\"__NAME__\",\"nativeType\":\"string\",\"type\":\"string\"},\"activeDate\":{\"nativeName\":\"activeDate\",\"nativeType\":\"string\",\"type\":\"string\"},\"email\":{\"nativeName\":\"email\",\"nativeType\":\"string\",\"type\":\"string\"},\"firstName\":{\"nativeName\":\"firstName\",\"nativeType\":\"string\",\"type\":\"string\"},\"lastName\":{\"nativeName\":\"lastName\",\"nativeType\":\"string\",\"type\":\"string\"}},\"type\":\"object\"}},\"operationTimeout\":{\"AUTHENTICATE\":-1,\"CREATE\":-1,\"DELETE\":-1,\"GET\":-1,\"RESOLVEUSERNAME\":-1,\"SCHEMA\":-1,\"SCRIPT_ON_CONNECTOR\":-1,\"SCRIPT_ON_RESOURCE\":-1,\"SEARCH\":-1,\"SYNC\":-1,\"TEST\":-1,\"UPDATE\":-1,\"VALIDATE\":-1},\"resultsHandlerConfig\":{\"enableAttributesToGetSearchResultsHandler\":true,\"enableCaseInsensitiveFilter\":false,\"enableFilteredResultsHandler\":false,\"enableNormalizingResultsHandler\":false},\"syncFailureHandler\":{\"maxRetries\":0,\"postRetryAction\":{\"script\":{\"globals\":{\"message\":\"hello world!\"},\"source\":\"/*\\n* This is a test script\\n*/\\nconsole.log(message);\",\"type\":\"text/javascript\"}}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/openidm",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 09 Apr 2026 22:50:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1725"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/openidm; Secure; HttpOnly"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 638,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-09T22:50:57.723Z",
+        "time": 26,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 26
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
I added a function to import connector definition configurations for the frodo config-manager push connector-definitions command.

I also added the command implementation file to enable the command.