### PR TITLE
feat: Add config-manager push secret-mappings command

### DIFF
--- a/src/cli/config-manager/config-manager-push/config-manager-push-secret-mappings.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push-secret-mappings.ts
@@ -1,0 +1,63 @@
+import { frodo } from '@rockcarver/frodo-lib';
+import { Option } from 'commander';
+
+import { configManagerImportSecretMappings } from '../../../configManagerOps/FrConfigSecretMappingsOps';
+import { getTokens } from '../../../ops/AuthenticateOps';
+import { printMessage, verboseMessage } from '../../../utils/Console';
+import { FrodoCommand } from '../../FrodoCommand';
+
+const { CLOUD_DEPLOYMENT_TYPE_KEY, DEFAULT_REALM_KEY } = frodo.utils.constants;
+
+const deploymentTypes = [CLOUD_DEPLOYMENT_TYPE_KEY];
+
+export default function setup() {
+  const program = new FrodoCommand(
+    'frodo config-manager push secret-mappings',
+    [],
+    deploymentTypes
+  );
+
+  program
+    .description('Import secret mappings.')
+    .addOption(
+      new Option(
+        '-n, --name <name>',
+        'Secret mapping name. It will only import secret mapping with the specified name.'
+      )
+    )
+    .action(async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
+      );
+
+      if (options.name && (!realm || realm === DEFAULT_REALM_KEY)) {
+        printMessage(
+          'The -n/--name option requires a realm argument to be specified.',
+          'error'
+        );
+        program.help();
+        process.exitCode = 1;
+        return;
+      }
+
+      const getTokensIsSuccessful = await getTokens(
+        false,
+        true,
+        deploymentTypes
+      );
+      if (!getTokensIsSuccessful) process.exit(1);
+      verboseMessage('Importing secret mappings configuration.');
+      const outcome = await configManagerImportSecretMappings(
+        options.name,
+        realm
+      );
+      if (!outcome) process.exitCode = 1;
+    });
+
+  return program;
+}

--- a/src/cli/config-manager/config-manager-push/config-manager-push.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push.ts
@@ -15,6 +15,7 @@ import ManagedObjects from './config-manager-push-managed-objects';
 import OrgPrivileges from './config-manager-push-org-privileges';
 import PasswordPolicy from './config-manager-push-password-policy';
 import Schedules from './config-manager-push-schedules';
+import SecretMappings from './config-manager-push-secret-mappings';
 import ServiceObjects from './config-manager-push-service-objects';
 import TermsAndConditions from './config-manager-push-terms-and-conditions';
 import Themes from './config-manager-push-themes';
