### PR TITLE
bugfix: Allow Forgeops deployments to export/import full AM configuration

### DIFF
--- a/src/cli/agent/agent-describe.ts
+++ b/src/cli/agent/agent-describe.ts
@@ -4,8 +4,12 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo agent describe');

--- a/src/cli/agent/agent-export.ts
+++ b/src/cli/agent/agent-export.ts
@@ -10,8 +10,12 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo agent export');

--- a/src/cli/agent/agent-import.ts
+++ b/src/cli/agent/agent-import.ts
@@ -11,8 +11,12 @@ import { getTokens } from '../../ops/AuthenticateOps';
 import { verboseMessage } from '../../utils/Console.js';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo agent import');

--- a/src/cli/agent/agent-list.ts
+++ b/src/cli/agent/agent-list.ts
@@ -5,8 +5,12 @@ import { listAgents } from '../../ops/AgentOps.js';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo agent list');

--- a/src/cli/authn/authn-describe.ts
+++ b/src/cli/authn/authn-describe.ts
@@ -6,8 +6,12 @@ import { describeAuthenticationSettings } from '../../ops/AuthenticationSettings
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo authn describe');

--- a/src/cli/authn/authn-export.ts
+++ b/src/cli/authn/authn-export.ts
@@ -6,8 +6,12 @@ import { exportAuthenticationSettingsToFile } from '../../ops/AuthenticationSett
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo authn export');

--- a/src/cli/authn/authn-import.ts
+++ b/src/cli/authn/authn-import.ts
@@ -6,8 +6,12 @@ import { importAuthenticationSettingsFromFile } from '../../ops/AuthenticationSe
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo authn import');

--- a/src/cli/realm/realm-import.ts
+++ b/src/cli/realm/realm-import.ts
@@ -10,8 +10,12 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
-const deploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
+const deploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo realm import');

--- a/src/cli/secretstore/secretstore-delete.ts
+++ b/src/cli/secretstore/secretstore-delete.ts
@@ -9,9 +9,13 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
 