@@ -24,7 +25,6 @@ export default function setup() {
   const program = new FrodoStubCommand('push').description(
     'Import configuration optimized for CI/CD pipelines (format compatible with fr-config-manager).'
   );
-
   program.addCommand(Themes().name('themes'));
   program.addCommand(TermsAndConditions().name('terms-and-conditions'));
   program.addCommand(PasswordPolicy().name('password-policy'));
@@ -45,6 +45,7 @@ export default function setup() {
   program.addCommand(Authentication().name('authentication'));
   program.addCommand(ConnectorDefinitions().name('connector-definitions'));
   program.addCommand(ConnectorMappings().name('connector-mappings'));
+  program.addCommand(SecretMappings().name('secret-mappings'));
 
   return program;
 }

--- a/src/configManagerOps/FrConfigSecretMappingsOps.ts
+++ b/src/configManagerOps/FrConfigSecretMappingsOps.ts
@@ -1,37 +1,34 @@
 import { frodo, state } from '@rockcarver/frodo-lib';
+import fs from 'fs';
+import path from 'path';
 
 import { printError } from '../utils/Console';
 import { realmList } from '../utils/FrConfig';
 
 const { saveJsonToFile, getFilePath } = frodo.utils;
-const { readSecretStoreMappings } = frodo.secretStore;
+const { readSecretStoreMappings, updateSecretStoreMapping } = frodo.secretStore;
 
+const constants = frodo.utils.constants;
+const { DEFAULT_REALM_KEY } = constants;
+
+const ESV_SECRET_STORE_ID = 'ESV';
+const ESV_SECRET_STORE_TYPE = 'GoogleSecretManagerSecretStoreProvider';
 export async function configManagerExportSecretMappings(
   name?,
   realm?
 ): Promise<boolean> {
   try {
-    if (realm && realm !== '__default__realm__') {
+    const realms =
+      realm && realm !== DEFAULT_REALM_KEY ? [realm] : await realmList();
+    for (const realm of realms) {
+      if (realm === '/') continue;
+      state.setRealm(realm);
       const readData = await readSecretStoreMappings(
-        'ESV',
-        'GoogleSecretManagerSecretStoreProvider',
+        ESV_SECRET_STORE_ID,
+        ESV_SECRET_STORE_TYPE,
         false
       );
       processSecretMappings(readData, `realms/${realm}/secret-mappings`, name);
-    } else {
-      for (const realm of await realmList()) {
-        state.setRealm(realm);
-        const readData = await readSecretStoreMappings(
-          'ESV',
-          'GoogleSecretManagerSecretStoreProvider',
-          false
-        );
-        processSecretMappings(
-          readData,
-          `realms/${realm}/secret-mappings`,
-          name
-        );
-      }
     }
     return true;
   } catch (error) {
@@ -62,6 +59,56 @@ async function aliasSearch(object, name) {
   if (object.includes(name)) {
     return true;
   } else {
+    return false;
+  }
+}
+
+/**
+ * Import all secret-mappings for ESV secret store
+ * @param {string} name the name of the mapping to import
+ * @param {string} realm the name of the realm to import to
+ * @returns {Promise<boolean>} true if successful, false otherwise
+ */
+export async function configManagerImportSecretMappings(
+  name?: string,
+  realm?: string
+): Promise<boolean> {
+  try {
+    const realms =
+      realm && realm !== DEFAULT_REALM_KEY ? [realm] : await realmList();
+
+    for (const realm of realms) {
+      if (realm === '/') continue;
+
+      state.setRealm(realm);
+
+      const dir = getFilePath(`realms/${realm}/secret-mappings/`);
+      if (!fs.existsSync(dir)) continue;
+
+      const configFiles = fs
+        .readdirSync(dir)
+        .filter((f) => path.extname(f) === '.json');
+
+      for (const configFile of configFiles) {
+        const importData = JSON.parse(
+          fs.readFileSync(path.join(dir, configFile), 'utf8')
+        );
+
+        if (name && name !== importData._id) continue;
+
+        delete importData._rev;
+
+        await updateSecretStoreMapping(
+          ESV_SECRET_STORE_ID,
+          ESV_SECRET_STORE_TYPE,
+          importData,
+          false
+        );
+      }
+    }
+    return true;
+  } catch (error) {
+    printError(error, `Error importing secret mappings`);
     return false;
   }
 }

--- a/test/client_cli/en/__snapshots__/config-manager-push-secret-mappings.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-secret-mappings.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI help interface for 'config-manager push secret-mappings' should be expected english 1`] = `
+"Usage: frodo config-manager push secret-mappings [options] [host] [realm] [username] [password]
+
+[Experimental] Import secret mappings.
+
+Arguments:
+  host               AM base URL, e.g.: https://cdk.iam.example.com/am. To use a
+                     connection profile, just specify a unique substring or
+                     alias.
+  realm              Realm. Specify realm as '/' for the root realm or 'realm'
+                     or '/parent/child' otherwise. (default: "alpha" for
+                     Identity Cloud tenants, "/" otherwise.)
+  username           Username to login with. Must be an admin user with
+                     appropriate rights to manage authentication journeys/trees.
+  password           Password.
+
+Deployment: Cloud-only
+
+Options:
+  -n, --name <name>  Secret mapping name. It will only import secret mapping
+                     with the specified name.
+  -h, --help         Help
+  -hh, --help-more   Help with all options.
+  -hhh, --help-all   Help with all options, environment variables, and usage
+                     examples.
+"
+`;

--- a/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
@@ -34,5 +34,8 @@ Commands:
   terms-and-conditions   [Experimental] Import terms and conditions.
   themes                 [Experimental] Import themes.
   ui-config              [Experimental] Import UI configuration.
+
+  (Cloud-only):
+  secret-mappings        [Experimental] Import secret mappings.
 "
 `;

--- a/test/client_cli/en/config-manager-push-secret-mappings.test.js
+++ b/test/client_cli/en/config-manager-push-secret-mappings.test.js
@@ -1,0 +1,10 @@
+import cp from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(cp.exec);
+const CMD = 'frodo config-manager push secret-mappings --help';
+const { stdout } = await exec(CMD);
+
+test("CLI help interface for 'config-manager push secret-mappings' should be expected english", async () => {
+    expect(stdout).toMatchSnapshot();
+});

--- a/test/e2e/__snapshots__/config-manager-export-all.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/config-manager-export-all.e2e.test.js.snap
@@ -27501,6 +27501,22 @@ exports[`frodo config-manager pulls "frodo config-manager pull all -D allDir1": 
 "
 `;
 
+exports[`frodo config-manager pulls "frodo config-manager pull all -D allDir1": should export all config in fr-config-manager style": allDir1/realms/alpha/secret-mappings/am.services.httpclient.mtls.clientcert.testClientCert.secret.json 1`] = `
+{
+  "_id": "am.services.httpclient.mtls.clientcert.testClientCert.secret",
+  "_rev": "243715290",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings",
+  },
+  "aliases": [
+    "esv-test-client-cert",
+  ],
+  "secretId": "am.services.httpclient.mtls.clientcert.testClientCert.secret",
+}
+`;
+
 exports[`frodo config-manager pulls "frodo config-manager pull all -D allDir1": should export all config in fr-config-manager style": allDir1/realms/alpha/services/SocialIdentityProviders.json 1`] = `
 {
   "_id": "",
@@ -37951,6 +37967,38 @@ function preSingleLogoutProcess() {
 function postSingleLogoutSuccess() {
 }
 "
+`;
+
+exports[`frodo config-manager pulls "frodo config-manager pull all -D allDir1": should export all config in fr-config-manager style": allDir1/realms/bravo/secret-mappings/am.applications.agents.remote.consent.request.signing.ES384.json 1`] = `
+{
+  "_id": "am.applications.agents.remote.consent.request.signing.ES384",
+  "_rev": "132500719",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings",
+  },
+  "aliases": [
+    "es384",
+  ],
+  "secretId": "am.applications.agents.remote.consent.request.signing.ES384",
+}
+`;
+
+exports[`frodo config-manager pulls "frodo config-manager pull all -D allDir1": should export all config in fr-config-manager style": allDir1/realms/bravo/secret-mappings/am.applications.agents.remote.consent.request.signing.ES512.json 1`] = `
+{
+  "_id": "am.applications.agents.remote.consent.request.signing.ES512",
+  "_rev": "132496622",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings",
+  },
+  "aliases": [
+    "es512",
+  ],
+  "secretId": "am.applications.agents.remote.consent.request.signing.ES512",
+}
 `;
 
 exports[`frodo config-manager pulls "frodo config-manager pull all -D allDir1": should export all config in fr-config-manager style": allDir1/realms/bravo/services/SocialIdentityProviders.json 1`] = `

--- a/test/e2e/__snapshots__/config-manager-push-secret-mappings.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/config-manager-push-secret-mappings.e2e.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo config-manager push secret-mappings "frodo config-manager push secret-mappings -D test/e2e/exports/fr-config-manager/cloud ": should import the secret mapping into cloud" 1`] = `""`;
+
+exports[`frodo config-manager push secret-mappings "frodo config-manager push secret-mappings -D test/e2e/exports/fr-config-manager/cloud ": should import the secret mapping into cloud" 2`] = `
+"Experimental feature in use: 'frodo config-manager push secret-mappings'. This feature may change without notice.
+"
+`;
+
+exports[`frodo config-manager push secret-mappings "frodo config-manager push secret-mappings -n am.services.iot.cert.verification -D test/e2e/exports/fr-config-manager/cloud": should import a specific secret mapping by name into cloud" 1`] = `""`;
+
+exports[`frodo config-manager push secret-mappings "frodo config-manager push secret-mappings -n am.services.iot.cert.verification -D test/e2e/exports/fr-config-manager/cloud": should import a specific secret mapping by name into cloud" 2`] = `
+"Experimental feature in use: 'frodo config-manager push secret-mappings'. This feature may change without notice.
+"
+`;

--- a/test/e2e/config-manager-push-secret-mappings.e2e.test.js
+++ b/test/e2e/config-manager-push-secret-mappings.e2e.test.js
@@ -1,0 +1,79 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+// Cloud
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager push secret-mappings -D test/e2e/exports/fr-config-manager/cloud 
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager push secret-mappings -n am.services.iot.cert.verification -D test/e2e/exports/fr-config-manager/cloud 
+
+*/
+
+import { getEnv, testSuccess } from './utils/TestUtils';
+import { connection as c } from './utils/TestConfig';
+
+process.env['FRODO_MOCK'] = '1';
+const cloudEnv = getEnv(c);
+
+const allDirectory = "test/e2e/exports/fr-config-manager/cloud";
+
+describe('frodo config-manager push secret-mappings', () => {
+    test(`"frodo config-manager push secret-mappings -D ${allDirectory} ": should import the secret mapping into cloud"`, async () => {
+        const CMD = `frodo config-manager push secret-mappings -D ${allDirectory} `;
+        await testSuccess(CMD, cloudEnv);
+    });
+
+    test(`"frodo config-manager push secret-mappings -n am.services.iot.cert.verification -D ${allDirectory}": should import a specific secret mapping by name into cloud"`, async () => {
+        const CMD = `frodo config-manager push secret-mappings -n am.services.iot.cert.verification -D ${allDirectory}`;
+        await testSuccess(CMD, {
+            env: {
+                ...cloudEnv.env,
+                FRODO_REALM: 'alpha'
+            }
+        }
+    )});
+});

--- a/test/e2e/exports/fr-config-manager/cloud/realms/alpha/secret-mappings/am.services.iot.cert.verification.json
+++ b/test/e2e/exports/fr-config-manager/cloud/realms/alpha/secret-mappings/am.services.iot.cert.verification.json
@@ -1,0 +1,13 @@
+{
+  "_id": "am.services.iot.cert.verification",
+  "_rev": "-297472146",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings"
+  },
+  "aliases": [
+    "Atest3"
+  ],
+  "secretId": "am.services.iot.cert.verification"
+}

--- a/test/e2e/exports/fr-config-manager/cloud/realms/alpha/secret-mappings/am.services.oauth2.oidc.signing.RSA.json
+++ b/test/e2e/exports/fr-config-manager/cloud/realms/alpha/secret-mappings/am.services.oauth2.oidc.signing.RSA.json
@@ -1,0 +1,13 @@
+{
+  "_id": "am.services.oauth2.oidc.signing.RSA",
+  "_rev": "-2046502567",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings"
+  },
+  "aliases": [
+    "Atest"
+  ],
+  "secretId": "am.services.oauth2.oidc.signing.RSA"
+}

--- a/test/e2e/exports/fr-config-manager/cloud/realms/alpha/secret-mappings/am.services.selfservice.token.signing.json
+++ b/test/e2e/exports/fr-config-manager/cloud/realms/alpha/secret-mappings/am.services.selfservice.token.signing.json
@@ -1,0 +1,13 @@
+{
+  "_id": "am.services.selfservice.token.signing",
+  "_rev": "1981656929",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings"
+  },
+  "aliases": [
+    "Atest2"
+  ],
+  "secretId": "am.services.selfservice.token.signing"
+}

--- a/test/e2e/exports/fr-config-manager/cloud/realms/bravo/secret-mappings/am.authentication.nodes.persistentcookie.encryption.json
+++ b/test/e2e/exports/fr-config-manager/cloud/realms/bravo/secret-mappings/am.authentication.nodes.persistentcookie.encryption.json
@@ -1,0 +1,13 @@
+{
+  "_id": "am.authentication.nodes.persistentcookie.encryption",
+  "_rev": "-161166124",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings"
+  },
+  "aliases": [
+    "Btest2"
+  ],
+  "secretId": "am.authentication.nodes.persistentcookie.encryption"
+}

--- a/test/e2e/exports/fr-config-manager/cloud/realms/bravo/secret-mappings/am.authentication.nodes.webauthn.fidometadataservice.rootcertificate.json
+++ b/test/e2e/exports/fr-config-manager/cloud/realms/bravo/secret-mappings/am.authentication.nodes.webauthn.fidometadataservice.rootcertificate.json
@@ -1,0 +1,13 @@
+{
+  "_id": "am.authentication.nodes.webauthn.fidometadataservice.rootcertificate",
+  "_rev": "132743902",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings"
+  },
+  "aliases": [
+    "Btest"
+  ],
+  "secretId": "am.authentication.nodes.webauthn.fidometadataservice.rootcertificate"
+}

--- a/test/e2e/exports/fr-config-manager/cloud/realms/bravo/secret-mappings/am.services.oauth2.stateless.signing.ES512.json
+++ b/test/e2e/exports/fr-config-manager/cloud/realms/bravo/secret-mappings/am.services.oauth2.stateless.signing.ES512.json
@@ -1,0 +1,13 @@
+{
+  "_id": "am.services.oauth2.stateless.signing.ES512",
+  "_rev": "-224635891",
+  "_type": {
+    "_id": "mappings",
+    "collection": true,
+    "name": "Mappings"
+  },
+  "aliases": [
+    "Btest3"
+  ],
+  "secretId": "am.services.oauth2.stateless.signing.ES512"
+}

--- a/test/e2e/mocks/config-manager_4167095917/pull_2167214206/all_321211332/0_F_D_2873540921/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/pull_2167214206/all_321211332/0_F_D_2873540921/am_1076162899/recording.har
@@ -62407,6 +62407,310 @@
           "ssl": -1,
           "wait": 241
         }