-const deploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const deploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand(

--- a/src/cli/secretstore/secretstore-describe.ts
+++ b/src/cli/secretstore/secretstore-describe.ts
@@ -6,10 +6,17 @@ import { describeSecretStore } from '../../ops/SecretStoreOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand(

--- a/src/cli/secretstore/secretstore-export.ts
+++ b/src/cli/secretstore/secretstore-export.ts
@@ -10,10 +10,17 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand(

--- a/src/cli/secretstore/secretstore-import.ts
+++ b/src/cli/secretstore/secretstore-import.ts
@@ -11,10 +11,17 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand(

--- a/src/cli/secretstore/secretstore-list.ts
+++ b/src/cli/secretstore/secretstore-list.ts
@@ -6,10 +6,17 @@ import { listSecretStores } from '../../ops/SecretStoreOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand(

--- a/src/cli/secretstore/secretstore-mapping-alias-activate.ts
+++ b/src/cli/secretstore/secretstore-mapping-alias-activate.ts
@@ -6,10 +6,17 @@ import { activateSecretStoreMappingAlias } from '../../ops/SecretStoreOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 const { canSecretStoreHaveMappings } = frodo.secretStore;
 

--- a/src/cli/secretstore/secretstore-mapping-alias-create.ts
+++ b/src/cli/secretstore/secretstore-mapping-alias-create.ts
@@ -6,10 +6,17 @@ import { createSecretStoreMappingAlias } from '../../ops/SecretStoreOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 const { canSecretStoreHaveMappings } = frodo.secretStore;
 

--- a/src/cli/secretstore/secretstore-mapping-alias-delete.ts
+++ b/src/cli/secretstore/secretstore-mapping-alias-delete.ts
@@ -9,10 +9,17 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 const { canSecretStoreHaveMappings } = frodo.secretStore;
 

--- a/src/cli/secretstore/secretstore-mapping-alias-list.ts
+++ b/src/cli/secretstore/secretstore-mapping-alias-list.ts
@@ -6,10 +6,17 @@ import { listSecretStoreMappingAliases } from '../../ops/SecretStoreOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 const { canSecretStoreHaveMappings } = frodo.secretStore;
 

--- a/src/cli/secretstore/secretstore-mapping-create.ts
+++ b/src/cli/secretstore/secretstore-mapping-create.ts
@@ -6,10 +6,17 @@ import { createSecretStoreMapping } from '../../ops/SecretStoreOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 const { canSecretStoreHaveMappings } = frodo.secretStore;
 

--- a/src/cli/secretstore/secretstore-mapping-delete.ts
+++ b/src/cli/secretstore/secretstore-mapping-delete.ts
@@ -9,10 +9,17 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 const { canSecretStoreHaveMappings } = frodo.secretStore;
 

--- a/src/cli/secretstore/secretstore-mapping-list.ts
+++ b/src/cli/secretstore/secretstore-mapping-list.ts
@@ -6,10 +6,17 @@ import { listSecretStoreMappings } from '../../ops/SecretStoreOps';
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { DEPLOYMENT_TYPES, CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const {
+  DEPLOYMENT_TYPES,
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+} = frodo.utils.constants;
 
 const deploymentTypes = DEPLOYMENT_TYPES;
-const globalDeploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const globalDeploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 const { canSecretStoreHaveMappings } = frodo.secretStore;
 

--- a/src/cli/server/server-delete.ts
+++ b/src/cli/server/server-delete.ts
@@ -4,9 +4,13 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
 
-const deploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const deploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo server delete', [], deploymentTypes);

--- a/src/cli/server/server-describe.ts
+++ b/src/cli/server/server-describe.ts
@@ -4,9 +4,13 @@ import { Option } from 'commander';
 import { getTokens } from '../../ops/AuthenticateOps';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
 
-const deploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const deploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand(

--- a/src/cli/server/server-export.ts
+++ b/src/cli/server/server-export.ts
@@ -10,9 +10,13 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
 
-const deploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const deploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo server export', [], deploymentTypes);

--- a/src/cli/server/server-import.ts
+++ b/src/cli/server/server-import.ts
@@ -11,9 +11,13 @@ import {
 import { printMessage, verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
 
-const deploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const deploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo server import', [], deploymentTypes);

--- a/src/cli/server/server-list.ts
+++ b/src/cli/server/server-list.ts
@@ -6,9 +6,13 @@ import { listServers } from '../../ops/classic/ServerOps';
 import { verboseMessage } from '../../utils/Console';
 import { FrodoCommand } from '../FrodoCommand';
 
-const { CLASSIC_DEPLOYMENT_TYPE_KEY } = frodo.utils.constants;
+const { CLASSIC_DEPLOYMENT_TYPE_KEY, FORGEOPS_DEPLOYMENT_TYPE_KEY } =
+  frodo.utils.constants;
 
-const deploymentTypes = [CLASSIC_DEPLOYMENT_TYPE_KEY];
+const deploymentTypes = [
+  CLASSIC_DEPLOYMENT_TYPE_KEY,
+  FORGEOPS_DEPLOYMENT_TYPE_KEY,
+];
 
 export default function setup() {
   const program = new FrodoCommand('frodo server list', [], deploymentTypes);

--- a/test/client_cli/en/__snapshots__/root.test.js.snap
+++ b/test/client_cli/en/__snapshots__/root.test.js.snap
@@ -37,11 +37,9 @@ Commands:
                                     trust.
   script                            Manage scripts.
   secretstore                       Manage secret stores.
+  server                            Manage servers.
   service                           Manage AM services.
   theme                             Manage themes.
-
-  (Classic-only):
-  server                            Manage servers.
 
   (Cloud-only):
   dcc|direct-configuration-control  [Preview] Direct Configuration Control (DCC)

--- a/test/client_cli/en/__snapshots__/secretstore-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-delete.test.js.snap
@@ -11,8 +11,6 @@ Arguments:
   username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
   password                                   Password.
 
-Deployment: Classic-only
-
 Options:
   -a, --all                                  Delete all secret stores. Ignored with -i.
   -g, --global                               Delete global secret stores.

--- a/test/client_cli/en/__snapshots__/secretstore.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore.test.js.snap
@@ -12,14 +12,12 @@ Options:
                     examples.
 
 Commands:
+  delete            Delete secret stores.
   describe          Describe secret stores.
   export            Export secret stores.
   help              display help for command
   import            Import secret stores.
   list              List secret stores.
   mapping           Manage secret store mappings.
-
-  (Classic-only):
-  delete            Delete secret stores.
 "
 `;

--- a/test/client_cli/en/__snapshots__/server-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/server-export.test.js.snap
@@ -19,8 +19,6 @@ Arguments:
                                  authentication journeys/trees.
   password                       Password.
 
-Deployment: Classic-only
-
 Options:
   -a, --all                      Export all servers to a single file. Ignored
                                  with -i.

--- a/test/client_cli/en/__snapshots__/server-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/server-import.test.js.snap
@@ -19,8 +19,6 @@ Arguments:
                                  authentication journeys/trees.
   password                       Password.
 
-Deployment: Classic-only
-
 Options:
   -a, --all                      Import all servers from single file. Ignored
                                  with -i.

--- a/test/client_cli/en/__snapshots__/server-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/server-list.test.js.snap
@@ -16,8 +16,6 @@ Arguments:
                     appropriate rights to manage authentication journeys/trees.
   password          Password.
 
-Deployment: Classic-only
-
 Options:
   -l, --long        Long with all fields. (default: false)
   -h, --help        Help

--- a/test/client_cli/en/__snapshots__/server.test.js.snap
+++ b/test/client_cli/en/__snapshots__/server.test.js.snap
@@ -5,8 +5,6 @@ exports[`CLI help interface for 'server' should be expected english 1`] = `
 
 Manage servers.
 
-Deployment: Classic-only
-
 Options:
   -h, --help        Help
   -hh, --help-more  Help with all options.
@@ -14,10 +12,8 @@ Options:
                     examples.
 
 Commands:
-  help              display help for command
-
-  (Classic-only):
   export            Export servers.
+  help              display help for command
   import            Import servers.
   list              List servers.
 "

--- a/test/e2e/__snapshots__/secretstore-delete.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/secretstore-delete.e2e.test.js.snap
@@ -3,7 +3,7 @@
 exports[`frodo secretstore delete "frodo secretstore delete --all": should fail deleting any secret store 1`] = `
 "Error getting tokens
   Service account login error
-    Unsupported deployment type: 'cloud' not in classic
+    Unsupported deployment type: 'cloud' not in classic,forgeops
 Unrecognized combination of options or no options...
 "
 `;
@@ -48,7 +48,7 @@ exports[`frodo secretstore delete "frodo secretstore delete -g --secretstore-id 
 exports[`frodo secretstore delete "frodo secretstore delete -i ESV": should fail deleting ESV secret store 1`] = `
 "Error getting tokens
   Service account login error
-    Unsupported deployment type: 'cloud' not in classic
+    Unsupported deployment type: 'cloud' not in classic,forgeops
 Unrecognized combination of options or no options...
 "
 `;


### PR DESCRIPTION
Updated all commands that are compatible in Forgeops to allow full export/import.

Dependent upon PR in Frodo-lib:

[https://github.com/rockcarver/frodo-lib/pull/582](https://github.com/rockcarver/frodo-lib/pull/582)