+      },
+      {
+        "_id": "d31df160f7a65201b317bc6e5698c065",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/3.1.0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d9bdb417-a045-4420-918e-4d71fba7523e"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2030,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 399,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 399,
+            "text": "{\"result\":[{\"_id\":\"am.services.httpclient.mtls.clientcert.testClientCert.secret\",\"_rev\":\"243715290\",\"secretId\":\"am.services.httpclient.mtls.clientcert.testClientCert.secret\",\"aliases\":[\"esv-test-client-cert\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}],\"resultCount\":1,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "399"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 23 Jun 2025 16:20:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d9bdb417-a045-4420-918e-4d71fba7523e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-06-23T16:20:03.049Z",
+        "time": 95,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 95
+        }
+      },
+      {
+        "_id": "90fa0b50b9dedf5721fedd4b38444036",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/3.1.0"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d9bdb417-a045-4420-918e-4d71fba7523e"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2030,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 627,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 627,
+            "text": "{\"result\":[{\"_id\":\"am.applications.agents.remote.consent.request.signing.ES512\",\"_rev\":\"132496622\",\"secretId\":\"am.applications.agents.remote.consent.request.signing.ES512\",\"aliases\":[\"es512\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}},{\"_id\":\"am.applications.agents.remote.consent.request.signing.ES384\",\"_rev\":\"132500719\",\"secretId\":\"am.applications.agents.remote.consent.request.signing.ES384\",\"aliases\":[\"es384\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}],\"resultCount\":2,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=2.0, resource=2.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "627"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 23 Jun 2025 16:20:03 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-d9bdb417-a045-4420-918e-4d71fba7523e"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 793,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-06-23T16:20:03.152Z",
+        "time": 88,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 88
+        }
       }
     ],
     "pages": [],

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/am_1076162899/recording.har
@@ -1,0 +1,1400 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_D/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 388,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 615,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 615,
+            "text": "{\"_id\":\"*\",\"_rev\":\"1955877839\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"6ac6499e9da2071\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"allowedWithoutReferer\":true,\"refererWhitelist\":[]},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"cloudOnlyFeaturesEnabled\":true,\"oauth2AIAgentsEnabled\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1955877839\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "615"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:25 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:25.814Z",
+        "time": 180,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 180
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1980,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 275,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 275,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-824275682\",\"version\":\"9.0.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 9.0.0-SNAPSHOT Build 75a770de430656acd9cf271c54af448902e5589a (2026-March-25 18:41)\",\"revision\":\"75a770de430656acd9cf271c54af448902e5589a\",\"date\":\"2026-March-25 18:41\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-824275682\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "275"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:26 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 787,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:26.184Z",
+        "time": 140,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 140
+        }
+      },
+      {
+        "_id": "7d9f50fd3e71cc96665ebde586994b01",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2014,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/global-config/realms/?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 420,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 420,
+            "text": "{\"result\":[{\"_id\":\"Lw\",\"_rev\":\"-345738000\",\"parentPath\":null,\"active\":true,\"name\":\"/\",\"aliases\":[]},{\"_id\":\"L2FscGhh\",\"_rev\":\"362268810\",\"parentPath\":\"/\",\"active\":true,\"name\":\"alpha\",\"aliases\":[]},{\"_id\":\"L2JyYXZv\",\"_rev\":\"480875699\",\"parentPath\":\"/\",\"active\":true,\"name\":\"bravo\",\"aliases\":[]}],\"resultCount\":3,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.0,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:26 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 800,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:26.602Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "10f09c71840c1ea5c1676542cdc3ea45",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 174,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "174"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2134,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"am.services.iot.cert.verification\",\"_type\":{\"_id\":\"mappings\",\"collection\":true,\"name\":\"Mappings\"},\"aliases\":[\"Atest3\"],\"secretId\":\"am.services.iot.cert.verification\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.iot.cert.verification"
+        },
+        "response": {
+          "bodySize": 194,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 194,
+            "text": "{\"_id\":\"am.services.iot.cert.verification\",\"_rev\":\"-297472146\",\"secretId\":\"am.services.iot.cert.verification\",\"aliases\":[\"Atest3\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-297472146\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:27 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 751,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:26.822Z",
+        "time": 269,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 269
+        }
+      },
+      {
+        "_id": "dadc149f7f51f8a7c20211d11ed3453c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 177,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "177"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2136,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"am.services.oauth2.oidc.signing.RSA\",\"_type\":{\"_id\":\"mappings\",\"collection\":true,\"name\":\"Mappings\"},\"aliases\":[\"Atest\"],\"secretId\":\"am.services.oauth2.oidc.signing.RSA\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.oauth2.oidc.signing.RSA"
+        },
+        "response": {
+          "bodySize": 198,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 198,
+            "text": "{\"_id\":\"am.services.oauth2.oidc.signing.RSA\",\"_rev\":\"-2046502567\",\"secretId\":\"am.services.oauth2.oidc.signing.RSA\",\"aliases\":[\"Atest\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-2046502567\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "198"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:27 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 752,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:27.098Z",
+        "time": 262,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 262
+        }
+      },
+      {
+        "_id": "3530c5cf06e3388db01b023f9af919d7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 182,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2138,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"am.services.selfservice.token.signing\",\"_type\":{\"_id\":\"mappings\",\"collection\":true,\"name\":\"Mappings\"},\"aliases\":[\"Atest2\"],\"secretId\":\"am.services.selfservice.token.signing\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.selfservice.token.signing"
+        },
+        "response": {
+          "bodySize": 202,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 202,
+            "text": "{\"_id\":\"am.services.selfservice.token.signing\",\"_rev\":\"1981656929\",\"secretId\":\"am.services.selfservice.token.signing\",\"aliases\":[\"Atest2\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"1981656929\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "202"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:27 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 751,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:27.368Z",
+        "time": 182,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 182
+        }
+      },
+      {
+        "_id": "6d03e6cda63a7293a7f7e354d14336e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 210,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "210"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2152,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"am.authentication.nodes.persistentcookie.encryption\",\"_type\":{\"_id\":\"mappings\",\"collection\":true,\"name\":\"Mappings\"},\"aliases\":[\"Btest2\"],\"secretId\":\"am.authentication.nodes.persistentcookie.encryption\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.authentication.nodes.persistentcookie.encryption"
+        },
+        "response": {
+          "bodySize": 230,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 230,
+            "text": "{\"_id\":\"am.authentication.nodes.persistentcookie.encryption\",\"_rev\":\"-161166124\",\"secretId\":\"am.authentication.nodes.persistentcookie.encryption\",\"aliases\":[\"Btest2\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-161166124\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "230"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:27 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 751,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:27.557Z",
+        "time": 228,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 228
+        }
+      },
+      {
+        "_id": "dcd133bd9bd499a97f5c6daff9a5496c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 243,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "243"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2169,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"am.authentication.nodes.webauthn.fidometadataservice.rootcertificate\",\"_type\":{\"_id\":\"mappings\",\"collection\":true,\"name\":\"Mappings\"},\"aliases\":[\"Btest\"],\"secretId\":\"am.authentication.nodes.webauthn.fidometadataservice.rootcertificate\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.authentication.nodes.webauthn.fidometadataservice.rootcertificate"
+        },
+        "response": {
+          "bodySize": 262,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 262,
+            "text": "{\"_id\":\"am.authentication.nodes.webauthn.fidometadataservice.rootcertificate\",\"_rev\":\"132743902\",\"secretId\":\"am.authentication.nodes.webauthn.fidometadataservice.rootcertificate\",\"aliases\":[\"Btest\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"132743902\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "262"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:27 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 750,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:27.791Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "cd525f1167835ed943176ac17e4b4846",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 192,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "192"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2143,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"am.services.oauth2.stateless.signing.ES512\",\"_type\":{\"_id\":\"mappings\",\"collection\":true,\"name\":\"Mappings\"},\"aliases\":[\"Btest3\"],\"secretId\":\"am.services.oauth2.stateless.signing.ES512\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/json/realms/root/realms/bravo/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.oauth2.stateless.signing.ES512"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 212,
+            "text": "{\"_id\":\"am.services.oauth2.stateless.signing.ES512\",\"_rev\":\"-224635891\",\"secretId\":\"am.services.oauth2.stateless.signing.ES512\",\"aliases\":[\"Btest3\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"-224635891\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "212"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:28 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 751,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:27.982Z",
+        "time": 192,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 192
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/environment_1072573434/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/environment_1072573434/recording.har
@@ -1,0 +1,125 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_D/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccc7ec61c2094114d7917814bb19b83b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1931,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/environment/scopes/service-accounts"
+        },
+        "response": {
+          "bodySize": 1975,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1975,
+            "text": "[{\"scope\":\"fr:am:*\",\"description\":\"All Access Management APIs\"},{\"scope\":\"fr:autoaccess:*\",\"description\":\"All Auto Access APIs\"},{\"scope\":\"fr:idc:analytics:*\",\"description\":\"All Analytics APIs\"},{\"scope\":\"fr:idc:certificate:*\",\"description\":\"All TLS certificate APIs\",\"childScopes\":[{\"scope\":\"fr:idc:certificate:read\",\"description\":\"Read TLS certificates\"}]},{\"scope\":\"fr:idc:content-security-policy:*\",\"description\":\"All content security policy APIs\",\"childScopes\":[{\"scope\":\"fr:idc:content-security-policy:read\",\"description\":\"Read content security policy\"}]},{\"scope\":\"fr:idc:cookie-domain:*\",\"description\":\"All cookie domain APIs\",\"childScopes\":[{\"scope\":\"fr:idc:cookie-domain:read\",\"description\":\"Read cookie domains\"}]},{\"scope\":\"fr:idc:custom-domain:*\",\"description\":\"All custom domain APIs\",\"childScopes\":[{\"scope\":\"fr:idc:custom-domain:read\",\"description\":\"Read custom domains\"}]},{\"scope\":\"fr:idc:dataset:*\",\"description\":\"All dataset deletion APIs\",\"childScopes\":[{\"scope\":\"fr:idc:dataset:read\",\"description\":\"Read dataset deletions\"}]},{\"scope\":\"fr:idc:esv:*\",\"description\":\"All ESV APIs\",\"childScopes\":[{\"scope\":\"fr:idc:esv:read\",\"description\":\"Read ESVs, excluding values of secrets\"},{\"scope\":\"fr:idc:esv:update\",\"description\":\"Create, modify, and delete ESVs\"},{\"scope\":\"fr:idc:esv:restart\",\"description\":\"Restart workloads that consume ESVs\"}]},{\"scope\":\"fr:idc:promotion:*\",\"description\":\"All configuration promotion APIs\",\"childScopes\":[{\"scope\":\"fr:idc:promotion:read\",\"description\":\"Read configuration promotion\"}]},{\"scope\":\"fr:idc:release:*\",\"description\":\"All product release APIs\",\"childScopes\":[{\"scope\":\"fr:idc:release:read\",\"description\":\"Read product release\"}]},{\"scope\":\"fr:idc:sso-cookie:*\",\"description\":\"All SSO cookie APIs\",\"childScopes\":[{\"scope\":\"fr:idc:sso-cookie:read\",\"description\":\"Read SSO cookie\"}]},{\"scope\":\"fr:idc:ws:admin\",\"description\":\"All PingFederate APIs\"},{\"scope\":\"fr:idm:*\",\"description\":\"All Identity Management APIs\"}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1975"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"7b7-9oeZSONSS8Sn+SSr15TXAygvvcE\""
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:26 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "efa496d6-31a4-4d41-b231-49d4fd5fd52d"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:26.330Z",
+        "time": 132,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 132
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/oauth2_393036114/recording.har
@@ -1,0 +1,146 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_D/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1362,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "1362"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 443,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:idc:ws:admin fr:am:* fr:autoaccess:* fr:idc:esv:* fr:idc:analytics:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:dataset:* fr:idc:cookie-domain:* fr:idc:promotion:*"
+          },
+          "queryString": [],
+          "url": "https://openam-frodo-dev.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1884,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1884,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:idc:ws:admin fr:am:* fr:autoaccess:* fr:idc:esv:* fr:idc:analytics:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:dataset:* fr:idc:cookie-domain:* fr:idc:promotion:*\",\"token_type\":\"Bearer\",\"expires_in\":899}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1884"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:26 GMT"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 561,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:26.011Z",
+        "time": 166,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 166
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_D_2157136892/openidm_3290118515/recording.har
@@ -1,0 +1,310 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_D/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/810dd2f4-874b-4aad-9e0a-f8a57789f182?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1408,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1408,
+            "text": "{\"_id\":\"810dd2f4-874b-4aad-9e0a-f8a57789f182\",\"_rev\":\"4773460a-f4b4-4472-a12b-8c7b7ad4fd76-9686\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1773261131370\",\"description\":\"phales@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:autoaccess:*\",\"fr:idc:certificate:*\",\"fr:idc:content-security-policy:*\",\"fr:idc:cookie-domain:*\",\"fr:idc:custom-domain:*\",\"fr:idc:dataset:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\",\"fr:idc:ws:admin\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"GIyq6foAjk7VGtM7NyJQZMEUxtAgSe02sjjgp4ey4go\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"rBa78YjWw5-Hkd2rP8uuY2fikjMf9FVeP2AUabFL2qqgVCJxs035yKQDlMAYAFnKaSUXME0vXhZKNkP5ZsWdYAl_sS-0o8HBO4AQk8dXSB--NnkPd0S-6c-sb01oy5tet1WFiKI8dfhzH9KZ65oy3ouzaSsnTjIpFQNMVaq1qQE3m2gPnmwMoRQZdP_hClkXMTtkdRapTL_cdxw7tYGGwpjFz2IJRX-fjFpE79NZdQ_dUaeWOm3tnoHAHjh01IrFu7qlT0o5Bf7-gDvoXU3eYAy5D9LcZAeXr8DiEqK-2aBltV43JSk-Z119DQhRUOFOVMlfbZzHYcWlMgPHBnneleAzChhaDnTxd3NGfqF329wfxQHUaGdj7-eVlXEEYIxmzVwFOiEK0ogEtyvkrlYqQiarxSGt1teNShBpb2QtKL4UPLh7ufxe6K961QuL-FmCkKbjGFxYY0PTegeIsf3rYTNKJRpADC9rGPDF67c5yuMbbBZU9G_GRq5Lj8yS5vG94oCM7PGmKzxxavS7neBu0BH6cqn_u6kuvbfcLtmszo7JqMnY6SqPIp0PU1wfizkjeXKG0s_6rtqQ57pH5IpZTUYwCrtkqcOLEColrUwort43MY12P-ELDuq-IaZFRxJWn8A9dqplVJzOQViUfHHtTVu5W2KiumLSXsxWUsQTb8E\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:26 GMT"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"4773460a-f4b4-4472-a12b-8c7b7ad4fd76-9686\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1408"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 682,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:26.222Z",
+        "time": 307,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 307
+        }
+      },
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "@rockcarver/frodo-lib/4.0.0-34"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1992,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-frodo-dev.forgeblocks.com/openidm/managed/svcacct/810dd2f4-874b-4aad-9e0a-f8a57789f182?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1408,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1408,
+            "text": "{\"_id\":\"810dd2f4-874b-4aad-9e0a-f8a57789f182\",\"_rev\":\"4773460a-f4b4-4472-a12b-8c7b7ad4fd76-9686\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1773261131370\",\"description\":\"phales@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:autoaccess:*\",\"fr:idc:certificate:*\",\"fr:idc:content-security-policy:*\",\"fr:idc:cookie-domain:*\",\"fr:idc:custom-domain:*\",\"fr:idc:dataset:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\",\"fr:idc:ws:admin\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"GIyq6foAjk7VGtM7NyJQZMEUxtAgSe02sjjgp4ey4go\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"rBa78YjWw5-Hkd2rP8uuY2fikjMf9FVeP2AUabFL2qqgVCJxs035yKQDlMAYAFnKaSUXME0vXhZKNkP5ZsWdYAl_sS-0o8HBO4AQk8dXSB--NnkPd0S-6c-sb01oy5tet1WFiKI8dfhzH9KZ65oy3ouzaSsnTjIpFQNMVaq1qQE3m2gPnmwMoRQZdP_hClkXMTtkdRapTL_cdxw7tYGGwpjFz2IJRX-fjFpE79NZdQ_dUaeWOm3tnoHAHjh01IrFu7qlT0o5Bf7-gDvoXU3eYAy5D9LcZAeXr8DiEqK-2aBltV43JSk-Z119DQhRUOFOVMlfbZzHYcWlMgPHBnneleAzChhaDnTxd3NGfqF329wfxQHUaGdj7-eVlXEEYIxmzVwFOiEK0ogEtyvkrlYqQiarxSGt1teNShBpb2QtKL4UPLh7ufxe6K961QuL-FmCkKbjGFxYY0PTegeIsf3rYTNKJRpADC9rGPDF67c5yuMbbBZU9G_GRq5Lj8yS5vG94oCM7PGmKzxxavS7neBu0BH6cqn_u6kuvbfcLtmszo7JqMnY6SqPIp0PU1wfizkjeXKG0s_6rtqQ57pH5IpZTUYwCrtkqcOLEColrUwort43MY12P-ELDuq-IaZFRxJWn8A9dqplVJzOQViUfHHtTVu5W2KiumLSXsxWUsQTb8E\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 08 Apr 2026 17:37:26 GMT"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "\"4773460a-f4b4-4472-a12b-8c7b7ad4fd76-9686\""
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1408"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "frodo-c26967b7-b710-4f90-9d74-7648c26b13f2"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+            }
+          ],
+          "headersSize": 682,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-04-08T17:37:26.468Z",
+        "time": 127,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 127
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/am_1076162899/recording.har
@@ -1,0 +1,472 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_n_D/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 391,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-trivir-demo.forgeblocks.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 638,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 638,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-1970707867\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"2f1378809259351\",\"secureCookie\":true,\"forgotPassword\":\"false\",\"forgotUsername\":\"false\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"false\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"cloudOnlyFeaturesEnabled\":true,\"oauth2AIAgentsEnabled\":false,\"cdkDeployment\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "638"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 763,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-21T15:38:56.771Z",
+        "time": 808,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 808
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1962,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-trivir-demo.forgeblocks.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 272,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 272,
+            "text": "{\"_id\":\"version\",\"_rev\":\"652844272\",\"version\":\"9.0.0-SNAPSHOT\",\"fullVersion\":\"ForgeRock Access Management 9.0.0-SNAPSHOT Build b740131a0f78378edca640cebb2de303d53d7226 (2026-July-13 13:43)\",\"revision\":\"b740131a0f78378edca640cebb2de303d53d7226\",\"date\":\"2026-July-13 13:43\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "272"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 786,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-21T15:39:00.429Z",
+        "time": 1722,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1722
+        }
+      },
+      {
+        "_id": "10f09c71840c1ea5c1676542cdc3ea45",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 174,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=2.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "content-length",
+              "value": "174"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 2116,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"am.services.iot.cert.verification\",\"_type\":{\"_id\":\"mappings\",\"collection\":true,\"name\":\"Mappings\"},\"aliases\":[\"Atest3\"],\"secretId\":\"am.services.iot.cert.verification\"}"
+          },
+          "queryString": [],
+          "url": "https://openam-trivir-demo.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.iot.cert.verification"
+        },
+        "response": {
+          "bodySize": 194,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 194,
+            "text": "{\"_id\":\"am.services.iot.cert.verification\",\"_rev\":\"-297472146\",\"secretId\":\"am.services.iot.cert.verification\",\"aliases\":[\"Atest3\"],\"_type\":{\"_id\":\"mappings\",\"name\":\"Mappings\",\"collection\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store, private, max-age=0, must-revalidate"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "https://openam-trivir-demo.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.iot.cert.verification"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 965,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://openam-trivir-demo.forgeblocks.com/am/json/realms/root/realms/alpha/realm-config/secrets/stores/GoogleSecretManagerSecretStoreProvider/ESV/mappings/am.services.iot.cert.verification",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2026-07-21T15:39:02.492Z",
+        "time": 3597,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3597
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/environment_1072573434/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/environment_1072573434/recording.har
@@ -1,0 +1,125 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_n_D/environment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccc7ec61c2094114d7917814bb19b83b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=1.0,resource=1.0"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1913,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://openam-trivir-demo.forgeblocks.com/environment/scopes/service-accounts"
+        },
+        "response": {
+          "bodySize": 1991,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1991,
+            "text": "[{\"scope\":\"fr:am:*\",\"description\":\"All Access Management APIs\"},{\"scope\":\"fr:idc:analytics:*\",\"description\":\"All Analytics APIs\"},{\"scope\":\"fr:idc:certificate:*\",\"description\":\"All TLS certificate APIs\",\"childScopes\":[{\"scope\":\"fr:idc:certificate:read\",\"description\":\"Read TLS certificates\"}]},{\"scope\":\"fr:idc:content-security-policy:*\",\"description\":\"All content security policy APIs\",\"childScopes\":[{\"scope\":\"fr:idc:content-security-policy:read\",\"description\":\"Read content security policy\"}]},{\"scope\":\"fr:idc:cookie-domain:*\",\"description\":\"All cookie domain APIs\",\"childScopes\":[{\"scope\":\"fr:idc:cookie-domain:read\",\"description\":\"Read cookie domains\"}]},{\"scope\":\"fr:idc:custom-domain:*\",\"description\":\"All custom domain APIs\",\"childScopes\":[{\"scope\":\"fr:idc:custom-domain:read\",\"description\":\"Read custom domains\"}]},{\"scope\":\"fr:idc:dataset:*\",\"description\":\"All dataset deletion APIs\",\"childScopes\":[{\"scope\":\"fr:idc:dataset:read\",\"description\":\"Read dataset deletions\"}]},{\"scope\":\"fr:idc:esv:*\",\"description\":\"All ESV APIs\",\"childScopes\":[{\"scope\":\"fr:idc:esv:read\",\"description\":\"Read ESVs, excluding values of secrets\"},{\"scope\":\"fr:idc:esv:update\",\"description\":\"Create, modify, and delete ESVs\"},{\"scope\":\"fr:idc:esv:restart\",\"description\":\"Restart workloads that consume ESVs\"}]},{\"scope\":\"fr:idc:promotion:*\",\"description\":\"All configuration promotion APIs\",\"childScopes\":[{\"scope\":\"fr:idc:promotion:read\",\"description\":\"Read configuration promotion\"}]},{\"scope\":\"fr:idc:release:*\",\"description\":\"All product release APIs\",\"childScopes\":[{\"scope\":\"fr:idc:release:read\",\"description\":\"Read product release\"}]},{\"scope\":\"fr:idc:sso-cookie:*\",\"description\":\"All SSO cookie APIs\",\"childScopes\":[{\"scope\":\"fr:idc:sso-cookie:read\",\"description\":\"Read SSO cookie\"}]},{\"scope\":\"fr:idc:telemetry:*\",\"description\":\"All telemetry APIs\",\"childScopes\":[{\"scope\":\"fr:idc:telemetry:read\",\"description\":\"Read telemetry\"}]},{\"scope\":\"fr:idm:*\",\"description\":\"All Identity Management APIs\"}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1991"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 413,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-21T15:39:02.183Z",
+        "time": 160,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 160
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/oauth2_393036114/recording.har
@@ -1,0 +1,146 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_n_D/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1351,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "1351"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "assertion=<assertion jwt token>&client_id=service-account&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&scope=fr:am:* fr:idc:esv:* fr:idc:analytics:* fr:idc:telemetry:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:dataset:* fr:idc:cookie-domain:* fr:idc:promotion:*"
+          },
+          "queryString": [],
+          "url": "https://openam-trivir-demo.forgeblocks.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1850,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1850,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"fr:am:* fr:idc:esv:* fr:idc:analytics:* fr:idc:telemetry:* fr:idc:custom-domain:* fr:idc:release:* fr:idc:sso-cookie:* fr:idc:content-security-policy:* fr:idc:certificate:* fr:idm:* fr:idc:dataset:* fr:idc:cookie-domain:* fr:idc:promotion:*\",\"token_type\":\"Bearer\",\"expires_in\":897}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "frame-ancestors 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1850"
+            },
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 561,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-21T15:38:57.609Z",
+        "time": 2813,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2813
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/openidm_3290118515/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/secret-mappings_2964824403/0_n_D_3738999489/openidm_3290118515/recording.har
@@ -1,0 +1,310 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/secret-mappings/0_n_D/openidm",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1974,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-trivir-demo.forgeblocks.com/openidm/managed/svcacct/f15311f9-9023-41f4-aed5-23300a504938?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1392,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1392,
+            "text": "{\"_id\":\"f15311f9-9023-41f4-aed5-23300a504938\",\"_rev\":\"af2df7b8-1790-4a57-9257-48d08f3328e4-4790\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1782322093573\",\"description\":\"dsevy@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:idc:certificate:*\",\"fr:idc:content-security-policy:*\",\"fr:idc:cookie-domain:*\",\"fr:idc:custom-domain:*\",\"fr:idc:dataset:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\",\"fr:idc:telemetry:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"ykb5BXjIlYbS1Si1ttIbQa0cKJDdpFbR-vPoMIWAi4I\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"qAUcPTuPGu9bsW3itRmJxzz_bzqOdFPL4QGItaiMVyabnDbqI2A_mk0y8ieY8pNMlt6glmhve9kp00tbRZKIXaM6SXtHJy03WMfBaQKjGn1QbGxm4jod0AunIxXu4Wafl7BddOj8-kKOPDWHyKu7zrPQ2lzYgy-ItJApGWGiEpPmsor4irQWcUhc5eu-dyLbNU34A0_4J7IhzWxTmJfVuLQS2z07d1z4GrO5nYqKe1v3BSoGEB9DylTpDhwqjv_JuC5Oc9eggu7Z2oUHQ30NWSUrdRpPit2IGnv9yFpeOWmQOPTQOXk9_0Tf11xVU3Q-hJchbztybIa5OcPtZQFu_tRLBHQ09POnX3QIKRONKIZFwWXU2bcbz0fOkQMV2-x0OwEjnSt34VnYjHEqS8sdsv7lVD2w1oxak2TtQc12Uii8_PewOMuJh4Xoy1FQn-hJJSeI-4B9V_2T_0zTCbdrHOqQqGLReAZWNcjlTEY_JZKXaGY-1Imx7d5BJX-SYl3OpmMMVstqDH9AX6lrbHcMjfK7SF9XlB537akGdGGucqzCP8q3iuJx4o-dFojdNuOedpEUoYcWHBtxmqXemhFirOuhtX_CTrM_tg38epHi8l0fFazM4Dkczz5SjlLfvBghhqkMPvMT0VnwhdMRzIXyT442hol6jCd4frxJC1G26g8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1392"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-21T15:39:00.468Z",
+        "time": 480,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 480
+        }
+      },
+      {
+        "_id": "9cb8561357870863838a9948da32d1e8",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "authorization",
+              "value": "Bearer <bearer token>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 1974,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_fields",
+              "value": "*"
+            }
+          ],
+          "url": "https://openam-trivir-demo.forgeblocks.com/openidm/managed/svcacct/f15311f9-9023-41f4-aed5-23300a504938?_fields=%2A"
+        },
+        "response": {
+          "bodySize": 1392,
+          "content": {
+            "mimeType": "application/json;charset=utf-8",
+            "size": 1392,
+            "text": "{\"_id\":\"f15311f9-9023-41f4-aed5-23300a504938\",\"_rev\":\"af2df7b8-1790-4a57-9257-48d08f3328e4-4790\",\"accountStatus\":\"active\",\"name\":\"Frodo-SA-1782322093573\",\"description\":\"dsevy@trivir.com's Frodo Service Account\",\"scopes\":[\"fr:am:*\",\"fr:idc:analytics:*\",\"fr:idc:certificate:*\",\"fr:idc:content-security-policy:*\",\"fr:idc:cookie-domain:*\",\"fr:idc:custom-domain:*\",\"fr:idc:dataset:*\",\"fr:idc:esv:*\",\"fr:idm:*\",\"fr:idc:promotion:*\",\"fr:idc:release:*\",\"fr:idc:sso-cookie:*\",\"fr:idc:telemetry:*\"],\"jwks\":\"{\\\"keys\\\":[{\\\"kty\\\":\\\"RSA\\\",\\\"kid\\\":\\\"ykb5BXjIlYbS1Si1ttIbQa0cKJDdpFbR-vPoMIWAi4I\\\",\\\"alg\\\":\\\"RS256\\\",\\\"e\\\":\\\"AQAB\\\",\\\"n\\\":\\\"qAUcPTuPGu9bsW3itRmJxzz_bzqOdFPL4QGItaiMVyabnDbqI2A_mk0y8ieY8pNMlt6glmhve9kp00tbRZKIXaM6SXtHJy03WMfBaQKjGn1QbGxm4jod0AunIxXu4Wafl7BddOj8-kKOPDWHyKu7zrPQ2lzYgy-ItJApGWGiEpPmsor4irQWcUhc5eu-dyLbNU34A0_4J7IhzWxTmJfVuLQS2z07d1z4GrO5nYqKe1v3BSoGEB9DylTpDhwqjv_JuC5Oc9eggu7Z2oUHQ30NWSUrdRpPit2IGnv9yFpeOWmQOPTQOXk9_0Tf11xVU3Q-hJchbztybIa5OcPtZQFu_tRLBHQ09POnX3QIKRONKIZFwWXU2bcbz0fOkQMV2-x0OwEjnSt34VnYjHEqS8sdsv7lVD2w1oxak2TtQc12Uii8_PewOMuJh4Xoy1FQn-hJJSeI-4B9V_2T_0zTCbdrHOqQqGLReAZWNcjlTEY_JZKXaGY-1Imx7d5BJX-SYl3OpmMMVstqDH9AX6lrbHcMjfK7SF9XlB537akGdGGucqzCP8q3iuJx4o-dFojdNuOedpEUoYcWHBtxmqXemhFirOuhtX_CTrM_tg38epHi8l0fFazM4Dkczz5SjlLfvBghhqkMPvMT0VnwhdMRzIXyT442hol6jCd4frxJC1G26g8\\\"}]}\",\"maxCachingTime\":\"15\",\"maxIdleTime\":\"15\",\"maxSessionTime\":\"15\",\"quotaLimit\":\"5\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=utf-8"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "content-length",
+              "value": "1392"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload;"
+            },
+            {
+              "name": "x-robots-tag",
+              "value": "none"
+            },
+            {
+              "name": "via",
+              "value": "<via>"
+            },
+            {
+              "name": "alt-svc",
+              "value": "<alt-svc>"
+            }
+          ],
+          "headersSize": 682,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-21T15:39:02.363Z",
+        "time": 122,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 122
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
I added a function to import secret mapping configurations for the frodo config-manager push secret mappings command.

I also added the command implementation file to enable the command.