### PR TITLE
feat: Add config-manager push journeys command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@rockcarver/frodo-lib": "4.1.7",
+        "@rockcarver/frodo-lib": "4.1.8",
         "@types/colors": "^1.2.1",
         "@types/fs-extra": "^11.0.1",
         "@types/jest": "^29.2.3",
@@ -1866,9 +1866,9 @@
       }
     },
     "node_modules/@rockcarver/frodo-lib": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@rockcarver/frodo-lib/-/frodo-lib-4.1.7.tgz",
-      "integrity": "sha512-KUTHTz4JVphvVK0Nx++XvkN3bP6fuoC1oBSwKEyO1KxYJVHi6pqgdMU4lrLfu2vVdbgDneueJSvva+NDm4KYJg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@rockcarver/frodo-lib/-/frodo-lib-4.1.8.tgz",
+      "integrity": "sha512-sSLsrlUjO9yP2REXePwMRxhIFKLR6URphDpu38naE7f0o9CYwDHRVsArs7qgJ7wVGLUHeN4naMZBrvs/NaiEOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@rockcarver/frodo-lib": "4.1.7",
+    "@rockcarver/frodo-lib": "4.1.8",
     "@types/colors": "^1.2.1",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.2.3",

--- a/src/cli/config-manager/config-manager-push/config-manager-push-journeys.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push-journeys.ts
@@ -1,0 +1,46 @@
+import { Option } from 'commander';
+
+import { configManagerImportJourneys } from '../../../configManagerOps/FrConfigJourneysOps';
+import { getTokens } from '../../../ops/AuthenticateOps';
+import { verboseMessage } from '../../../utils/Console';
+import { FrodoCommand } from '../../FrodoCommand';
+
+export default function setup() {
+  const program = new FrodoCommand('frodo config-manager push journeys', []);
+
+  program
+    .description('Import journeys.')
+    .addOption(
+      new Option(
+        '-n, --name <name>',
+        'Journey name, imports the specified Journey.'
+      )
+    )
+
+    .addOption(
+      new Option('-d, --push-dependencies', 'Push scripts and inner journeys')
+    )
+
+    .action(async (host, realm, user, password, options, command) => {
+      command.handleDefaultArgsAndOpts(
+        host,
+        realm,
+        user,
+        password,
+        options,
+        command
+      );
+
+      const getTokensIsSuccessful = await getTokens(false, true);
+      if (!getTokensIsSuccessful) process.exit(1);
+      verboseMessage('Importing email provider configuration.');
+      const outcome = await configManagerImportJourneys(
+        options.name,
+        realm,
+        options.pushDependencies
+      );
+      if (!outcome) process.exitCode = 1;
+    });
+
+  return program;
+}

--- a/src/cli/config-manager/config-manager-push/config-manager-push.ts
+++ b/src/cli/config-manager/config-manager-push/config-manager-push.ts
@@ -12,6 +12,7 @@ import EmailProvider from './config-manager-push-email-provider';
 import EmailTemplates from './config-manager-push-email-templates';
 import Endpoints from './config-manager-push-endpoints';
 import InternalRoles from './config-manager-push-internal-roles';
+import Journeys from './config-manager-push-journeys';
 import Kba from './config-manager-push-kba';
 import Locales from './config-manager-push-locales';
 import ManagedObjects from './config-manager-push-managed-objects';
@@ -56,6 +57,7 @@ export default function setup() {
   program.addCommand(CustomNodes().name('custom-nodes'));
   program.addCommand(CSP().name('csp'));
   program.addCommand(Restart().name('restart'));
+  program.addCommand(Journeys().name('journeys'));
 
   return program;
 }

--- a/src/configManagerOps/FrConfigAuthenticationOps.ts
+++ b/src/configManagerOps/FrConfigAuthenticationOps.ts
@@ -2,7 +2,7 @@ import { frodo, state } from '@rockcarver/frodo-lib';
 import { AuthenticationSettingsExportInterface } from '@rockcarver/frodo-lib/types/ops/AuthenticationSettingsOps';
 import fs from 'fs';
 
-import { printError } from '../utils/Console';
+import { printError, verboseMessage } from '../utils/Console';
 import { realmList } from '../utils/FrConfig';
 
 const {
@@ -65,6 +65,12 @@ export async function configManagerImportAuthentication(
       const filePath = getFilePath(
         `realms/${realm}/realm-config/authentication.json`
       );
+
+      if (!fs.existsSync(filePath)) {
+        verboseMessage('No authentication file found to import.');
+        return false;
+      }
+
       const fileContent = fs.readFileSync(filePath, 'utf-8');
       const authData = JSON.parse(fileContent);
       delete authData._rev;
@@ -76,6 +82,7 @@ export async function configManagerImportAuthentication(
     } else {
       const realmsPath = getFilePath(`realms/`);
       const realmDirs = fs.readdirSync(realmsPath);
+
       for (const realmName of realmDirs) {
         await state.setRealm(realmName);
         let realmPath;
@@ -88,6 +95,10 @@ export async function configManagerImportAuthentication(
           realmPath = getFilePath(
             `realms/${realmName}/realm-config/authentication.json`
           );
+        }
+
+        if (!fs.existsSync(realmPath)) {
+          continue;
         }
 
         const fileContent = fs.readFileSync(realmPath, 'utf-8');

--- a/src/configManagerOps/FrConfigJourneysOps.ts
+++ b/src/configManagerOps/FrConfigJourneysOps.ts
@@ -1,197 +1,183 @@
 import { frodo, state } from '@rockcarver/frodo-lib';
-import {
-  MultiTreeExportInterface,
-  TreeExportOptions,
-} from '@rockcarver/frodo-lib/types/ops/JourneyOps';
+import { NodeSkeleton } from '@rockcarver/frodo-lib/types/api/NodeApi';
+import { ScriptSkeleton } from '@rockcarver/frodo-lib/types/api/ScriptApi';
+import { SingleTreeExportInterface } from '@rockcarver/frodo-lib/types/ops/JourneyOps';
+import fs from 'fs';
 
 import { extractFrConfigDataToFile } from '../utils/Config';
-import { printError, verboseMessage } from '../utils/Console';
+import { printError, printMessage } from '../utils/Console';
 import { existScript, realmList, safeFileName } from '../utils/FrConfig';
 
 const { saveJsonToFile, getFilePath } = frodo.utils;
-const { exportJourneys } = frodo.authn.journey;
+const { exportScript } = frodo.script;
+const { exportJourneys, importJourneys, createSingleTreeExportTemplate } =
+  frodo.authn.journey;
+const { DEFAULT_REALM_KEY } = frodo.utils.constants;
 
+/**
+ * Export journeys in fr-config-manager format
+ * @param {string} name exports only the specifically named journey
+ * @param {string} realm exports journeys only in specified realm
+ * @param {boolean} pullDependencies include journey dependencies
+ * @param {boolean} clean if true clear existing configuration, otherwise false
+ * @returns {Promise<boolean>} A promise that resolves to true if successful, false otherwise
+ */
 export async function configManagerExportJourneys(
-  name?,
-  realm?,
-  pullDependency?
-  // TO DO: clean?
+  name?: string,
+  realm?: string,
+  pullDependencies: boolean = false,
+  clean: boolean = false
 ): Promise<boolean> {
-  const options: TreeExportOptions = {
-    deps: pullDependency,
-    useStringArrays: true,
-    coords: true,
-  };
-
   try {
-    if (realm && realm !== '__default__realm__') {
-      const exportData = (await exportJourneys(
-        options
-      )) as MultiTreeExportInterface;
-      processJourneys(exportData.trees, realm, name, pullDependency, 'realms');
-    } else {
-      for (const realm of await realmList()) {
-        if (
-          realm === '/' &&
-          state.getDeploymentType() ===
-            frodo.utils.constants.CLOUD_DEPLOYMENT_TYPE_KEY
-        )
-          continue;
-
-        state.setRealm(realm);
-        const exportData = (await exportJourneys(
-          options
-        )) as MultiTreeExportInterface;
-        await processJourneys(
-          exportData.trees,
-          realm,
-          name,
-          pullDependency,
-          'realms'
-        );
-      }
+    const realmNames =
+      realm && realm !== DEFAULT_REALM_KEY ? [realm] : await realmList();
+    for (const realmName of realmNames) {
+      if (
+        realmName === '/' &&
+        state.getDeploymentType() ===
+          frodo.utils.constants.CLOUD_DEPLOYMENT_TYPE_KEY
+      )
+        continue;
+      state.setRealm(realmName);
+      const exportData = await exportJourneys({
+        deps: false,
+        useStringArrays: false,
+        coords: true,
+      });
+      await processJourneysExport(
+        exportData.trees,
+        name,
+        pullDependencies,
+        clean
+      );
     }
     return true;
   } catch (error) {
-    printError(error, `Error exporting config entity endpoints`);
+    printError(error, `Error exporting journeys`);
   }
   return false;
 }
 
-function matchJourneyName(journey, name) {
-  return journey.tree._id === name;
-}
-
-function fileNameFromNode(displayName, id) {
-  return safeFileName(`${displayName} - ${id}`);
-}
-
-async function processJourneys(
-  journeys,
-  realm,
-  name,
-  pullDependencies,
-  exportDir
+/**
+ * Helper that processes a journey node for export
+ * @param {NodeSkeleton} node the journey node
+ * @param {string} displayName the node display name
+ * @param {string} nodeDir the node directory
+ * @param {string} realmDir the realm directory
+ * @param {boolean} pullDependencies include journey dependencies
+ * @param {SingleTreeExportInterface} journey the journey export
+ */
+async function processNodeExport(
+  node: NodeSkeleton,
+  displayName: string,
+  nodeDir: string,
+  realmDir: string,
+  pullDependencies: boolean,
+  journey: SingleTreeExportInterface
 ) {
-  const fileDir = `${exportDir}/${realm}/journeys`;
-  try {
-    for (const [, journey] of Object.entries(journeys) as [string, any]) {
-      if (name && !matchJourneyName(journey, name)) {
-        continue;
-      }
-      const journeyDir = `${fileDir}/${journey.tree._id}`;
-      const nodeDir = `${journeyDir}/nodes`;
-      const scriptJsonDir = `realms/${realm}/scripts/scripts-config`;
-
-      for (const [nodeId, node] of Object.entries(journey.nodes) as [
-        string,
-        any,
-      ]) {
-        const nodeFileNameRoot = `${nodeDir}/${fileNameFromNode(journey.tree.nodes[nodeId].displayName, nodeId)}`;
-
-        if (node._type._id === 'PageNode') {
-          for (const subNode of node.nodes) {
-            const subNodeSpec = journey.innerNodes[subNode._id];
-
-            const subNodeFilename = `${nodeFileNameRoot}/${fileNameFromNode(subNode.displayName, subNode._id)}.json`;
-            saveJsonToFile(
-              subNodeSpec,
-              getFilePath(subNodeFilename, true),
-              false,
-              true,
-              true
-            );
-            if (
-              pullDependencies &&
-              journeyNodeNeedsScript(subNodeSpec) &&
-              !(await existScript(subNodeSpec.script, realm))
-            ) {
-              const script = journey.scripts[subNodeSpec.script];
-
-              const scriptText = Array.isArray(script.script)
-                ? script.script.join('\n')
-                : script.script;
-              const scriptExtractDir = `realms/${realm}/scripts/`;
-              const scriptExtractName = `scripts-content/${script.context}/${script.name}.js`;
-              extractFrConfigDataToFile(
-                scriptText,
-                scriptExtractName,
-                scriptExtractDir
-              );
-              script.script = { file: `${scriptExtractName}` };
-
-              saveJsonToFile(
-                script,
-                getFilePath(`${scriptJsonDir}/${script._id}.json`, true),
-                false,
-                true,
-                true
-              );
-            }
-          }
-        } else if (
-          pullDependencies &&
-          journeyNodeNeedsScript(node) &&
-          !(await existScript(node.script, realm))
-        ) {
-          verboseMessage('Trying to save the script on the node');
-          verboseMessage(nodeId);
-          verboseMessage(node.script);
-
-          const script = journey.scripts[node.script];
-          const scriptText = Array.isArray(script.script)
-            ? script.script.join('\n')
-            : script.script;
-          const scriptExtractDir = `realms/${realm}/scripts`;
-          const scriptExtractName = `scripts-content/${script.context}/${script.name}.js`;
-          extractFrConfigDataToFile(
-            scriptText,
-            scriptExtractName,
-            scriptExtractDir
-          );
-
-          script.script = { file: `${scriptExtractName}` };
-          saveJsonToFile(
-            script,
-            getFilePath(`${scriptJsonDir}/${script._id}.json`, true),
-            false,
-            true,
-            true
-          );
-        } else if (
-          !!name &&
-          pullDependencies &&
-          node._type._id === 'InnerTreeEvaluatorNode'
-        ) {
-          await processJourneys(
-            journeys,
-            realm,
-            node.tree,
-            pullDependencies,
-            exportDir
-          );
-        }
-
-        saveJsonToFile(
-          node,
-          getFilePath(`${nodeFileNameRoot}.json`, true),
-          false,
-          true,
-          true
-        );
-      }
-
-      const fileName = `${journeyDir}/${journey.tree._id}.json`;
-      saveJsonToFile(
-        journey.tree,
-        getFilePath(`${fileName}`, true),
-        false,
-        true,
-        true
+  const nodeFileDir = `${nodeDir}/${safeFileName(`${displayName} - ${node._id}`)}`;
+  if (node._type?._id === 'PageNode') {
+    for (const innerNode of node.nodes) {
+      await processNodeExport(
+        journey.innerNodes[innerNode._id],
+        innerNode.displayName,
+        nodeFileDir,
+        realmDir,
+        pullDependencies,
+        journey
       );
     }
-  } catch (err) {
-    printError(err);
+  }
+  if (
+    pullDependencies &&
+    journeyNodeNeedsScript(node) &&
+    !existScript(node.script, realmDir)
+  ) {
+    const script = (
+      await exportScript(node.script, {
+        deps: false,
+        includeDefault: true,
+        useStringArrays: false,
+      })
+    ).script[node.script];
+    const scriptsDir = `realms/${realmDir}/scripts/`;
+    script.script = extractFrConfigDataToFile(
+      script.script,
+      `scripts-content/${script.context}/${script.name}.js`,
+      scriptsDir
+    ) as any;
+    saveJsonToFile(
+      script,
+      getFilePath(`${scriptsDir}scripts-config/${script._id}.json`, true),
+      false,
+      true,
+      true
+    );
+  }
+  saveJsonToFile(
+    node,
+    getFilePath(`${nodeFileDir}.json`, true),
+    false,
+    true,
+    true
+  );
+}
+
+/**
+ * Helper that processes journeys for export
+ * @param {Record<string, SingleTreeExportInterface>} journeys The journeys to process
+ * @param {string} name processes only the specifically named journey
+ * @param {boolean} pullDependencies include journey dependencies
+ * @param {boolean} clean if true clear existing configuration, otherwise false
+ */
+async function processJourneysExport(
+  journeys: Record<string, SingleTreeExportInterface>,
+  name?: string,
+  pullDependencies: boolean = false,
+  clean: boolean = false
+): Promise<void> {
+  const realmDir = state.getRealm() === '/' ? 'root' : state.getRealm();
+  for (const [treeId, journey] of Object.entries(journeys)) {
+    if (name && treeId !== name) {
+      continue;
+    }
+    const journeyDir = `realms/${realmDir}/journeys/${treeId}`;
+    const nodeDir = `${journeyDir}/nodes`;
+    if (clean) {
+      fs.rmSync(nodeDir, { recursive: true, force: true });
+    }
+    if (!fs.existsSync(nodeDir)) {
+      fs.mkdirSync(nodeDir, { recursive: true });
+    }
+    for (const node of Object.values(journey.nodes)) {
+      if (
+        name &&
+        pullDependencies &&
+        node._type._id === 'InnerTreeEvaluatorNode'
+      ) {
+        await processJourneysExport(
+          journeys,
+          node.tree,
+          pullDependencies,
+          clean
+        );
+      }
+      await processNodeExport(
+        node,
+        journey.tree.nodes[node._id].displayName,
+        nodeDir,
+        realmDir,
+        pullDependencies,
+        journey
+      );
+    }
+    saveJsonToFile(
+      journey.tree,
+      getFilePath(`${journeyDir}/${journey.tree._id}.json`, true),
+      false,
+      true,
+      true
+    );
   }
 }
 
@@ -202,4 +188,216 @@ function journeyNodeNeedsScript(node) {
     // eslint-disable-next-line no-prototype-builtins
     (!node.hasOwnProperty('useScript') || node.useScript)
   );
+}
+
+/**
+ * Read a node's script from the fr-config-manager scripts directory, inlining its content into the scripts map
+ * @param {NodeSkeleton} node journey node that may reference a script
+ * @param {boolean} pushScripts whether script export is enabled
+ * @param {Record<string, ScriptSkeleton>} scripts map of script id to script object, populated by this function
+ * @param {string} realmDir on-disk realm directory name
+ */
+function readNodeScript(
+  node: NodeSkeleton,
+  pushScripts: boolean,
+  scripts: Record<string, ScriptSkeleton>,
+  realmDir: string
+): void {
+  if (!pushScripts || !journeyNodeNeedsScript(node) || scripts[node.script])
+    return;
+
+  const baseDir = getFilePath(`realms/${realmDir}/scripts`);
+  const scriptConfigFile = `${baseDir}/scripts-config/${node.script}.json`;
+  if (!fs.existsSync(scriptConfigFile)) {
+    printMessage(`Script config not found: ${scriptConfigFile}`, 'error');
+    return;
+  }
+
+  const script = JSON.parse(fs.readFileSync(scriptConfigFile, 'utf8'));
+
+  if (script.script?.file) {
+    const contentFile = `${baseDir}/${script.script.file}`;
+    if (!fs.existsSync(contentFile)) {
+      printMessage(`Script content not found: ${contentFile}`, 'error');
+      return;
+    }
+    script.script = fs.readFileSync(contentFile, 'utf8').split('\n');
+  }
+
+  scripts[node.script] = script;
+}
+/**
+ * Process a journey directory for configManagerImportJourneys
+ * @param {string} journeyName name of the journey
+ * @param {boolean} pushInnerJourneys if true processes innner journers
+ * @param {boolean} pushScripts if true processes scripts
+ * @param {string} journeysBaseDir base directory containing all journeys for the realm
+ * @param {string} realmDir path to the realm the journey
+ * @param {Set<string>} processedJourneys set of already-processed journey names to prevent processing the same journey multiple times
+ * @returns {Record<string, SingleTreeExportInterface>} map of journey names to their import data
+ */
+function processJourneyImport(
+  journeyName: string,
+  pushInnerJourneys: boolean,
+  pushScripts: boolean,
+  journeysBaseDir: string,
+  realmDir: string,
+  processedJourneys: Set<string> = new Set()
+): Record<string, SingleTreeExportInterface> {
+  if (processedJourneys.has(journeyName)) {
+    return {};
+  }
+  processedJourneys.add(journeyName);
+
+  const treeJsonPath = `${journeysBaseDir}/${journeyName}/${journeyName}.json`;
+
+  const treeData = fs.readFileSync(treeJsonPath, 'utf8');
+  const tree = JSON.parse(treeData);
+
+  const journeyData = createSingleTreeExportTemplate();
+  journeyData.tree = tree;
+
+  const innerTreeNames: string[] = [];
+
+  const nodesDir = `${journeysBaseDir}/${journeyName}/nodes`;
+  if (fs.existsSync(nodesDir)) {
+    const entries = fs.readdirSync(nodesDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith('.json')) {
+        const node = JSON.parse(
+          fs.readFileSync(`${nodesDir}/${entry.name}`, 'utf8')
+        );
+        journeyData.nodes[node._id] = node;
+
+        if (pushInnerJourneys && node._type?._id === 'InnerTreeEvaluatorNode') {
+          innerTreeNames.push(node.tree);
+        } else {
+          readNodeScript(node, pushScripts, journeyData.scripts, realmDir);
+        }
+      }
+
+      if (entry.isDirectory()) {
+        const pageNodeDir = `${nodesDir}/${entry.name}`;
+        const innerFiles = fs.readdirSync(pageNodeDir);
+        for (const innerFile of innerFiles) {
+          if (!innerFile.endsWith('.json')) continue;
+          const innerData = fs.readFileSync(
+            `${pageNodeDir}/${innerFile}`,
+            'utf8'
+          );
+          const innerNode = JSON.parse(innerData);
+          journeyData.innerNodes[innerNode._id] = innerNode;
+          readNodeScript(innerNode, pushScripts, journeyData.scripts, realmDir);
+        }
+      }
+    }
+  }
+
+  const trees: Record<string, SingleTreeExportInterface> = {
+    [journeyName]: journeyData,
+  };
+
+  for (const innerTreeName of innerTreeNames) {
+    const innerTrees = processJourneyImport(
+      innerTreeName,
+      pushInnerJourneys,
+      pushScripts,
+      journeysBaseDir,
+      realmDir,
+      processedJourneys
+    );
+    Object.assign(trees, innerTrees);
+  }
+
+  return trees;
+}
+
+/**
+ * Import journeys from fr-config-manager file structure
+ * @param {string} name optional journey name to import
+ * @param {string} realm optional realm to import to
+ * @param {boolean} dependencies if true, push scripts and inner tree dependencies
+ * @returns true if successful, false otherwise
+ */
+export async function configManagerImportJourneys(
+  name?: string,
+  realm?: string,
+  dependencies: boolean = false
+): Promise<boolean> {
+  try {
+    const pushInnerJourneys = !name || dependencies;
+    const pushScripts = dependencies;
+    const options = { deps: dependencies, reUuid: false };
+
+    const realmsDir = getFilePath('realms');
+    if (!fs.existsSync(realmsDir)) {
+      printMessage('No journey files found to import.', 'error');
+      return false;
+    }
+
+    const realmDirs = fs
+      .readdirSync(realmsDir, { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => dirent.name);
+
+    let imported = false;
+
+    for (const realmDir of realmDirs) {
+      state.setRealm(realmDir === 'root' ? '/' : realmDir);
+
+      if (
+        (state.getRealm() === '/' &&
+          state.getDeploymentType() ===
+            frodo.utils.constants.CLOUD_DEPLOYMENT_TYPE_KEY) ||
+        (realm !== DEFAULT_REALM_KEY && state.getRealm() !== realm)
+      )
+        continue;
+
+      const journeysBaseDir = `${realmsDir}/${realmDir}/journeys`;
+      if (!fs.existsSync(journeysBaseDir)) continue;
+
+      const journeyNames = name
+        ? [name]
+        : fs
+            .readdirSync(journeysBaseDir, { withFileTypes: true })
+            .filter((dirent) => dirent.isDirectory())
+            .map((dirent) => dirent.name);
+
+      const trees: Record<string, any> = {};
+      const processed = new Set<string>();
+
+      for (const journeyName of journeyNames) {
+        const journeyDir = `${journeysBaseDir}/${journeyName}`;
+        if (!fs.existsSync(journeyDir)) continue;
+
+        Object.assign(
+          trees,
+          processJourneyImport(
+            journeyName,
+            pushInnerJourneys,
+            pushScripts,
+            journeysBaseDir,
+            realmDir,
+            processed
+          )
+        );
+      }
+
+      if (Object.keys(trees).length) {
+        await importJourneys({ trees }, options);
+        imported = true;
+      }
+    }
+
+    if (!imported) {
+      printMessage('No journey files found to import.', 'error');
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    printError(error, `Error importing journeys`);
+  }
+  return false;
 }

--- a/src/utils/FrConfig.ts
+++ b/src/utils/FrConfig.ts
@@ -1,9 +1,10 @@
 import { frodo } from '@rockcarver/frodo-lib';
+import fs from 'fs';
 import sanitize from 'sanitize-filename';
 
 const { readRealms } = frodo.realm;
 
-const { getFilePath, findFilesByName, getWorkingDirectory } = frodo.utils;
+const { findFilesByName } = frodo.utils;
 
 export async function realmList(): Promise<string[]> {
   const realms = await readRealms();
@@ -45,20 +46,9 @@ export function replaceAllInJson(
   return JSON.parse(contentString);
 }
 
-export async function existScript(
-  fileName: string,
-  realm: string
-): Promise<boolean> {
-  await getFilePath(`realms/${realm}/scripts/scripts-config/`, true);
-  const result = await findFilesByName(
-    `${fileName}.json`,
-    true,
-    `${getWorkingDirectory()}/realms/${realm}/scripts/scripts-config`
-  );
-
-  if (result.length) {
-    return true;
-  } else {
-    return false;
-  }
+export function existScript(fileName: string, realmDir: string): boolean {
+  const scriptDir = `realms/${realmDir}/scripts/scripts-config`;
+  if (!fs.existsSync(scriptDir)) return false;
+  const result = findFilesByName(`${fileName}.json`, true, scriptDir);
+  return result.length > 0;
 }

--- a/test/client_cli/en/__snapshots__/config-manager-push-journeys.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-journeys.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI help interface for 'config-manager push journeys' should be expected english 1`] = `
+"Usage: frodo config-manager push journeys [options] [host] [realm] [username] [password]
+
+[Experimental] Import journeys.
+
+Arguments:
+  host                     AM base URL, e.g.: https://cdk.iam.example.com/am. To
+                           use a connection profile, just specify a unique
+                           substring or alias.
+  realm                    Realm. Specify realm as '/' for the root realm or
+                           'realm' or '/parent/child' otherwise. (default:
+                           "alpha" for Identity Cloud tenants, "/" otherwise.)
+  username                 Username to login with. Must be an admin user with
+                           appropriate rights to manage authentication
+                           journeys/trees.
+  password                 Password.
+
+Options:
+  -d, --push-dependencies  Push scripts and inner journeys
+  -n, --name <name>        Journey name, imports the specified Journey.
+  -h, --help               Help
+  -hh, --help-more         Help with all options.
+  -hhh, --help-all         Help with all options, environment variables, and
+                           usage examples.
+"
+`;

--- a/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push.test.js.snap
@@ -26,6 +26,7 @@ Commands:
   endpoints              [Experimental] Import custom endpoints objects.
   help                   display help for command
   internal-roles         [Experimental] Import internal roles.
+  journeys               [Experimental] Import journeys.
   kba                    [Experimental] Import kba configuration.
   locales                [Experimental] Import custom locales objects.
   managed-objects        [Experimental] Import managed objects.

--- a/test/client_cli/en/config-manager-push-journeys.test.js
+++ b/test/client_cli/en/config-manager-push-journeys.test.js
@@ -1,0 +1,10 @@
+import cp from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(cp.exec);
+const CMD = 'frodo config-manager push journeys --help';
+const { stdout } = await exec(CMD);
+
+test("CLI help interface for 'config-manager push journeys' should be expected english", async () => {
+    expect(stdout).toMatchSnapshot();
+});

--- a/test/e2e/__snapshots__/config-manager-export-journeys.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/config-manager-export-journeys.e2e.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style" 1`] = `0`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style" 1`] = `0`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style" 2`] = `""`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style" 2`] = `""`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Agent/Agent.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Agent/Agent.json 1`] = `
 {
   "_id": "Agent",
   "_rev": "-737774734",
@@ -70,7 +70,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Agent/nodes/Agent Data Store Decision - 6736a00a-fc65-438e-b4ea-23f66b4a8739.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Agent/nodes/Agent Data Store Decision - 6736a00a-fc65-438e-b4ea-23f66b4a8739.json 1`] = `
 {
   "_id": "6736a00a-fc65-438e-b4ea-23f66b4a8739",
   "_outcomes": [
@@ -93,7 +93,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080.json 1`] = `
 {
   "_id": "cbd1f1af-eb0a-4274-a762-adacf04c7080",
   "_outcomes": [
@@ -128,7 +128,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Password - 6072842f-5f7c-4b62-8ae2-4f18a5701ba4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Password - 6072842f-5f7c-4b62-8ae2-4f18a5701ba4.json 1`] = `
 {
   "_id": "6072842f-5f7c-4b62-8ae2-4f18a5701ba4",
   "_outcomes": [
@@ -149,7 +149,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Username - 2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Username - 2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018.json 1`] = `
 {
   "_id": "2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018",
   "_outcomes": [
@@ -171,7 +171,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Agent/nodes/Zero Page Login Collector - 51e2cd24-cf1f-4313-8af0-35ea9e04d2fe.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Agent/nodes/Zero Page Login Collector - 51e2cd24-cf1f-4313-8af0-35ea9e04d2fe.json 1`] = `
 {
   "_id": "51e2cd24-cf1f-4313-8af0-35ea9e04d2fe",
   "_outcomes": [
@@ -198,7 +198,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
 {
   "_id": "ForgottenUsername",
   "_rev": "-830414370",
@@ -274,7 +274,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
 {
   "_id": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
   "_outcomes": [
@@ -300,7 +300,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
 {
   "_id": "bf9ea8d5-9802-4f26-9664-a21840faac23",
   "_outcomes": [
@@ -325,7 +325,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
 {
   "_id": "b93ce36e-1976-4610-b24f-8d6760b5463b",
   "_outcomes": [
@@ -350,7 +350,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
 {
   "_id": "5e2a7c95-94af-4b23-8724-deb13853726a",
   "_outcomes": [
@@ -383,7 +383,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
 {
   "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
   "_outcomes": [
@@ -408,7 +408,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
 {
   "_id": "FrodoTest",
   "_rev": "-1175854005",
@@ -522,7 +522,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
 {
   "_id": "e2c39477-847a-4df2-9c5d-b449a752638b",
   "_outcomes": [
@@ -556,7 +556,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
 {
   "_id": "bf153f37-83dd-4f39-aa0c-74135430242e",
   "_outcomes": [
@@ -582,7 +582,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
 {
   "_id": "278bf084-9eea-46fe-8ce9-2600dde3b046",
   "_outcomes": [
@@ -627,7 +627,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
 {
   "_id": "804e6a68-1720-442b-926a-007e90f02782",
   "_outcomes": [
@@ -648,7 +648,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
 {
   "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
   "_outcomes": [
@@ -676,7 +676,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
 {
   "_id": "7a351800-fb7e-4145-903c-388554747556",
   "_outcomes": [
@@ -698,7 +698,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
 {
   "_id": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
   "_outcomes": [
@@ -737,7 +737,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
 {
   "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
   "_outcomes": [
@@ -758,7 +758,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
 {
   "_id": "038f9b2a-36b2-489b-9e03-386c9a62ea21",
   "_outcomes": [
@@ -786,7 +786,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
 {
   "_id": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
   "_outcomes": [
@@ -825,7 +825,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
 {
   "_id": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
   "_outcomes": [
@@ -853,7 +853,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
 {
   "_id": "fc7e47cd-c679-4211-8e05-a36654f23c67",
   "_outcomes": [
@@ -891,7 +891,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTestJourney13/FrodoTestJourney13.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTestJourney13/FrodoTestJourney13.json 1`] = `
 {
   "_id": "FrodoTestJourney13",
   "_rev": "1535600290",
@@ -946,7 +946,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c.json 1`] = `
 {
   "_id": "c847e93b-afa3-4d20-9a15-f75404ec353c",
   "_outcomes": [
@@ -981,7 +981,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Password - e4c5071f-acc8-47c9-b097-5c4144170742.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Password - e4c5071f-acc8-47c9-b097-5c4144170742.json 1`] = `
 {
   "_id": "e4c5071f-acc8-47c9-b097-5c4144170742",
   "_outcomes": [
@@ -1002,7 +1002,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Username - 64dceffc-2db4-468b-96d1-491824e037a2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Username - 64dceffc-2db4-468b-96d1-491824e037a2.json 1`] = `
 {
   "_id": "64dceffc-2db4-468b-96d1-491824e037a2",
   "_outcomes": [
@@ -1025,7 +1025,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/FrodoTestJourney13/nodes/Validate Credentials - bdca20b7-ada8-4906-8b3a-e59c313f6491.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/FrodoTestJourney13/nodes/Validate Credentials - bdca20b7-ada8-4906-8b3a-e59c313f6491.json 1`] = `
 {
   "_id": "bdca20b7-ada8-4906-8b3a-e59c313f6491",
   "_outcomes": [
@@ -1048,7 +1048,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/Login.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/Login.json 1`] = `
 {
   "_id": "Login",
   "_rev": "384176338",
@@ -1148,7 +1148,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Account Lockout - 51e8c4c1-3509-4635-90e6-d2cc31c4a6a5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Account Lockout - 51e8c4c1-3509-4635-90e6-d2cc31c4a6a5.json 1`] = `
 {
   "_id": "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5",
   "_outcomes": [
@@ -1168,7 +1168,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Identity Store Decision - 7f0c2aee-8c74-4d02-82a6-9d4ed9d11708.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Identity Store Decision - 7f0c2aee-8c74-4d02-82a6-9d4ed9d11708.json 1`] = `
 {
   "_id": "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708",
   "_outcomes": [
@@ -1206,7 +1206,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
 {
   "_id": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
   "_outcomes": [
@@ -1226,7 +1226,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
 {
   "_id": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
   "_outcomes": [
@@ -1251,7 +1251,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
 {
   "_id": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
   "_outcomes": [
@@ -1290,7 +1290,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
 {
   "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
   "_outcomes": [
@@ -1311,7 +1311,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
 {
   "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
   "_outcomes": [
@@ -1333,7 +1333,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Login/nodes/Retry Limit Decision - 2119f332-0f69-4088-a7a1-6582bf0f2001.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Login/nodes/Retry Limit Decision - 2119f332-0f69-4088-a7a1-6582bf0f2001.json 1`] = `
 {
   "_id": "2119f332-0f69-4088-a7a1-6582bf0f2001",
   "_outcomes": [
@@ -1358,7 +1358,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/OrphanedTest/OrphanedTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/OrphanedTest/OrphanedTest.json 1`] = `
 {
   "_id": "OrphanedTest",
   "_rev": "680738111",
@@ -1406,7 +1406,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/OrphanedTest/nodes/Identity Store Decision - 343e745f-923a-43c4-8675-649a490fd0a3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/OrphanedTest/nodes/Identity Store Decision - 343e745f-923a-43c4-8675-649a490fd0a3.json 1`] = `
 {
   "_id": "343e745f-923a-43c4-8675-649a490fd0a3",
   "_outcomes": [
@@ -1444,7 +1444,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/P1P-Test.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/P1P-Test.json 1`] = `
 {
   "_id": "P1P-Test",
   "_rev": "946402521",
@@ -1609,7 +1609,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540.json 1`] = `
 {
   "_id": "f1cb199e-9e9a-4761-bacf-bc717ca6c540",
   "_outcomes": [
@@ -1640,7 +1640,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540/Debug - de8fa10c-f4cc-44b7-b675-cdc75dcc600f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540/Debug - de8fa10c-f4cc-44b7-b675-cdc75dcc600f.json 1`] = `
 {
   "_id": "de8fa10c-f4cc-44b7-b675-cdc75dcc600f",
   "_outcomes": [
@@ -1664,7 +1664,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/FAILED - e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/FAILED - e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece.json 1`] = `
 {
   "_id": "e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece",
   "_outcomes": [
@@ -1684,7 +1684,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939.json 1`] = `
 {
   "_id": "084c3d2d-7d47-4f2e-81d1-57961d496939",
   "_outcomes": [
@@ -1715,7 +1715,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939/Debug - 2c8f0d12-c373-4a25-9a30-b3184888d163.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939/Debug - 2c8f0d12-c373-4a25-9a30-b3184888d163.json 1`] = `
 {
   "_id": "2c8f0d12-c373-4a25-9a30-b3184888d163",
   "_outcomes": [
@@ -1739,7 +1739,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Identity Store Decision - ef1929b1-255e-446e-a597-7d7a3c4bf63f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Identity Store Decision - ef1929b1-255e-446e-a597-7d7a3c4bf63f.json 1`] = `
 {
   "_id": "ef1929b1-255e-446e-a597-7d7a3c4bf63f",
   "_outcomes": [
@@ -1777,7 +1777,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Initialize Signals SDK - 6632fe0f-6395-4cc1-88d8-c9ca4a9061b6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Initialize Signals SDK - 6632fe0f-6395-4cc1-88d8-c9ca4a9061b6.json 1`] = `
 {
   "_id": "6632fe0f-6395-4cc1-88d8-c9ca4a9061b6",
   "_outcomes": [
@@ -1811,7 +1811,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5.json 1`] = `
 {
   "_id": "4fdf4255-0236-4527-ae6d-d10d2c0ee8d5",
   "_outcomes": [
@@ -1846,7 +1846,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Password - 6a428d9f-a221-44f6-a5c6-c6981f90f9fc.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Password - 6a428d9f-a221-44f6-a5c6-c6981f90f9fc.json 1`] = `
 {
   "_id": "6a428d9f-a221-44f6-a5c6-c6981f90f9fc",
   "_outcomes": [
@@ -1867,7 +1867,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Username - f74e82e2-72ab-4a1a-9188-655622794a37.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Username - f74e82e2-72ab-4a1a-9188-655622794a37.json 1`] = `
 {
   "_id": "f74e82e2-72ab-4a1a-9188-655622794a37",
   "_outcomes": [
@@ -1890,7 +1890,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4.json 1`] = `
 {
   "_id": "00a4835b-6e99-4938-9bb8-50d5569a68d4",
   "_outcomes": [
@@ -1921,7 +1921,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4/Debug - 843dd22b-a890-461b-9a16-33d8bd871396.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4/Debug - 843dd22b-a890-461b-9a16-33d8bd871396.json 1`] = `
 {
   "_id": "843dd22b-a890-461b-9a16-33d8bd871396",
   "_outcomes": [
@@ -1945,7 +1945,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394.json 1`] = `
 {
   "_id": "37f190ea-fa18-4d44-941b-4e5ac325f394",
   "_outcomes": [
@@ -1976,7 +1976,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394/Debug - 8835fe59-3988-4121-8b15-ad16a7049d7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394/Debug - 8835fe59-3988-4121-8b15-ad16a7049d7a.json 1`] = `
 {
   "_id": "8835fe59-3988-4121-8b15-ad16a7049d7a",
   "_outcomes": [
@@ -2000,7 +2000,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576.json 1`] = `
 {
   "_id": "a0059e3b-de04-4f0f-a5ed-49525d1da576",
   "_outcomes": [
@@ -2031,7 +2031,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576/Debug - c1804982-10dc-4668-bd53-909107cc4039.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576/Debug - c1804982-10dc-4668-bd53-909107cc4039.json 1`] = `
 {
   "_id": "c1804982-10dc-4668-bd53-909107cc4039",
   "_outcomes": [
@@ -2055,7 +2055,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92.json 1`] = `
 {
   "_id": "8120e613-dee8-42b4-9668-71b8a25c1c92",
   "_outcomes": [
@@ -2086,7 +2086,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92/Debug - 52ab689c-491b-4117-b729-ff590b5d1f61.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92/Debug - 52ab689c-491b-4117-b729-ff590b5d1f61.json 1`] = `
 {
   "_id": "52ab689c-491b-4117-b729-ff590b5d1f61",
   "_outcomes": [
@@ -2110,7 +2110,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/P1P Risk Decision - df827cfc-6e2d-4b9f-a8b1-d92c2910eb07.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/P1P Risk Decision - df827cfc-6e2d-4b9f-a8b1-d92c2910eb07.json 1`] = `
 {
   "_id": "df827cfc-6e2d-4b9f-a8b1-d92c2910eb07",
   "_outcomes": [
@@ -2164,7 +2164,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/P1P-Test/nodes/SUCCESS - 167b87dd-a97c-4e3b-82ba-581090fd7863.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/P1P-Test/nodes/SUCCESS - 167b87dd-a97c-4e3b-82ba-581090fd7863.json 1`] = `
 {
   "_id": "167b87dd-a97c-4e3b-82ba-581090fd7863",
   "_outcomes": [
@@ -2184,7 +2184,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/PrestonTest/PrestonTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/PrestonTest/PrestonTest.json 1`] = `
 {
   "_id": "PrestonTest",
   "_rev": "-2075247621",
@@ -2204,7 +2204,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
 {
   "_id": "ProgressiveProfile",
   "_rev": "260694535",
@@ -2281,7 +2281,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
 {
   "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
   "_outcomes": [
@@ -2307,7 +2307,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
 {
   "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
   "_outcomes": [
@@ -2338,7 +2338,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
 {
   "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
   "_outcomes": [
@@ -2364,7 +2364,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
 {
   "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
   "_outcomes": [
@@ -2391,7 +2391,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
 {
   "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
   "_outcomes": [
@@ -2416,7 +2416,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/RadioChoice/RadioChoice.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/RadioChoice/RadioChoice.json 1`] = `
 {
   "_id": "RadioChoice",
   "_rev": "1819878661",
@@ -2461,7 +2461,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e.json 1`] = `
 {
   "_id": "5d6cd20e-5074-43de-8832-fddd95fb078e",
   "_outcomes": [
@@ -2499,7 +2499,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e/Choice Collector - a566e474-99f3-46e4-9e70-682402bfaa84.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e/Choice Collector - a566e474-99f3-46e4-9e70-682402bfaa84.json 1`] = `
 {
   "_id": "a566e474-99f3-46e4-9e70-682402bfaa84",
   "_outcomes": [
@@ -2533,7 +2533,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/Registration.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/Registration.json 1`] = `
 {
   "_id": "Registration",
   "_rev": "388671950",
@@ -2608,7 +2608,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
 {
   "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
   "_outcomes": [
@@ -2632,7 +2632,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Email Suspend Node - 466f8b54-07fb-4e31-a11d-a6842618cc37.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Email Suspend Node - 466f8b54-07fb-4e31-a11d-a6842618cc37.json 1`] = `
 {
   "_id": "466f8b54-07fb-4e31-a11d-a6842618cc37",
   "_outcomes": [
@@ -2658,7 +2658,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
 {
   "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
   "_outcomes": [
@@ -2678,7 +2678,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
 {
   "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
   "_outcomes": [
@@ -2736,7 +2736,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
 {
   "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
   "_outcomes": [
@@ -2755,7 +2755,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
 {
   "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
   "_outcomes": [
@@ -2784,7 +2784,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
 {
   "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
   "_outcomes": [
@@ -2807,7 +2807,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
 {
   "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
   "_outcomes": [
@@ -2828,7 +2828,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
 {
   "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
   "_outcomes": [
@@ -2850,7 +2850,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/ResetPassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/ResetPassword.json 1`] = `
 {
   "_id": "ResetPassword",
   "_rev": "1685804267",
@@ -2936,7 +2936,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
 {
   "_id": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
   "_outcomes": [
@@ -2962,7 +2962,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
 {
   "_id": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
   "_outcomes": [
@@ -2987,7 +2987,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
 {
   "_id": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
   "_outcomes": [
@@ -3020,7 +3020,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
 {
   "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
   "_outcomes": [
@@ -3045,7 +3045,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
 {
   "_id": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
   "_outcomes": [
@@ -3078,7 +3078,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
 {
   "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
   "_outcomes": [
@@ -3099,7 +3099,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
 {
   "_id": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
   "_outcomes": [
@@ -3126,7 +3126,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/SocialProviderHandler/SocialProviderHandler.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/SocialProviderHandler/SocialProviderHandler.json 1`] = `
 {
   "_id": "SocialProviderHandler",
   "_rev": "-2033719727",
@@ -3182,7 +3182,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/SocialProviderHandler/nodes/Legacy Social Provider Handler Node - 3af612be-340e-4dc9-80fb-62319a187b74.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/SocialProviderHandler/nodes/Legacy Social Provider Handler Node - 3af612be-340e-4dc9-80fb-62319a187b74.json 1`] = `
 {
   "_id": "3af612be-340e-4dc9-80fb-62319a187b74",
   "_outcomes": [
@@ -3210,7 +3210,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/SocialProviderHandler/nodes/Social Provider Handler Node - e15c8efe-b7a7-42bf-845e-861a9419af32.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/SocialProviderHandler/nodes/Social Provider Handler Node - e15c8efe-b7a7-42bf-845e-861a9419af32.json 1`] = `
 {
   "_id": "e15c8efe-b7a7-42bf-845e-861a9419af32",
   "_outcomes": [
@@ -3243,7 +3243,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/UpdatePassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/UpdatePassword.json 1`] = `
 {
   "_id": "UpdatePassword",
   "_rev": "-1098606408",
@@ -3350,7 +3350,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
 {
   "_id": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
   "_outcomes": [
@@ -3375,7 +3375,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
 {
   "_id": "7d1deabe-cd98-49c8-943f-ca12305775f3",
   "_outcomes": [
@@ -3398,7 +3398,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
 {
   "_id": "a3d97b53-e38a-4b24-aed0-a021050eb744",
   "_outcomes": [
@@ -3424,7 +3424,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
 {
   "_id": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
   "_outcomes": [
@@ -3445,7 +3445,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
 {
   "_id": "20237b34-26cb-4a0b-958f-abb422290d42",
   "_outcomes": [
@@ -3478,7 +3478,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
 {
   "_id": "fe2962fc-4db3-4066-8624-553649afc438",
   "_outcomes": [
@@ -3499,7 +3499,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
 {
   "_id": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
   "_outcomes": [
@@ -3532,7 +3532,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
 {
   "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
   "_outcomes": [
@@ -3553,7 +3553,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
 {
   "_id": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
   "_outcomes": [
@@ -3582,7 +3582,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j00/j00.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j00/j00.json 1`] = `
 {
   "_id": "j00",
   "_rev": "2108856917",
@@ -3678,7 +3678,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j00/nodes/debug - ba503a1e-633e-4d0d-ba18-c9a9b1105b5b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j00/nodes/debug - ba503a1e-633e-4d0d-ba18-c9a9b1105b5b.json 1`] = `
 {
   "_id": "ba503a1e-633e-4d0d-ba18-c9a9b1105b5b",
   "_outcomes": [
@@ -3707,7 +3707,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j00/nodes/level - 3c1e8d61-0c48-44ba-86dc-52e9555b6aeb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j00/nodes/level - 3c1e8d61-0c48-44ba-86dc-52e9555b6aeb.json 1`] = `
 {
   "_id": "3c1e8d61-0c48-44ba-86dc-52e9555b6aeb",
   "_outcomes": [
@@ -3736,7 +3736,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j00/nodes/level - 39b48197-f4be-42b9-800a-866587b4b9b5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j00/nodes/level - 39b48197-f4be-42b9-800a-866587b4b9b5.json 1`] = `
 {
   "_id": "39b48197-f4be-42b9-800a-866587b4b9b5",
   "_outcomes": [
@@ -3765,7 +3765,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j00/nodes/mode - 513a2ab4-f0b8-4f94-b840-6fe14796cc84.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j00/nodes/mode - 513a2ab4-f0b8-4f94-b840-6fe14796cc84.json 1`] = `
 {
   "_id": "513a2ab4-f0b8-4f94-b840-6fe14796cc84",
   "_outcomes": [
@@ -3813,7 +3813,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j00/nodes/shared - 01d3785f-7fb4-44a7-9458-72c380a9818f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j00/nodes/shared - 01d3785f-7fb4-44a7-9458-72c380a9818f.json 1`] = `
 {
   "_id": "01d3785f-7fb4-44a7-9458-72c380a9818f",
   "_outcomes": [
@@ -3842,7 +3842,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j00/nodes/shared - d17ffaa1-2c61-4abd-9bb1-2559160d0a5c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j00/nodes/shared - d17ffaa1-2c61-4abd-9bb1-2559160d0a5c.json 1`] = `
 {
   "_id": "d17ffaa1-2c61-4abd-9bb1-2559160d0a5c",
   "_outcomes": [
@@ -3871,7 +3871,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j01/j01.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j01/j01.json 1`] = `
 {
   "_id": "j01",
   "_rev": "-1240740730",
@@ -3968,7 +3968,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j01/nodes/level - bdfbe97c-1ff4-4162-85bc-47f6f14b2c66.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j01/nodes/level - bdfbe97c-1ff4-4162-85bc-47f6f14b2c66.json 1`] = `
 {
   "_id": "bdfbe97c-1ff4-4162-85bc-47f6f14b2c66",
   "_outcomes": [
@@ -3997,7 +3997,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j01/nodes/level - e92d5139-b8a6-43dc-9b13-95ba1d0dc53c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j01/nodes/level - e92d5139-b8a6-43dc-9b13-95ba1d0dc53c.json 1`] = `
 {
   "_id": "e92d5139-b8a6-43dc-9b13-95ba1d0dc53c",
   "_outcomes": [
@@ -4026,7 +4026,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j01/nodes/mode - f129f0df-b49e-453b-97fb-db508e3893ce.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j01/nodes/mode - f129f0df-b49e-453b-97fb-db508e3893ce.json 1`] = `
 {
   "_id": "f129f0df-b49e-453b-97fb-db508e3893ce",
   "_outcomes": [
@@ -4074,7 +4074,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j01/nodes/nest - bb1e96af-f316-4eb0-b1c6-36b3f1af9e35.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j01/nodes/nest - bb1e96af-f316-4eb0-b1c6-36b3f1af9e35.json 1`] = `
 {
   "_id": "bb1e96af-f316-4eb0-b1c6-36b3f1af9e35",
   "_outcomes": [
@@ -4099,7 +4099,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j01/nodes/shared - 89ce5d57-82fa-4d58-8d15-0329f7dbd7e7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j01/nodes/shared - 89ce5d57-82fa-4d58-8d15-0329f7dbd7e7.json 1`] = `
 {
   "_id": "89ce5d57-82fa-4d58-8d15-0329f7dbd7e7",
   "_outcomes": [
@@ -4128,7 +4128,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j01/nodes/shared - 6674b4ac-dd89-4e13-9440-6f81194e3a22.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j01/nodes/shared - 6674b4ac-dd89-4e13-9440-6f81194e3a22.json 1`] = `
 {
   "_id": "6674b4ac-dd89-4e13-9440-6f81194e3a22",
   "_outcomes": [
@@ -4157,7 +4157,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j02/j02.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j02/j02.json 1`] = `
 {
   "_id": "j02",
   "_rev": "1006720127",
@@ -4254,7 +4254,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j02/nodes/level - 2dbd2d37-c659-48cf-8357-c9fc1166e3a7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j02/nodes/level - 2dbd2d37-c659-48cf-8357-c9fc1166e3a7.json 1`] = `
 {
   "_id": "2dbd2d37-c659-48cf-8357-c9fc1166e3a7",
   "_outcomes": [
@@ -4283,7 +4283,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j02/nodes/level - 4416aff7-3ebd-47e6-9831-c2f6bbe3ae24.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j02/nodes/level - 4416aff7-3ebd-47e6-9831-c2f6bbe3ae24.json 1`] = `
 {
   "_id": "4416aff7-3ebd-47e6-9831-c2f6bbe3ae24",
   "_outcomes": [
@@ -4312,7 +4312,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j02/nodes/mode - 59b06306-a886-443d-92df-7a27a60c394e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j02/nodes/mode - 59b06306-a886-443d-92df-7a27a60c394e.json 1`] = `
 {
   "_id": "59b06306-a886-443d-92df-7a27a60c394e",
   "_outcomes": [
@@ -4360,7 +4360,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j02/nodes/nest - 56899fef-92a1-4f2a-ade3-973c81eb3af1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j02/nodes/nest - 56899fef-92a1-4f2a-ade3-973c81eb3af1.json 1`] = `
 {
   "_id": "56899fef-92a1-4f2a-ade3-973c81eb3af1",
   "_outcomes": [
@@ -4385,7 +4385,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j02/nodes/shared - cbb3d506-b267-4b99-9edd-363e90aac997.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j02/nodes/shared - cbb3d506-b267-4b99-9edd-363e90aac997.json 1`] = `
 {
   "_id": "cbb3d506-b267-4b99-9edd-363e90aac997",
   "_outcomes": [
@@ -4414,7 +4414,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j02/nodes/shared - e0983ead-4918-48f6-858d-9aff0f03759c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j02/nodes/shared - e0983ead-4918-48f6-858d-9aff0f03759c.json 1`] = `
 {
   "_id": "e0983ead-4918-48f6-858d-9aff0f03759c",
   "_outcomes": [
@@ -4443,7 +4443,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j03/j03.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j03/j03.json 1`] = `
 {
   "_id": "j03",
   "_rev": "1203078238",
@@ -4540,7 +4540,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j03/nodes/level - 3a92300d-6d64-451d-8156-30cb51781026.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j03/nodes/level - 3a92300d-6d64-451d-8156-30cb51781026.json 1`] = `
 {
   "_id": "3a92300d-6d64-451d-8156-30cb51781026",
   "_outcomes": [
@@ -4569,7 +4569,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j03/nodes/level - 35a4f94b-c895-46b9-bc0a-93cf59233759.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j03/nodes/level - 35a4f94b-c895-46b9-bc0a-93cf59233759.json 1`] = `
 {
   "_id": "35a4f94b-c895-46b9-bc0a-93cf59233759",
   "_outcomes": [
@@ -4598,7 +4598,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j03/nodes/mode - e0cfbd13-6f1e-4924-9d2d-0f7c23507172.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j03/nodes/mode - e0cfbd13-6f1e-4924-9d2d-0f7c23507172.json 1`] = `
 {
   "_id": "e0cfbd13-6f1e-4924-9d2d-0f7c23507172",
   "_outcomes": [
@@ -4646,7 +4646,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j03/nodes/nest - bcb8c535-5ecd-4d3d-b970-26816de96bf2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j03/nodes/nest - bcb8c535-5ecd-4d3d-b970-26816de96bf2.json 1`] = `
 {
   "_id": "bcb8c535-5ecd-4d3d-b970-26816de96bf2",
   "_outcomes": [
@@ -4671,7 +4671,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j03/nodes/shared - 6f9de973-9ed4-41f5-b43d-4036041e2b96.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j03/nodes/shared - 6f9de973-9ed4-41f5-b43d-4036041e2b96.json 1`] = `
 {
   "_id": "6f9de973-9ed4-41f5-b43d-4036041e2b96",
   "_outcomes": [
@@ -4700,7 +4700,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j03/nodes/shared - fae7424e-13c9-45bd-b3a2-045773671a3f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j03/nodes/shared - fae7424e-13c9-45bd-b3a2-045773671a3f.json 1`] = `
 {
   "_id": "fae7424e-13c9-45bd-b3a2-045773671a3f",
   "_outcomes": [
@@ -4729,7 +4729,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j04/j04.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j04/j04.json 1`] = `
 {
   "_id": "j04",
   "_rev": "125884797",
@@ -4826,7 +4826,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j04/nodes/level - 69ae8ec1-de43-44ac-98e5-733db80ac176.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j04/nodes/level - 69ae8ec1-de43-44ac-98e5-733db80ac176.json 1`] = `
 {
   "_id": "69ae8ec1-de43-44ac-98e5-733db80ac176",
   "_outcomes": [
@@ -4855,7 +4855,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j04/nodes/level - d10104e9-1f8d-4da6-a110-28d879d13959.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j04/nodes/level - d10104e9-1f8d-4da6-a110-28d879d13959.json 1`] = `
 {
   "_id": "d10104e9-1f8d-4da6-a110-28d879d13959",
   "_outcomes": [
@@ -4884,7 +4884,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j04/nodes/mode - 040b6c89-313b-4664-92e0-6732017384b8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j04/nodes/mode - 040b6c89-313b-4664-92e0-6732017384b8.json 1`] = `
 {
   "_id": "040b6c89-313b-4664-92e0-6732017384b8",
   "_outcomes": [
@@ -4932,7 +4932,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j04/nodes/nest - 00e75aa0-2f9b-4895-9257-d515286fd64b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j04/nodes/nest - 00e75aa0-2f9b-4895-9257-d515286fd64b.json 1`] = `
 {
   "_id": "00e75aa0-2f9b-4895-9257-d515286fd64b",
   "_outcomes": [
@@ -4957,7 +4957,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j04/nodes/shared - 9603ef52-30f0-4ddc-b3c0-28dac83c7bdb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j04/nodes/shared - 9603ef52-30f0-4ddc-b3c0-28dac83c7bdb.json 1`] = `
 {
   "_id": "9603ef52-30f0-4ddc-b3c0-28dac83c7bdb",
   "_outcomes": [
@@ -4986,7 +4986,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j04/nodes/shared - f5c317ce-fabd-4a10-9907-c71cea037844.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j04/nodes/shared - f5c317ce-fabd-4a10-9907-c71cea037844.json 1`] = `
 {
   "_id": "f5c317ce-fabd-4a10-9907-c71cea037844",
   "_outcomes": [
@@ -5015,7 +5015,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j05/j05.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j05/j05.json 1`] = `
 {
   "_id": "j05",
   "_rev": "-1683838231",
@@ -5112,7 +5112,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j05/nodes/level - 3c106772-ace7-4808-8f3a-9840de8f67f0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j05/nodes/level - 3c106772-ace7-4808-8f3a-9840de8f67f0.json 1`] = `
 {
   "_id": "3c106772-ace7-4808-8f3a-9840de8f67f0",
   "_outcomes": [
@@ -5141,7 +5141,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j05/nodes/level - e90ae257-c279-46e0-9b43-5ecd89784d77.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j05/nodes/level - e90ae257-c279-46e0-9b43-5ecd89784d77.json 1`] = `
 {
   "_id": "e90ae257-c279-46e0-9b43-5ecd89784d77",
   "_outcomes": [
@@ -5170,7 +5170,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j05/nodes/mode - 622179cb-98f1-484a-820d-9a0df6e45e95.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j05/nodes/mode - 622179cb-98f1-484a-820d-9a0df6e45e95.json 1`] = `
 {
   "_id": "622179cb-98f1-484a-820d-9a0df6e45e95",
   "_outcomes": [
@@ -5218,7 +5218,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j05/nodes/nest - f17ecb7c-abc3-4523-9943-4cbdd90305cb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j05/nodes/nest - f17ecb7c-abc3-4523-9943-4cbdd90305cb.json 1`] = `
 {
   "_id": "f17ecb7c-abc3-4523-9943-4cbdd90305cb",
   "_outcomes": [
@@ -5243,7 +5243,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j05/nodes/shared - 11f1c31c-50a9-4717-8213-420f6932481f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j05/nodes/shared - 11f1c31c-50a9-4717-8213-420f6932481f.json 1`] = `
 {
   "_id": "11f1c31c-50a9-4717-8213-420f6932481f",
   "_outcomes": [
@@ -5272,7 +5272,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j05/nodes/shared - a0782616-84b7-4bf5-87ed-a01fb3018563.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j05/nodes/shared - a0782616-84b7-4bf5-87ed-a01fb3018563.json 1`] = `
 {
   "_id": "a0782616-84b7-4bf5-87ed-a01fb3018563",
   "_outcomes": [
@@ -5301,7 +5301,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j06/j06.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j06/j06.json 1`] = `
 {
   "_id": "j06",
   "_rev": "-1311195611",
@@ -5398,7 +5398,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j06/nodes/level - 2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j06/nodes/level - 2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3.json 1`] = `
 {
   "_id": "2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3",
   "_outcomes": [
@@ -5427,7 +5427,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j06/nodes/level - fe8f27df-8a27-4d88-9196-834ce398b2b7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j06/nodes/level - fe8f27df-8a27-4d88-9196-834ce398b2b7.json 1`] = `
 {
   "_id": "fe8f27df-8a27-4d88-9196-834ce398b2b7",
   "_outcomes": [
@@ -5456,7 +5456,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j06/nodes/mode - 44b8651c-7c1e-41f1-b9a6-2e441b0ce05a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j06/nodes/mode - 44b8651c-7c1e-41f1-b9a6-2e441b0ce05a.json 1`] = `
 {
   "_id": "44b8651c-7c1e-41f1-b9a6-2e441b0ce05a",
   "_outcomes": [
@@ -5504,7 +5504,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j06/nodes/nest - 409c251f-c23b-411d-9009-d3b3d26d1b90.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j06/nodes/nest - 409c251f-c23b-411d-9009-d3b3d26d1b90.json 1`] = `
 {
   "_id": "409c251f-c23b-411d-9009-d3b3d26d1b90",
   "_outcomes": [
@@ -5529,7 +5529,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j06/nodes/shared - 1d59caff-243c-45bd-b7d0-6dcc563989c5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j06/nodes/shared - 1d59caff-243c-45bd-b7d0-6dcc563989c5.json 1`] = `
 {
   "_id": "1d59caff-243c-45bd-b7d0-6dcc563989c5",
   "_outcomes": [
@@ -5558,7 +5558,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j06/nodes/shared - da878771-421c-463f-aad7-4d5f2ad5e59a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j06/nodes/shared - da878771-421c-463f-aad7-4d5f2ad5e59a.json 1`] = `
 {
   "_id": "da878771-421c-463f-aad7-4d5f2ad5e59a",
   "_outcomes": [
@@ -5587,7 +5587,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j07/j07.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j07/j07.json 1`] = `
 {
   "_id": "j07",
   "_rev": "-1925267397",
@@ -5684,7 +5684,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j07/nodes/level - d90dd9f8-8b12-4e90-abaf-228ecc0174a7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j07/nodes/level - d90dd9f8-8b12-4e90-abaf-228ecc0174a7.json 1`] = `
 {
   "_id": "d90dd9f8-8b12-4e90-abaf-228ecc0174a7",
   "_outcomes": [
@@ -5713,7 +5713,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j07/nodes/level - f2fe740c-cd75-460a-8baa-fe4b52ecc947.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j07/nodes/level - f2fe740c-cd75-460a-8baa-fe4b52ecc947.json 1`] = `
 {
   "_id": "f2fe740c-cd75-460a-8baa-fe4b52ecc947",
   "_outcomes": [
@@ -5742,7 +5742,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j07/nodes/mode - 13b12fe6-cf53-46a4-a83d-0a3c1fda814f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j07/nodes/mode - 13b12fe6-cf53-46a4-a83d-0a3c1fda814f.json 1`] = `
 {
   "_id": "13b12fe6-cf53-46a4-a83d-0a3c1fda814f",
   "_outcomes": [
@@ -5790,7 +5790,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j07/nodes/nest - e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j07/nodes/nest - e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9.json 1`] = `
 {
   "_id": "e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9",
   "_outcomes": [
@@ -5815,7 +5815,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j07/nodes/shared - ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j07/nodes/shared - ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0.json 1`] = `
 {
   "_id": "ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0",
   "_outcomes": [
@@ -5844,7 +5844,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j07/nodes/shared - d9a06d3a-7e3f-4244-9a32-63ffa0d26e00.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j07/nodes/shared - d9a06d3a-7e3f-4244-9a32-63ffa0d26e00.json 1`] = `
 {
   "_id": "d9a06d3a-7e3f-4244-9a32-63ffa0d26e00",
   "_outcomes": [
@@ -5873,7 +5873,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j08/j08.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j08/j08.json 1`] = `
 {
   "_id": "j08",
   "_rev": "-282238685",
@@ -5970,7 +5970,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j08/nodes/level - 87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j08/nodes/level - 87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d.json 1`] = `
 {
   "_id": "87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d",
   "_outcomes": [
@@ -5999,7 +5999,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j08/nodes/level - 8096649e-973e-4209-88ce-e1d87ae2bb96.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j08/nodes/level - 8096649e-973e-4209-88ce-e1d87ae2bb96.json 1`] = `
 {
   "_id": "8096649e-973e-4209-88ce-e1d87ae2bb96",
   "_outcomes": [
@@ -6028,7 +6028,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j08/nodes/mode - d429b2b5-b215-46a5-b239-4994df65cb8b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j08/nodes/mode - d429b2b5-b215-46a5-b239-4994df65cb8b.json 1`] = `
 {
   "_id": "d429b2b5-b215-46a5-b239-4994df65cb8b",
   "_outcomes": [
@@ -6076,7 +6076,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j08/nodes/nest - 66026170-5088-4fcd-a6c8-ed89d7a5c79d.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j08/nodes/nest - 66026170-5088-4fcd-a6c8-ed89d7a5c79d.json 1`] = `
 {
   "_id": "66026170-5088-4fcd-a6c8-ed89d7a5c79d",
   "_outcomes": [
@@ -6101,7 +6101,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j08/nodes/shared - 042b600b-71cb-45a8-93ae-a6f57b16a6e5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j08/nodes/shared - 042b600b-71cb-45a8-93ae-a6f57b16a6e5.json 1`] = `
 {
   "_id": "042b600b-71cb-45a8-93ae-a6f57b16a6e5",
   "_outcomes": [
@@ -6130,7 +6130,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j08/nodes/shared - 948e21f4-c512-450a-9d42-e0d629217834.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j08/nodes/shared - 948e21f4-c512-450a-9d42-e0d629217834.json 1`] = `
 {
   "_id": "948e21f4-c512-450a-9d42-e0d629217834",
   "_outcomes": [
@@ -6159,7 +6159,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j09/j09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j09/j09.json 1`] = `
 {
   "_id": "j09",
   "_rev": "-1396884723",
@@ -6256,7 +6256,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j09/nodes/level - 56b82371-0c61-4dc3-8d06-c1158415b8f9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j09/nodes/level - 56b82371-0c61-4dc3-8d06-c1158415b8f9.json 1`] = `
 {
   "_id": "56b82371-0c61-4dc3-8d06-c1158415b8f9",
   "_outcomes": [
@@ -6285,7 +6285,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j09/nodes/level - bb294e05-6b6b-4478-b46f-b8d9e7711c66.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j09/nodes/level - bb294e05-6b6b-4478-b46f-b8d9e7711c66.json 1`] = `
 {
   "_id": "bb294e05-6b6b-4478-b46f-b8d9e7711c66",
   "_outcomes": [
@@ -6314,7 +6314,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j09/nodes/mode - 251f35c3-1a32-4520-be10-1f4af9600935.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j09/nodes/mode - 251f35c3-1a32-4520-be10-1f4af9600935.json 1`] = `
 {
   "_id": "251f35c3-1a32-4520-be10-1f4af9600935",
   "_outcomes": [
@@ -6362,7 +6362,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j09/nodes/nest - 6df24fdd-0b6c-4def-bf42-77af998f28b8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j09/nodes/nest - 6df24fdd-0b6c-4def-bf42-77af998f28b8.json 1`] = `
 {
   "_id": "6df24fdd-0b6c-4def-bf42-77af998f28b8",
   "_outcomes": [
@@ -6387,7 +6387,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j09/nodes/shared - 8c5e9cb5-471b-4dd6-b150-ecaaeda98195.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j09/nodes/shared - 8c5e9cb5-471b-4dd6-b150-ecaaeda98195.json 1`] = `
 {
   "_id": "8c5e9cb5-471b-4dd6-b150-ecaaeda98195",
   "_outcomes": [
@@ -6416,7 +6416,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j09/nodes/shared - f57cf53c-b4c6-48f7-84e8-91f535a2e8f8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j09/nodes/shared - f57cf53c-b4c6-48f7-84e8-91f535a2e8f8.json 1`] = `
 {
   "_id": "f57cf53c-b4c6-48f7-84e8-91f535a2e8f8",
   "_outcomes": [
@@ -6445,7 +6445,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j10/j10.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j10/j10.json 1`] = `
 {
   "_id": "j10",
   "_rev": "1630303400",
@@ -6542,7 +6542,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j10/nodes/level - 8d7d64ee-da20-461f-a2ca-206b7479dd67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j10/nodes/level - 8d7d64ee-da20-461f-a2ca-206b7479dd67.json 1`] = `
 {
   "_id": "8d7d64ee-da20-461f-a2ca-206b7479dd67",
   "_outcomes": [
@@ -6571,7 +6571,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j10/nodes/level - 300feda0-3248-49a9-b60f-01df802b2229.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j10/nodes/level - 300feda0-3248-49a9-b60f-01df802b2229.json 1`] = `
 {
   "_id": "300feda0-3248-49a9-b60f-01df802b2229",
   "_outcomes": [
@@ -6600,7 +6600,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j10/nodes/mode - c91d626e-1156-41bd-b1fb-d292f640fba6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j10/nodes/mode - c91d626e-1156-41bd-b1fb-d292f640fba6.json 1`] = `
 {
   "_id": "c91d626e-1156-41bd-b1fb-d292f640fba6",
   "_outcomes": [
@@ -6648,7 +6648,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j10/nodes/nest - c7fcf7ae-1ab5-474b-b5b0-272e10468fbd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j10/nodes/nest - c7fcf7ae-1ab5-474b-b5b0-272e10468fbd.json 1`] = `
 {
   "_id": "c7fcf7ae-1ab5-474b-b5b0-272e10468fbd",
   "_outcomes": [
@@ -6673,7 +6673,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j10/nodes/shared - 40afb384-e9b6-4dcb-acde-04de109474c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j10/nodes/shared - 40afb384-e9b6-4dcb-acde-04de109474c8.json 1`] = `
 {
   "_id": "40afb384-e9b6-4dcb-acde-04de109474c8",
   "_outcomes": [
@@ -6702,7 +6702,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/j10/nodes/shared - 97ef9d96-99e7-4d2d-b6c6-4177b5397ead.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/j10/nodes/shared - 97ef9d96-99e7-4d2d-b6c6-4177b5397ead.json 1`] = `
 {
   "_id": "97ef9d96-99e7-4d2d-b6c6-4177b5397ead",
   "_outcomes": [
@@ -6731,7 +6731,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/alpha/journeys/test/test.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/alpha/journeys/test/test.json 1`] = `
 {
   "_id": "test",
   "_rev": "1505940492",
@@ -6761,7 +6761,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Agent/Agent.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Agent/Agent.json 1`] = `
 {
   "_id": "Agent",
   "_rev": "-995271915",
@@ -6827,7 +6827,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Agent/nodes/Agent Data Store Decision - a02fa1ec-2752-42bc-a98f-e41e08f225e7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Agent/nodes/Agent Data Store Decision - a02fa1ec-2752-42bc-a98f-e41e08f225e7.json 1`] = `
 {
   "_id": "a02fa1ec-2752-42bc-a98f-e41e08f225e7",
   "_outcomes": [
@@ -6850,7 +6850,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2.json 1`] = `
 {
   "_id": "0fde84fa-bf2f-4322-a040-fc700bd9b8f2",
   "_outcomes": [
@@ -6885,7 +6885,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Password - 52db314b-2eda-41a9-8dda-8d0b8b8e5876.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Password - 52db314b-2eda-41a9-8dda-8d0b8b8e5876.json 1`] = `
 {
   "_id": "52db314b-2eda-41a9-8dda-8d0b8b8e5876",
   "_outcomes": [
@@ -6906,7 +6906,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Username - 16ac997e-4d48-4c19-b6b9-98086845131a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Username - 16ac997e-4d48-4c19-b6b9-98086845131a.json 1`] = `
 {
   "_id": "16ac997e-4d48-4c19-b6b9-98086845131a",
   "_outcomes": [
@@ -6928,7 +6928,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Agent/nodes/Zero Page Login Collector - 53fc9e71-93b1-4329-a0ee-0493c6b4fcd6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Agent/nodes/Zero Page Login Collector - 53fc9e71-93b1-4329-a0ee-0493c6b4fcd6.json 1`] = `
 {
   "_id": "53fc9e71-93b1-4329-a0ee-0493c6b4fcd6",
   "_outcomes": [
@@ -6955,7 +6955,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
 {
   "_id": "ForgottenUsername",
   "_rev": "1922908182",
@@ -7031,7 +7031,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
 {
   "_id": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
   "_outcomes": [
@@ -7057,7 +7057,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
 {
   "_id": "bf9ea8d5-9802-4f26-9664-a21840faac23",
   "_outcomes": [
@@ -7082,7 +7082,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
 {
   "_id": "b93ce36e-1976-4610-b24f-8d6760b5463b",
   "_outcomes": [
@@ -7107,7 +7107,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
 {
   "_id": "5e2a7c95-94af-4b23-8724-deb13853726a",
   "_outcomes": [
@@ -7140,7 +7140,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
 {
   "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
   "_outcomes": [
@@ -7165,7 +7165,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/Login.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/Login.json 1`] = `
 {
   "_id": "Login",
   "_rev": "1447343562",
@@ -7265,7 +7265,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Account Lockout - 76b5e15c-493c-47dc-b813-01cbc74c5a85.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Account Lockout - 76b5e15c-493c-47dc-b813-01cbc74c5a85.json 1`] = `
 {
   "_id": "76b5e15c-493c-47dc-b813-01cbc74c5a85",
   "_outcomes": [
@@ -7285,7 +7285,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Identity Store Decision - a30b1258-4c35-4ebe-90f3-c11fced9b1e4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Identity Store Decision - a30b1258-4c35-4ebe-90f3-c11fced9b1e4.json 1`] = `
 {
   "_id": "a30b1258-4c35-4ebe-90f3-c11fced9b1e4",
   "_outcomes": [
@@ -7323,7 +7323,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
 {
   "_id": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
   "_outcomes": [
@@ -7343,7 +7343,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
 {
   "_id": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
   "_outcomes": [
@@ -7368,7 +7368,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
 {
   "_id": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
   "_outcomes": [
@@ -7407,7 +7407,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
 {
   "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
   "_outcomes": [
@@ -7428,7 +7428,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
 {
   "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
   "_outcomes": [
@@ -7450,7 +7450,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Login/nodes/Retry Limit Decision - feecdfb1-386c-423f-b4a0-05cf6b05f783.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Login/nodes/Retry Limit Decision - feecdfb1-386c-423f-b4a0-05cf6b05f783.json 1`] = `
 {
   "_id": "feecdfb1-386c-423f-b4a0-05cf6b05f783",
   "_outcomes": [
@@ -7475,7 +7475,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
 {
   "_id": "ProgressiveProfile",
   "_rev": "-1280941645",
@@ -7552,7 +7552,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
 {
   "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
   "_outcomes": [
@@ -7578,7 +7578,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
 {
   "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
   "_outcomes": [
@@ -7609,7 +7609,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
 {
   "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
   "_outcomes": [
@@ -7635,7 +7635,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
 {
   "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
   "_outcomes": [
@@ -7662,7 +7662,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
 {
   "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
   "_outcomes": [
@@ -7687,7 +7687,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/Registration.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/Registration.json 1`] = `
 {
   "_id": "Registration",
   "_rev": "2125060565",
@@ -7762,7 +7762,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
 {
   "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
   "_outcomes": [
@@ -7786,7 +7786,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Email Suspend Node - 6b70de2f-a625-4957-93d9-37005e33e6e1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Email Suspend Node - 6b70de2f-a625-4957-93d9-37005e33e6e1.json 1`] = `
 {
   "_id": "6b70de2f-a625-4957-93d9-37005e33e6e1",
   "_outcomes": [
@@ -7812,7 +7812,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
 {
   "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
   "_outcomes": [
@@ -7832,7 +7832,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
 {
   "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
   "_outcomes": [
@@ -7889,7 +7889,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
 {
   "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
   "_outcomes": [
@@ -7908,7 +7908,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
 {
   "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
   "_outcomes": [
@@ -7937,7 +7937,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
 {
   "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
   "_outcomes": [
@@ -7960,7 +7960,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
 {
   "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
   "_outcomes": [
@@ -7981,7 +7981,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
 {
   "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
   "_outcomes": [
@@ -8003,7 +8003,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/ResetPassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/ResetPassword.json 1`] = `
 {
   "_id": "ResetPassword",
   "_rev": "144168087",
@@ -8089,7 +8089,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
 {
   "_id": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
   "_outcomes": [
@@ -8115,7 +8115,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
 {
   "_id": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
   "_outcomes": [
@@ -8140,7 +8140,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
 {
   "_id": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
   "_outcomes": [
@@ -8173,7 +8173,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
 {
   "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
   "_outcomes": [
@@ -8198,7 +8198,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
 {
   "_id": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
   "_outcomes": [
@@ -8231,7 +8231,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
 {
   "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
   "_outcomes": [
@@ -8252,7 +8252,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
 {
   "_id": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
   "_outcomes": [
@@ -8279,7 +8279,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/UpdatePassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/UpdatePassword.json 1`] = `
 {
   "_id": "UpdatePassword",
   "_rev": "1654724708",
@@ -8386,7 +8386,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
 {
   "_id": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
   "_outcomes": [
@@ -8411,7 +8411,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
 {
   "_id": "7d1deabe-cd98-49c8-943f-ca12305775f3",
   "_outcomes": [
@@ -8434,7 +8434,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
 {
   "_id": "a3d97b53-e38a-4b24-aed0-a021050eb744",
   "_outcomes": [
@@ -8460,7 +8460,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
 {
   "_id": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
   "_outcomes": [
@@ -8481,7 +8481,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
 {
   "_id": "20237b34-26cb-4a0b-958f-abb422290d42",
   "_outcomes": [
@@ -8514,7 +8514,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
 {
   "_id": "fe2962fc-4db3-4066-8624-553649afc438",
   "_outcomes": [
@@ -8535,7 +8535,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
 {
   "_id": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
   "_outcomes": [
@@ -8568,7 +8568,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
 {
   "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
   "_outcomes": [
@@ -8589,7 +8589,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style": testDir11/realms/bravo/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style": ConfigJourneytestDir1/realms/bravo/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
 {
   "_id": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
   "_outcomes": [
@@ -8618,11 +8618,11 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style" 1`] = `0`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style" 1`] = `0`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style" 2`] = `""`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style" 2`] = `""`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Agent/Agent.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Agent/Agent.json 1`] = `
 {
   "_id": "Agent",
   "_rev": "-737774734",
@@ -8688,7 +8688,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Agent/nodes/Agent Data Store Decision - 6736a00a-fc65-438e-b4ea-23f66b4a8739.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Agent/nodes/Agent Data Store Decision - 6736a00a-fc65-438e-b4ea-23f66b4a8739.json 1`] = `
 {
   "_id": "6736a00a-fc65-438e-b4ea-23f66b4a8739",
   "_outcomes": [
@@ -8711,7 +8711,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080.json 1`] = `
 {
   "_id": "cbd1f1af-eb0a-4274-a762-adacf04c7080",
   "_outcomes": [
@@ -8746,7 +8746,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Password - 6072842f-5f7c-4b62-8ae2-4f18a5701ba4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Password - 6072842f-5f7c-4b62-8ae2-4f18a5701ba4.json 1`] = `
 {
   "_id": "6072842f-5f7c-4b62-8ae2-4f18a5701ba4",
   "_outcomes": [
@@ -8767,7 +8767,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Username - 2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Username - 2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018.json 1`] = `
 {
   "_id": "2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018",
   "_outcomes": [
@@ -8789,7 +8789,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Agent/nodes/Zero Page Login Collector - 51e2cd24-cf1f-4313-8af0-35ea9e04d2fe.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Agent/nodes/Zero Page Login Collector - 51e2cd24-cf1f-4313-8af0-35ea9e04d2fe.json 1`] = `
 {
   "_id": "51e2cd24-cf1f-4313-8af0-35ea9e04d2fe",
   "_outcomes": [
@@ -8816,7 +8816,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
 {
   "_id": "ForgottenUsername",
   "_rev": "-830414370",
@@ -8892,7 +8892,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
 {
   "_id": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
   "_outcomes": [
@@ -8918,7 +8918,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
 {
   "_id": "bf9ea8d5-9802-4f26-9664-a21840faac23",
   "_outcomes": [
@@ -8943,7 +8943,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
 {
   "_id": "b93ce36e-1976-4610-b24f-8d6760b5463b",
   "_outcomes": [
@@ -8968,7 +8968,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
 {
   "_id": "5e2a7c95-94af-4b23-8724-deb13853726a",
   "_outcomes": [
@@ -9001,7 +9001,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
 {
   "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
   "_outcomes": [
@@ -9026,7 +9026,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
 {
   "_id": "FrodoTest",
   "_rev": "-1175854005",
@@ -9140,7 +9140,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
 {
   "_id": "e2c39477-847a-4df2-9c5d-b449a752638b",
   "_outcomes": [
@@ -9174,7 +9174,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
 {
   "_id": "bf153f37-83dd-4f39-aa0c-74135430242e",
   "_outcomes": [
@@ -9200,7 +9200,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
 {
   "_id": "278bf084-9eea-46fe-8ce9-2600dde3b046",
   "_outcomes": [
@@ -9245,7 +9245,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
 {
   "_id": "804e6a68-1720-442b-926a-007e90f02782",
   "_outcomes": [
@@ -9266,7 +9266,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
 {
   "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
   "_outcomes": [
@@ -9294,7 +9294,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
 {
   "_id": "7a351800-fb7e-4145-903c-388554747556",
   "_outcomes": [
@@ -9316,7 +9316,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
 {
   "_id": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
   "_outcomes": [
@@ -9355,7 +9355,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
 {
   "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
   "_outcomes": [
@@ -9376,7 +9376,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
 {
   "_id": "038f9b2a-36b2-489b-9e03-386c9a62ea21",
   "_outcomes": [
@@ -9404,7 +9404,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
 {
   "_id": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
   "_outcomes": [
@@ -9443,7 +9443,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
 {
   "_id": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
   "_outcomes": [
@@ -9471,7 +9471,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
 {
   "_id": "fc7e47cd-c679-4211-8e05-a36654f23c67",
   "_outcomes": [
@@ -9509,7 +9509,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTestJourney13/FrodoTestJourney13.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTestJourney13/FrodoTestJourney13.json 1`] = `
 {
   "_id": "FrodoTestJourney13",
   "_rev": "1535600290",
@@ -9564,7 +9564,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c.json 1`] = `
 {
   "_id": "c847e93b-afa3-4d20-9a15-f75404ec353c",
   "_outcomes": [
@@ -9599,7 +9599,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Password - e4c5071f-acc8-47c9-b097-5c4144170742.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Password - e4c5071f-acc8-47c9-b097-5c4144170742.json 1`] = `
 {
   "_id": "e4c5071f-acc8-47c9-b097-5c4144170742",
   "_outcomes": [
@@ -9620,7 +9620,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Username - 64dceffc-2db4-468b-96d1-491824e037a2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Username - 64dceffc-2db4-468b-96d1-491824e037a2.json 1`] = `
 {
   "_id": "64dceffc-2db4-468b-96d1-491824e037a2",
   "_outcomes": [
@@ -9643,7 +9643,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/FrodoTestJourney13/nodes/Validate Credentials - bdca20b7-ada8-4906-8b3a-e59c313f6491.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/FrodoTestJourney13/nodes/Validate Credentials - bdca20b7-ada8-4906-8b3a-e59c313f6491.json 1`] = `
 {
   "_id": "bdca20b7-ada8-4906-8b3a-e59c313f6491",
   "_outcomes": [
@@ -9666,7 +9666,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/Login.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/Login.json 1`] = `
 {
   "_id": "Login",
   "_rev": "384176338",
@@ -9766,7 +9766,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Account Lockout - 51e8c4c1-3509-4635-90e6-d2cc31c4a6a5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Account Lockout - 51e8c4c1-3509-4635-90e6-d2cc31c4a6a5.json 1`] = `
 {
   "_id": "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5",
   "_outcomes": [
@@ -9786,7 +9786,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Identity Store Decision - 7f0c2aee-8c74-4d02-82a6-9d4ed9d11708.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Identity Store Decision - 7f0c2aee-8c74-4d02-82a6-9d4ed9d11708.json 1`] = `
 {
   "_id": "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708",
   "_outcomes": [
@@ -9824,7 +9824,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
 {
   "_id": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
   "_outcomes": [
@@ -9844,7 +9844,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
 {
   "_id": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
   "_outcomes": [
@@ -9869,7 +9869,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
 {
   "_id": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
   "_outcomes": [
@@ -9908,7 +9908,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
 {
   "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
   "_outcomes": [
@@ -9929,7 +9929,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
 {
   "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
   "_outcomes": [
@@ -9951,7 +9951,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Login/nodes/Retry Limit Decision - 2119f332-0f69-4088-a7a1-6582bf0f2001.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Login/nodes/Retry Limit Decision - 2119f332-0f69-4088-a7a1-6582bf0f2001.json 1`] = `
 {
   "_id": "2119f332-0f69-4088-a7a1-6582bf0f2001",
   "_outcomes": [
@@ -9976,7 +9976,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/OrphanedTest/OrphanedTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/OrphanedTest/OrphanedTest.json 1`] = `
 {
   "_id": "OrphanedTest",
   "_rev": "680738111",
@@ -10024,7 +10024,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/OrphanedTest/nodes/Identity Store Decision - 343e745f-923a-43c4-8675-649a490fd0a3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/OrphanedTest/nodes/Identity Store Decision - 343e745f-923a-43c4-8675-649a490fd0a3.json 1`] = `
 {
   "_id": "343e745f-923a-43c4-8675-649a490fd0a3",
   "_outcomes": [
@@ -10062,7 +10062,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/P1P-Test.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/P1P-Test.json 1`] = `
 {
   "_id": "P1P-Test",
   "_rev": "946402521",
@@ -10227,7 +10227,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540.json 1`] = `
 {
   "_id": "f1cb199e-9e9a-4761-bacf-bc717ca6c540",
   "_outcomes": [
@@ -10258,7 +10258,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540/Debug - de8fa10c-f4cc-44b7-b675-cdc75dcc600f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540/Debug - de8fa10c-f4cc-44b7-b675-cdc75dcc600f.json 1`] = `
 {
   "_id": "de8fa10c-f4cc-44b7-b675-cdc75dcc600f",
   "_outcomes": [
@@ -10282,7 +10282,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/FAILED - e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/FAILED - e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece.json 1`] = `
 {
   "_id": "e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece",
   "_outcomes": [
@@ -10302,7 +10302,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939.json 1`] = `
 {
   "_id": "084c3d2d-7d47-4f2e-81d1-57961d496939",
   "_outcomes": [
@@ -10333,7 +10333,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939/Debug - 2c8f0d12-c373-4a25-9a30-b3184888d163.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939/Debug - 2c8f0d12-c373-4a25-9a30-b3184888d163.json 1`] = `
 {
   "_id": "2c8f0d12-c373-4a25-9a30-b3184888d163",
   "_outcomes": [
@@ -10357,7 +10357,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Identity Store Decision - ef1929b1-255e-446e-a597-7d7a3c4bf63f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Identity Store Decision - ef1929b1-255e-446e-a597-7d7a3c4bf63f.json 1`] = `
 {
   "_id": "ef1929b1-255e-446e-a597-7d7a3c4bf63f",
   "_outcomes": [
@@ -10395,7 +10395,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Initialize Signals SDK - 6632fe0f-6395-4cc1-88d8-c9ca4a9061b6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Initialize Signals SDK - 6632fe0f-6395-4cc1-88d8-c9ca4a9061b6.json 1`] = `
 {
   "_id": "6632fe0f-6395-4cc1-88d8-c9ca4a9061b6",
   "_outcomes": [
@@ -10429,7 +10429,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5.json 1`] = `
 {
   "_id": "4fdf4255-0236-4527-ae6d-d10d2c0ee8d5",
   "_outcomes": [
@@ -10464,7 +10464,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Password - 6a428d9f-a221-44f6-a5c6-c6981f90f9fc.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Password - 6a428d9f-a221-44f6-a5c6-c6981f90f9fc.json 1`] = `
 {
   "_id": "6a428d9f-a221-44f6-a5c6-c6981f90f9fc",
   "_outcomes": [
@@ -10485,7 +10485,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Username - f74e82e2-72ab-4a1a-9188-655622794a37.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Username - f74e82e2-72ab-4a1a-9188-655622794a37.json 1`] = `
 {
   "_id": "f74e82e2-72ab-4a1a-9188-655622794a37",
   "_outcomes": [
@@ -10508,7 +10508,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4.json 1`] = `
 {
   "_id": "00a4835b-6e99-4938-9bb8-50d5569a68d4",
   "_outcomes": [
@@ -10539,7 +10539,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4/Debug - 843dd22b-a890-461b-9a16-33d8bd871396.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4/Debug - 843dd22b-a890-461b-9a16-33d8bd871396.json 1`] = `
 {
   "_id": "843dd22b-a890-461b-9a16-33d8bd871396",
   "_outcomes": [
@@ -10563,7 +10563,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394.json 1`] = `
 {
   "_id": "37f190ea-fa18-4d44-941b-4e5ac325f394",
   "_outcomes": [
@@ -10594,7 +10594,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394/Debug - 8835fe59-3988-4121-8b15-ad16a7049d7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394/Debug - 8835fe59-3988-4121-8b15-ad16a7049d7a.json 1`] = `
 {
   "_id": "8835fe59-3988-4121-8b15-ad16a7049d7a",
   "_outcomes": [
@@ -10618,7 +10618,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576.json 1`] = `
 {
   "_id": "a0059e3b-de04-4f0f-a5ed-49525d1da576",
   "_outcomes": [
@@ -10649,7 +10649,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576/Debug - c1804982-10dc-4668-bd53-909107cc4039.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576/Debug - c1804982-10dc-4668-bd53-909107cc4039.json 1`] = `
 {
   "_id": "c1804982-10dc-4668-bd53-909107cc4039",
   "_outcomes": [
@@ -10673,7 +10673,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92.json 1`] = `
 {
   "_id": "8120e613-dee8-42b4-9668-71b8a25c1c92",
   "_outcomes": [
@@ -10704,7 +10704,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92/Debug - 52ab689c-491b-4117-b729-ff590b5d1f61.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92/Debug - 52ab689c-491b-4117-b729-ff590b5d1f61.json 1`] = `
 {
   "_id": "52ab689c-491b-4117-b729-ff590b5d1f61",
   "_outcomes": [
@@ -10728,7 +10728,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/P1P Risk Decision - df827cfc-6e2d-4b9f-a8b1-d92c2910eb07.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/P1P Risk Decision - df827cfc-6e2d-4b9f-a8b1-d92c2910eb07.json 1`] = `
 {
   "_id": "df827cfc-6e2d-4b9f-a8b1-d92c2910eb07",
   "_outcomes": [
@@ -10782,7 +10782,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/P1P-Test/nodes/SUCCESS - 167b87dd-a97c-4e3b-82ba-581090fd7863.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/P1P-Test/nodes/SUCCESS - 167b87dd-a97c-4e3b-82ba-581090fd7863.json 1`] = `
 {
   "_id": "167b87dd-a97c-4e3b-82ba-581090fd7863",
   "_outcomes": [
@@ -10802,7 +10802,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/PrestonTest/PrestonTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/PrestonTest/PrestonTest.json 1`] = `
 {
   "_id": "PrestonTest",
   "_rev": "-2075247621",
@@ -10822,7 +10822,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
 {
   "_id": "ProgressiveProfile",
   "_rev": "260694535",
@@ -10899,7 +10899,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
 {
   "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
   "_outcomes": [
@@ -10925,7 +10925,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
 {
   "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
   "_outcomes": [
@@ -10956,7 +10956,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
 {
   "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
   "_outcomes": [
@@ -10982,7 +10982,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
 {
   "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
   "_outcomes": [
@@ -11009,7 +11009,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
 {
   "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
   "_outcomes": [
@@ -11034,7 +11034,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/RadioChoice/RadioChoice.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/RadioChoice/RadioChoice.json 1`] = `
 {
   "_id": "RadioChoice",
   "_rev": "1819878661",
@@ -11079,7 +11079,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e.json 1`] = `
 {
   "_id": "5d6cd20e-5074-43de-8832-fddd95fb078e",
   "_outcomes": [
@@ -11117,7 +11117,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e/Choice Collector - a566e474-99f3-46e4-9e70-682402bfaa84.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e/Choice Collector - a566e474-99f3-46e4-9e70-682402bfaa84.json 1`] = `
 {
   "_id": "a566e474-99f3-46e4-9e70-682402bfaa84",
   "_outcomes": [
@@ -11151,7 +11151,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/Registration.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/Registration.json 1`] = `
 {
   "_id": "Registration",
   "_rev": "388671950",
@@ -11226,7 +11226,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
 {
   "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
   "_outcomes": [
@@ -11250,7 +11250,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Email Suspend Node - 466f8b54-07fb-4e31-a11d-a6842618cc37.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Email Suspend Node - 466f8b54-07fb-4e31-a11d-a6842618cc37.json 1`] = `
 {
   "_id": "466f8b54-07fb-4e31-a11d-a6842618cc37",
   "_outcomes": [
@@ -11276,7 +11276,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
 {
   "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
   "_outcomes": [
@@ -11296,7 +11296,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
 {
   "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
   "_outcomes": [
@@ -11354,7 +11354,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
 {
   "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
   "_outcomes": [
@@ -11373,7 +11373,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
 {
   "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
   "_outcomes": [
@@ -11402,7 +11402,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
 {
   "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
   "_outcomes": [
@@ -11425,7 +11425,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
 {
   "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
   "_outcomes": [
@@ -11446,7 +11446,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
 {
   "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
   "_outcomes": [
@@ -11468,7 +11468,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/ResetPassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/ResetPassword.json 1`] = `
 {
   "_id": "ResetPassword",
   "_rev": "1685804267",
@@ -11554,7 +11554,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
 {
   "_id": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
   "_outcomes": [
@@ -11580,7 +11580,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
 {
   "_id": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
   "_outcomes": [
@@ -11605,7 +11605,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
 {
   "_id": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
   "_outcomes": [
@@ -11638,7 +11638,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
 {
   "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
   "_outcomes": [
@@ -11663,7 +11663,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
 {
   "_id": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
   "_outcomes": [
@@ -11696,7 +11696,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
 {
   "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
   "_outcomes": [
@@ -11717,7 +11717,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
 {
   "_id": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
   "_outcomes": [
@@ -11744,7 +11744,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/SocialProviderHandler/SocialProviderHandler.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/SocialProviderHandler/SocialProviderHandler.json 1`] = `
 {
   "_id": "SocialProviderHandler",
   "_rev": "-2033719727",
@@ -11800,7 +11800,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/SocialProviderHandler/nodes/Legacy Social Provider Handler Node - 3af612be-340e-4dc9-80fb-62319a187b74.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/SocialProviderHandler/nodes/Legacy Social Provider Handler Node - 3af612be-340e-4dc9-80fb-62319a187b74.json 1`] = `
 {
   "_id": "3af612be-340e-4dc9-80fb-62319a187b74",
   "_outcomes": [
@@ -11828,7 +11828,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/SocialProviderHandler/nodes/Social Provider Handler Node - e15c8efe-b7a7-42bf-845e-861a9419af32.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/SocialProviderHandler/nodes/Social Provider Handler Node - e15c8efe-b7a7-42bf-845e-861a9419af32.json 1`] = `
 {
   "_id": "e15c8efe-b7a7-42bf-845e-861a9419af32",
   "_outcomes": [
@@ -11861,7 +11861,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/UpdatePassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/UpdatePassword.json 1`] = `
 {
   "_id": "UpdatePassword",
   "_rev": "-1098606408",
@@ -11968,7 +11968,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
 {
   "_id": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
   "_outcomes": [
@@ -11993,7 +11993,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
 {
   "_id": "7d1deabe-cd98-49c8-943f-ca12305775f3",
   "_outcomes": [
@@ -12016,7 +12016,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
 {
   "_id": "a3d97b53-e38a-4b24-aed0-a021050eb744",
   "_outcomes": [
@@ -12042,7 +12042,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
 {
   "_id": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
   "_outcomes": [
@@ -12063,7 +12063,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
 {
   "_id": "20237b34-26cb-4a0b-958f-abb422290d42",
   "_outcomes": [
@@ -12096,7 +12096,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
 {
   "_id": "fe2962fc-4db3-4066-8624-553649afc438",
   "_outcomes": [
@@ -12117,7 +12117,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
 {
   "_id": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
   "_outcomes": [
@@ -12150,7 +12150,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
 {
   "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
   "_outcomes": [
@@ -12171,7 +12171,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
 {
   "_id": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
   "_outcomes": [
@@ -12200,7 +12200,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j00/j00.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j00/j00.json 1`] = `
 {
   "_id": "j00",
   "_rev": "2108856917",
@@ -12296,7 +12296,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j00/nodes/debug - ba503a1e-633e-4d0d-ba18-c9a9b1105b5b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j00/nodes/debug - ba503a1e-633e-4d0d-ba18-c9a9b1105b5b.json 1`] = `
 {
   "_id": "ba503a1e-633e-4d0d-ba18-c9a9b1105b5b",
   "_outcomes": [
@@ -12325,7 +12325,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j00/nodes/level - 3c1e8d61-0c48-44ba-86dc-52e9555b6aeb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j00/nodes/level - 3c1e8d61-0c48-44ba-86dc-52e9555b6aeb.json 1`] = `
 {
   "_id": "3c1e8d61-0c48-44ba-86dc-52e9555b6aeb",
   "_outcomes": [
@@ -12354,7 +12354,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j00/nodes/level - 39b48197-f4be-42b9-800a-866587b4b9b5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j00/nodes/level - 39b48197-f4be-42b9-800a-866587b4b9b5.json 1`] = `
 {
   "_id": "39b48197-f4be-42b9-800a-866587b4b9b5",
   "_outcomes": [
@@ -12383,7 +12383,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j00/nodes/mode - 513a2ab4-f0b8-4f94-b840-6fe14796cc84.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j00/nodes/mode - 513a2ab4-f0b8-4f94-b840-6fe14796cc84.json 1`] = `
 {
   "_id": "513a2ab4-f0b8-4f94-b840-6fe14796cc84",
   "_outcomes": [
@@ -12431,7 +12431,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j00/nodes/shared - 01d3785f-7fb4-44a7-9458-72c380a9818f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j00/nodes/shared - 01d3785f-7fb4-44a7-9458-72c380a9818f.json 1`] = `
 {
   "_id": "01d3785f-7fb4-44a7-9458-72c380a9818f",
   "_outcomes": [
@@ -12460,7 +12460,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j00/nodes/shared - d17ffaa1-2c61-4abd-9bb1-2559160d0a5c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j00/nodes/shared - d17ffaa1-2c61-4abd-9bb1-2559160d0a5c.json 1`] = `
 {
   "_id": "d17ffaa1-2c61-4abd-9bb1-2559160d0a5c",
   "_outcomes": [
@@ -12489,7 +12489,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j01/j01.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j01/j01.json 1`] = `
 {
   "_id": "j01",
   "_rev": "-1240740730",
@@ -12586,7 +12586,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j01/nodes/level - bdfbe97c-1ff4-4162-85bc-47f6f14b2c66.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j01/nodes/level - bdfbe97c-1ff4-4162-85bc-47f6f14b2c66.json 1`] = `
 {
   "_id": "bdfbe97c-1ff4-4162-85bc-47f6f14b2c66",
   "_outcomes": [
@@ -12615,7 +12615,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j01/nodes/level - e92d5139-b8a6-43dc-9b13-95ba1d0dc53c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j01/nodes/level - e92d5139-b8a6-43dc-9b13-95ba1d0dc53c.json 1`] = `
 {
   "_id": "e92d5139-b8a6-43dc-9b13-95ba1d0dc53c",
   "_outcomes": [
@@ -12644,7 +12644,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j01/nodes/mode - f129f0df-b49e-453b-97fb-db508e3893ce.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j01/nodes/mode - f129f0df-b49e-453b-97fb-db508e3893ce.json 1`] = `
 {
   "_id": "f129f0df-b49e-453b-97fb-db508e3893ce",
   "_outcomes": [
@@ -12692,7 +12692,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j01/nodes/nest - bb1e96af-f316-4eb0-b1c6-36b3f1af9e35.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j01/nodes/nest - bb1e96af-f316-4eb0-b1c6-36b3f1af9e35.json 1`] = `
 {
   "_id": "bb1e96af-f316-4eb0-b1c6-36b3f1af9e35",
   "_outcomes": [
@@ -12717,7 +12717,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j01/nodes/shared - 89ce5d57-82fa-4d58-8d15-0329f7dbd7e7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j01/nodes/shared - 89ce5d57-82fa-4d58-8d15-0329f7dbd7e7.json 1`] = `
 {
   "_id": "89ce5d57-82fa-4d58-8d15-0329f7dbd7e7",
   "_outcomes": [
@@ -12746,7 +12746,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j01/nodes/shared - 6674b4ac-dd89-4e13-9440-6f81194e3a22.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j01/nodes/shared - 6674b4ac-dd89-4e13-9440-6f81194e3a22.json 1`] = `
 {
   "_id": "6674b4ac-dd89-4e13-9440-6f81194e3a22",
   "_outcomes": [
@@ -12775,7 +12775,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j02/j02.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j02/j02.json 1`] = `
 {
   "_id": "j02",
   "_rev": "1006720127",
@@ -12872,7 +12872,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j02/nodes/level - 2dbd2d37-c659-48cf-8357-c9fc1166e3a7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j02/nodes/level - 2dbd2d37-c659-48cf-8357-c9fc1166e3a7.json 1`] = `
 {
   "_id": "2dbd2d37-c659-48cf-8357-c9fc1166e3a7",
   "_outcomes": [
@@ -12901,7 +12901,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j02/nodes/level - 4416aff7-3ebd-47e6-9831-c2f6bbe3ae24.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j02/nodes/level - 4416aff7-3ebd-47e6-9831-c2f6bbe3ae24.json 1`] = `
 {
   "_id": "4416aff7-3ebd-47e6-9831-c2f6bbe3ae24",
   "_outcomes": [
@@ -12930,7 +12930,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j02/nodes/mode - 59b06306-a886-443d-92df-7a27a60c394e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j02/nodes/mode - 59b06306-a886-443d-92df-7a27a60c394e.json 1`] = `
 {
   "_id": "59b06306-a886-443d-92df-7a27a60c394e",
   "_outcomes": [
@@ -12978,7 +12978,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j02/nodes/nest - 56899fef-92a1-4f2a-ade3-973c81eb3af1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j02/nodes/nest - 56899fef-92a1-4f2a-ade3-973c81eb3af1.json 1`] = `
 {
   "_id": "56899fef-92a1-4f2a-ade3-973c81eb3af1",
   "_outcomes": [
@@ -13003,7 +13003,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j02/nodes/shared - cbb3d506-b267-4b99-9edd-363e90aac997.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j02/nodes/shared - cbb3d506-b267-4b99-9edd-363e90aac997.json 1`] = `
 {
   "_id": "cbb3d506-b267-4b99-9edd-363e90aac997",
   "_outcomes": [
@@ -13032,7 +13032,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j02/nodes/shared - e0983ead-4918-48f6-858d-9aff0f03759c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j02/nodes/shared - e0983ead-4918-48f6-858d-9aff0f03759c.json 1`] = `
 {
   "_id": "e0983ead-4918-48f6-858d-9aff0f03759c",
   "_outcomes": [
@@ -13061,7 +13061,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j03/j03.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j03/j03.json 1`] = `
 {
   "_id": "j03",
   "_rev": "1203078238",
@@ -13158,7 +13158,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j03/nodes/level - 3a92300d-6d64-451d-8156-30cb51781026.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j03/nodes/level - 3a92300d-6d64-451d-8156-30cb51781026.json 1`] = `
 {
   "_id": "3a92300d-6d64-451d-8156-30cb51781026",
   "_outcomes": [
@@ -13187,7 +13187,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j03/nodes/level - 35a4f94b-c895-46b9-bc0a-93cf59233759.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j03/nodes/level - 35a4f94b-c895-46b9-bc0a-93cf59233759.json 1`] = `
 {
   "_id": "35a4f94b-c895-46b9-bc0a-93cf59233759",
   "_outcomes": [
@@ -13216,7 +13216,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j03/nodes/mode - e0cfbd13-6f1e-4924-9d2d-0f7c23507172.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j03/nodes/mode - e0cfbd13-6f1e-4924-9d2d-0f7c23507172.json 1`] = `
 {
   "_id": "e0cfbd13-6f1e-4924-9d2d-0f7c23507172",
   "_outcomes": [
@@ -13264,7 +13264,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j03/nodes/nest - bcb8c535-5ecd-4d3d-b970-26816de96bf2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j03/nodes/nest - bcb8c535-5ecd-4d3d-b970-26816de96bf2.json 1`] = `
 {
   "_id": "bcb8c535-5ecd-4d3d-b970-26816de96bf2",
   "_outcomes": [
@@ -13289,7 +13289,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j03/nodes/shared - 6f9de973-9ed4-41f5-b43d-4036041e2b96.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j03/nodes/shared - 6f9de973-9ed4-41f5-b43d-4036041e2b96.json 1`] = `
 {
   "_id": "6f9de973-9ed4-41f5-b43d-4036041e2b96",
   "_outcomes": [
@@ -13318,7 +13318,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j03/nodes/shared - fae7424e-13c9-45bd-b3a2-045773671a3f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j03/nodes/shared - fae7424e-13c9-45bd-b3a2-045773671a3f.json 1`] = `
 {
   "_id": "fae7424e-13c9-45bd-b3a2-045773671a3f",
   "_outcomes": [
@@ -13347,7 +13347,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j04/j04.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j04/j04.json 1`] = `
 {
   "_id": "j04",
   "_rev": "125884797",
@@ -13444,7 +13444,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j04/nodes/level - 69ae8ec1-de43-44ac-98e5-733db80ac176.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j04/nodes/level - 69ae8ec1-de43-44ac-98e5-733db80ac176.json 1`] = `
 {
   "_id": "69ae8ec1-de43-44ac-98e5-733db80ac176",
   "_outcomes": [
@@ -13473,7 +13473,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j04/nodes/level - d10104e9-1f8d-4da6-a110-28d879d13959.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j04/nodes/level - d10104e9-1f8d-4da6-a110-28d879d13959.json 1`] = `
 {
   "_id": "d10104e9-1f8d-4da6-a110-28d879d13959",
   "_outcomes": [
@@ -13502,7 +13502,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j04/nodes/mode - 040b6c89-313b-4664-92e0-6732017384b8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j04/nodes/mode - 040b6c89-313b-4664-92e0-6732017384b8.json 1`] = `
 {
   "_id": "040b6c89-313b-4664-92e0-6732017384b8",
   "_outcomes": [
@@ -13550,7 +13550,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j04/nodes/nest - 00e75aa0-2f9b-4895-9257-d515286fd64b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j04/nodes/nest - 00e75aa0-2f9b-4895-9257-d515286fd64b.json 1`] = `
 {
   "_id": "00e75aa0-2f9b-4895-9257-d515286fd64b",
   "_outcomes": [
@@ -13575,7 +13575,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j04/nodes/shared - 9603ef52-30f0-4ddc-b3c0-28dac83c7bdb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j04/nodes/shared - 9603ef52-30f0-4ddc-b3c0-28dac83c7bdb.json 1`] = `
 {
   "_id": "9603ef52-30f0-4ddc-b3c0-28dac83c7bdb",
   "_outcomes": [
@@ -13604,7 +13604,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j04/nodes/shared - f5c317ce-fabd-4a10-9907-c71cea037844.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j04/nodes/shared - f5c317ce-fabd-4a10-9907-c71cea037844.json 1`] = `
 {
   "_id": "f5c317ce-fabd-4a10-9907-c71cea037844",
   "_outcomes": [
@@ -13633,7 +13633,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j05/j05.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j05/j05.json 1`] = `
 {
   "_id": "j05",
   "_rev": "-1683838231",
@@ -13730,7 +13730,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j05/nodes/level - 3c106772-ace7-4808-8f3a-9840de8f67f0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j05/nodes/level - 3c106772-ace7-4808-8f3a-9840de8f67f0.json 1`] = `
 {
   "_id": "3c106772-ace7-4808-8f3a-9840de8f67f0",
   "_outcomes": [
@@ -13759,7 +13759,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j05/nodes/level - e90ae257-c279-46e0-9b43-5ecd89784d77.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j05/nodes/level - e90ae257-c279-46e0-9b43-5ecd89784d77.json 1`] = `
 {
   "_id": "e90ae257-c279-46e0-9b43-5ecd89784d77",
   "_outcomes": [
@@ -13788,7 +13788,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j05/nodes/mode - 622179cb-98f1-484a-820d-9a0df6e45e95.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j05/nodes/mode - 622179cb-98f1-484a-820d-9a0df6e45e95.json 1`] = `
 {
   "_id": "622179cb-98f1-484a-820d-9a0df6e45e95",
   "_outcomes": [
@@ -13836,7 +13836,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j05/nodes/nest - f17ecb7c-abc3-4523-9943-4cbdd90305cb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j05/nodes/nest - f17ecb7c-abc3-4523-9943-4cbdd90305cb.json 1`] = `
 {
   "_id": "f17ecb7c-abc3-4523-9943-4cbdd90305cb",
   "_outcomes": [
@@ -13861,7 +13861,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j05/nodes/shared - 11f1c31c-50a9-4717-8213-420f6932481f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j05/nodes/shared - 11f1c31c-50a9-4717-8213-420f6932481f.json 1`] = `
 {
   "_id": "11f1c31c-50a9-4717-8213-420f6932481f",
   "_outcomes": [
@@ -13890,7 +13890,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j05/nodes/shared - a0782616-84b7-4bf5-87ed-a01fb3018563.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j05/nodes/shared - a0782616-84b7-4bf5-87ed-a01fb3018563.json 1`] = `
 {
   "_id": "a0782616-84b7-4bf5-87ed-a01fb3018563",
   "_outcomes": [
@@ -13919,7 +13919,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j06/j06.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j06/j06.json 1`] = `
 {
   "_id": "j06",
   "_rev": "-1311195611",
@@ -14016,7 +14016,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j06/nodes/level - 2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j06/nodes/level - 2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3.json 1`] = `
 {
   "_id": "2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3",
   "_outcomes": [
@@ -14045,7 +14045,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j06/nodes/level - fe8f27df-8a27-4d88-9196-834ce398b2b7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j06/nodes/level - fe8f27df-8a27-4d88-9196-834ce398b2b7.json 1`] = `
 {
   "_id": "fe8f27df-8a27-4d88-9196-834ce398b2b7",
   "_outcomes": [
@@ -14074,7 +14074,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j06/nodes/mode - 44b8651c-7c1e-41f1-b9a6-2e441b0ce05a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j06/nodes/mode - 44b8651c-7c1e-41f1-b9a6-2e441b0ce05a.json 1`] = `
 {
   "_id": "44b8651c-7c1e-41f1-b9a6-2e441b0ce05a",
   "_outcomes": [
@@ -14122,7 +14122,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j06/nodes/nest - 409c251f-c23b-411d-9009-d3b3d26d1b90.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j06/nodes/nest - 409c251f-c23b-411d-9009-d3b3d26d1b90.json 1`] = `
 {
   "_id": "409c251f-c23b-411d-9009-d3b3d26d1b90",
   "_outcomes": [
@@ -14147,7 +14147,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j06/nodes/shared - 1d59caff-243c-45bd-b7d0-6dcc563989c5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j06/nodes/shared - 1d59caff-243c-45bd-b7d0-6dcc563989c5.json 1`] = `
 {
   "_id": "1d59caff-243c-45bd-b7d0-6dcc563989c5",
   "_outcomes": [
@@ -14176,7 +14176,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j06/nodes/shared - da878771-421c-463f-aad7-4d5f2ad5e59a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j06/nodes/shared - da878771-421c-463f-aad7-4d5f2ad5e59a.json 1`] = `
 {
   "_id": "da878771-421c-463f-aad7-4d5f2ad5e59a",
   "_outcomes": [
@@ -14205,7 +14205,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j07/j07.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j07/j07.json 1`] = `
 {
   "_id": "j07",
   "_rev": "-1925267397",
@@ -14302,7 +14302,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j07/nodes/level - d90dd9f8-8b12-4e90-abaf-228ecc0174a7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j07/nodes/level - d90dd9f8-8b12-4e90-abaf-228ecc0174a7.json 1`] = `
 {
   "_id": "d90dd9f8-8b12-4e90-abaf-228ecc0174a7",
   "_outcomes": [
@@ -14331,7 +14331,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j07/nodes/level - f2fe740c-cd75-460a-8baa-fe4b52ecc947.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j07/nodes/level - f2fe740c-cd75-460a-8baa-fe4b52ecc947.json 1`] = `
 {
   "_id": "f2fe740c-cd75-460a-8baa-fe4b52ecc947",
   "_outcomes": [
@@ -14360,7 +14360,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j07/nodes/mode - 13b12fe6-cf53-46a4-a83d-0a3c1fda814f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j07/nodes/mode - 13b12fe6-cf53-46a4-a83d-0a3c1fda814f.json 1`] = `
 {
   "_id": "13b12fe6-cf53-46a4-a83d-0a3c1fda814f",
   "_outcomes": [
@@ -14408,7 +14408,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j07/nodes/nest - e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j07/nodes/nest - e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9.json 1`] = `
 {
   "_id": "e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9",
   "_outcomes": [
@@ -14433,7 +14433,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j07/nodes/shared - ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j07/nodes/shared - ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0.json 1`] = `
 {
   "_id": "ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0",
   "_outcomes": [
@@ -14462,7 +14462,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j07/nodes/shared - d9a06d3a-7e3f-4244-9a32-63ffa0d26e00.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j07/nodes/shared - d9a06d3a-7e3f-4244-9a32-63ffa0d26e00.json 1`] = `
 {
   "_id": "d9a06d3a-7e3f-4244-9a32-63ffa0d26e00",
   "_outcomes": [
@@ -14491,7 +14491,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j08/j08.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j08/j08.json 1`] = `
 {
   "_id": "j08",
   "_rev": "-282238685",
@@ -14588,7 +14588,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j08/nodes/level - 87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j08/nodes/level - 87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d.json 1`] = `
 {
   "_id": "87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d",
   "_outcomes": [
@@ -14617,7 +14617,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j08/nodes/level - 8096649e-973e-4209-88ce-e1d87ae2bb96.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j08/nodes/level - 8096649e-973e-4209-88ce-e1d87ae2bb96.json 1`] = `
 {
   "_id": "8096649e-973e-4209-88ce-e1d87ae2bb96",
   "_outcomes": [
@@ -14646,7 +14646,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j08/nodes/mode - d429b2b5-b215-46a5-b239-4994df65cb8b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j08/nodes/mode - d429b2b5-b215-46a5-b239-4994df65cb8b.json 1`] = `
 {
   "_id": "d429b2b5-b215-46a5-b239-4994df65cb8b",
   "_outcomes": [
@@ -14694,7 +14694,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j08/nodes/nest - 66026170-5088-4fcd-a6c8-ed89d7a5c79d.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j08/nodes/nest - 66026170-5088-4fcd-a6c8-ed89d7a5c79d.json 1`] = `
 {
   "_id": "66026170-5088-4fcd-a6c8-ed89d7a5c79d",
   "_outcomes": [
@@ -14719,7 +14719,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j08/nodes/shared - 042b600b-71cb-45a8-93ae-a6f57b16a6e5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j08/nodes/shared - 042b600b-71cb-45a8-93ae-a6f57b16a6e5.json 1`] = `
 {
   "_id": "042b600b-71cb-45a8-93ae-a6f57b16a6e5",
   "_outcomes": [
@@ -14748,7 +14748,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j08/nodes/shared - 948e21f4-c512-450a-9d42-e0d629217834.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j08/nodes/shared - 948e21f4-c512-450a-9d42-e0d629217834.json 1`] = `
 {
   "_id": "948e21f4-c512-450a-9d42-e0d629217834",
   "_outcomes": [
@@ -14777,7 +14777,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j09/j09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j09/j09.json 1`] = `
 {
   "_id": "j09",
   "_rev": "-1396884723",
@@ -14874,7 +14874,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j09/nodes/level - 56b82371-0c61-4dc3-8d06-c1158415b8f9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j09/nodes/level - 56b82371-0c61-4dc3-8d06-c1158415b8f9.json 1`] = `
 {
   "_id": "56b82371-0c61-4dc3-8d06-c1158415b8f9",
   "_outcomes": [
@@ -14903,7 +14903,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j09/nodes/level - bb294e05-6b6b-4478-b46f-b8d9e7711c66.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j09/nodes/level - bb294e05-6b6b-4478-b46f-b8d9e7711c66.json 1`] = `
 {
   "_id": "bb294e05-6b6b-4478-b46f-b8d9e7711c66",
   "_outcomes": [
@@ -14932,7 +14932,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j09/nodes/mode - 251f35c3-1a32-4520-be10-1f4af9600935.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j09/nodes/mode - 251f35c3-1a32-4520-be10-1f4af9600935.json 1`] = `
 {
   "_id": "251f35c3-1a32-4520-be10-1f4af9600935",
   "_outcomes": [
@@ -14980,7 +14980,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j09/nodes/nest - 6df24fdd-0b6c-4def-bf42-77af998f28b8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j09/nodes/nest - 6df24fdd-0b6c-4def-bf42-77af998f28b8.json 1`] = `
 {
   "_id": "6df24fdd-0b6c-4def-bf42-77af998f28b8",
   "_outcomes": [
@@ -15005,7 +15005,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j09/nodes/shared - 8c5e9cb5-471b-4dd6-b150-ecaaeda98195.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j09/nodes/shared - 8c5e9cb5-471b-4dd6-b150-ecaaeda98195.json 1`] = `
 {
   "_id": "8c5e9cb5-471b-4dd6-b150-ecaaeda98195",
   "_outcomes": [
@@ -15034,7 +15034,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j09/nodes/shared - f57cf53c-b4c6-48f7-84e8-91f535a2e8f8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j09/nodes/shared - f57cf53c-b4c6-48f7-84e8-91f535a2e8f8.json 1`] = `
 {
   "_id": "f57cf53c-b4c6-48f7-84e8-91f535a2e8f8",
   "_outcomes": [
@@ -15063,7 +15063,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j10/j10.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j10/j10.json 1`] = `
 {
   "_id": "j10",
   "_rev": "1630303400",
@@ -15160,7 +15160,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j10/nodes/level - 8d7d64ee-da20-461f-a2ca-206b7479dd67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j10/nodes/level - 8d7d64ee-da20-461f-a2ca-206b7479dd67.json 1`] = `
 {
   "_id": "8d7d64ee-da20-461f-a2ca-206b7479dd67",
   "_outcomes": [
@@ -15189,7 +15189,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j10/nodes/level - 300feda0-3248-49a9-b60f-01df802b2229.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j10/nodes/level - 300feda0-3248-49a9-b60f-01df802b2229.json 1`] = `
 {
   "_id": "300feda0-3248-49a9-b60f-01df802b2229",
   "_outcomes": [
@@ -15218,7 +15218,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j10/nodes/mode - c91d626e-1156-41bd-b1fb-d292f640fba6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j10/nodes/mode - c91d626e-1156-41bd-b1fb-d292f640fba6.json 1`] = `
 {
   "_id": "c91d626e-1156-41bd-b1fb-d292f640fba6",
   "_outcomes": [
@@ -15266,7 +15266,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j10/nodes/nest - c7fcf7ae-1ab5-474b-b5b0-272e10468fbd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j10/nodes/nest - c7fcf7ae-1ab5-474b-b5b0-272e10468fbd.json 1`] = `
 {
   "_id": "c7fcf7ae-1ab5-474b-b5b0-272e10468fbd",
   "_outcomes": [
@@ -15291,7 +15291,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j10/nodes/shared - 40afb384-e9b6-4dcb-acde-04de109474c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j10/nodes/shared - 40afb384-e9b6-4dcb-acde-04de109474c8.json 1`] = `
 {
   "_id": "40afb384-e9b6-4dcb-acde-04de109474c8",
   "_outcomes": [
@@ -15320,7 +15320,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/j10/nodes/shared - 97ef9d96-99e7-4d2d-b6c6-4177b5397ead.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/j10/nodes/shared - 97ef9d96-99e7-4d2d-b6c6-4177b5397ead.json 1`] = `
 {
   "_id": "97ef9d96-99e7-4d2d-b6c6-4177b5397ead",
   "_outcomes": [
@@ -15349,7 +15349,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/journeys/test/test.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/journeys/test/test.json 1`] = `
 {
   "_id": "test",
   "_rev": "1505940492",
@@ -15379,7 +15379,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-config/1b52a7e0-4019-40fa-958a-15a49870e901.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-config/1b52a7e0-4019-40fa-958a-15a49870e901.json 1`] = `
 {
   "_id": "1b52a7e0-4019-40fa-958a-15a49870e901",
   "context": "AUTHENTICATION_TREE_DECISION_NODE",
@@ -15398,7 +15398,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-config/3cb43516-ae69-433a-8787-501d45db14e9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-config/3cb43516-ae69-433a-8787-501d45db14e9.json 1`] = `
 {
   "_id": "3cb43516-ae69-433a-8787-501d45db14e9",
   "context": "AUTHENTICATION_TREE_DECISION_NODE",
@@ -15417,7 +15417,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-config/5bbdaeff-ddee-44b9-b608-8d413d7d65a6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-config/5bbdaeff-ddee-44b9-b608-8d413d7d65a6.json 1`] = `
 {
   "_id": "5bbdaeff-ddee-44b9-b608-8d413d7d65a6",
   "context": "AUTHENTICATION_TREE_DECISION_NODE",
@@ -15436,7 +15436,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-config/41c24257-d7fc-4654-8b46-c2666dc5b56d.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-config/41c24257-d7fc-4654-8b46-c2666dc5b56d.json 1`] = `
 {
   "_id": "41c24257-d7fc-4654-8b46-c2666dc5b56d",
   "context": "AUTHENTICATION_TREE_DECISION_NODE",
@@ -15455,7 +15455,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-config/58c824ae-84ed-4724-82cd-db128fc3f6c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-config/58c824ae-84ed-4724-82cd-db128fc3f6c.json 1`] = `
 {
   "_id": "58c824ae-84ed-4724-82cd-db128fc3f6c",
   "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
@@ -15474,7 +15474,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-config/739bdc48-fd24-4c52-b353-88706d75558a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-config/739bdc48-fd24-4c52-b353-88706d75558a.json 1`] = `
 {
   "_id": "739bdc48-fd24-4c52-b353-88706d75558a",
   "context": "AUTHENTICATION_TREE_DECISION_NODE",
@@ -15493,7 +15493,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-config/ed685f9f-5909-4726-86e8-22bd38b47663.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-config/ed685f9f-5909-4726-86e8-22bd38b47663.json 1`] = `
 {
   "_id": "ed685f9f-5909-4726-86e8-22bd38b47663",
   "context": "SOCIAL_IDP_PROFILE_TRANSFORMATION",
@@ -15512,7 +15512,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Check Username.js 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Check Username.js 1`] = `
 "/* Check Username
  *
  * Author: volker.scheuber@forgerock.com
@@ -15537,7 +15537,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 "
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/debug.js 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/debug.js 1`] = `
 "/* debug
  *
  * Author: volker.scheuber@forgerock.com
@@ -15602,7 +15602,7 @@ function generateNumericToken(format) {
 "
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/level.js 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/level.js 1`] = `
 "(function () {
   outcome = 'true';
   var level = nodeState.get('level').asInteger();
@@ -15611,7 +15611,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 "
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/mode.js 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/mode.js 1`] = `
 "/* mode
  *
  * Author: volker.scheuber@forgerock.com
@@ -15657,7 +15657,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 "
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/shared.js 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/shared.js 1`] = `
 "(function () {
   outcome = 'true';
   var level = nodeState.get('level').asInteger();
@@ -15666,7 +15666,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 "
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-content/SOCIAL_IDP_PROFILE_TRANSFORMATION/Normalized Profile to Identity.js 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-content/SOCIAL_IDP_PROFILE_TRANSFORMATION/Normalized Profile to Identity.js 1`] = `
 "/*
  * Copyright 2021 ForgeRock AS. All Rights Reserved
  *
@@ -15693,12 +15693,12 @@ return identity
 "
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/alpha/scripts/scripts-content/SOCIAL_IDP_PROFILE_TRANSFORMATION/Normalized Profile to Managed User.js 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/alpha/scripts/scripts-content/SOCIAL_IDP_PROFILE_TRANSFORMATION/Normalized Profile to Managed User.js 1`] = `
 ""/*\\n * Copyright 2020 ForgeRock AS. All Rights Reserved\\n *\\n * Use of this code requires a commercial software license with ForgeRock AS.\\n * or with one of its affiliates. All use shall be exclusively subject\\n * to such license between the licensee and ForgeRock AS.\\n */\\n\\nimport static org.forgerock.json.JsonValue.field\\nimport static org.forgerock.json.JsonValue.json\\nimport static org.forgerock.json.JsonValue.object\\n\\nimport org.forgerock.json.JsonValue\\n\\nJsonValue managedUser = json(object(\\n        field(\\"givenName\\", normalizedProfile.givenName),\\n        field(\\"sn\\", normalizedProfile.familyName),\\n        field(\\"mail\\", normalizedProfile.email),\\n        field(\\"userName\\", normalizedProfile.username)))\\n\\nif (normalizedProfile.postalAddress.isNotNull()) managedUser.put(\\"postalAddress\\", normalizedProfile.postalAddress)\\nif (normalizedProfile.addressLocality.isNotNull()) managedUser.put(\\"city\\", normalizedProfile.addressLocality)\\nif (normalizedProfile.addressRegion.isNotNull()) managedUser.put(\\"stateProvince\\", normalizedProfile.addressRegion)\\nif (normalizedProfile.postalCode.isNotNull()) managedUser.put(\\"postalCode\\", normalizedProfile.postalCode)\\nif (normalizedProfile.country.isNotNull()) managedUser.put(\\"country\\", normalizedProfile.country)\\nif (normalizedProfile.phone.isNotNull()) managedUser.put(\\"telephoneNumber\\", normalizedProfile.phone)\\n\\n// if the givenName and familyName is null or empty\\n// then add a boolean flag to the shared state to indicate names are not present\\n// this could be used elsewhere\\n// for eg. this could be used in a scripted decision node to by-pass patching\\n// the user object with blank values when givenName  and familyName is not present\\nboolean noGivenName = normalizedProfile.givenName.isNull() || (!normalizedProfile.givenName.asString()?.trim())\\nboolean noFamilyName = normalizedProfile.familyName.isNull() || (!normalizedProfile.familyName.asString()?.trim())\\nsharedState.put(\\"nameEmptyOrNull\\", noGivenName && noFamilyName)\\n\\nreturn managedUser\\n"
 "
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Agent/Agent.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Agent/Agent.json 1`] = `
 {
   "_id": "Agent",
   "_rev": "-995271915",
@@ -15764,7 +15764,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Agent/nodes/Agent Data Store Decision - a02fa1ec-2752-42bc-a98f-e41e08f225e7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Agent/nodes/Agent Data Store Decision - a02fa1ec-2752-42bc-a98f-e41e08f225e7.json 1`] = `
 {
   "_id": "a02fa1ec-2752-42bc-a98f-e41e08f225e7",
   "_outcomes": [
@@ -15787,7 +15787,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2.json 1`] = `
 {
   "_id": "0fde84fa-bf2f-4322-a040-fc700bd9b8f2",
   "_outcomes": [
@@ -15822,7 +15822,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Password - 52db314b-2eda-41a9-8dda-8d0b8b8e5876.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Password - 52db314b-2eda-41a9-8dda-8d0b8b8e5876.json 1`] = `
 {
   "_id": "52db314b-2eda-41a9-8dda-8d0b8b8e5876",
   "_outcomes": [
@@ -15843,7 +15843,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Username - 16ac997e-4d48-4c19-b6b9-98086845131a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Agent/nodes/Page Node - 0fde84fa-bf2f-4322-a040-fc700bd9b8f2/Platform Username - 16ac997e-4d48-4c19-b6b9-98086845131a.json 1`] = `
 {
   "_id": "16ac997e-4d48-4c19-b6b9-98086845131a",
   "_outcomes": [
@@ -15865,7 +15865,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Agent/nodes/Zero Page Login Collector - 53fc9e71-93b1-4329-a0ee-0493c6b4fcd6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Agent/nodes/Zero Page Login Collector - 53fc9e71-93b1-4329-a0ee-0493c6b4fcd6.json 1`] = `
 {
   "_id": "53fc9e71-93b1-4329-a0ee-0493c6b4fcd6",
   "_outcomes": [
@@ -15892,7 +15892,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
 {
   "_id": "ForgottenUsername",
   "_rev": "1922908182",
@@ -15968,7 +15968,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
 {
   "_id": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
   "_outcomes": [
@@ -15994,7 +15994,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
 {
   "_id": "bf9ea8d5-9802-4f26-9664-a21840faac23",
   "_outcomes": [
@@ -16019,7 +16019,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
 {
   "_id": "b93ce36e-1976-4610-b24f-8d6760b5463b",
   "_outcomes": [
@@ -16044,7 +16044,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
 {
   "_id": "5e2a7c95-94af-4b23-8724-deb13853726a",
   "_outcomes": [
@@ -16077,7 +16077,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
 {
   "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
   "_outcomes": [
@@ -16102,7 +16102,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/Login.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/Login.json 1`] = `
 {
   "_id": "Login",
   "_rev": "1447343562",
@@ -16202,7 +16202,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Account Lockout - 76b5e15c-493c-47dc-b813-01cbc74c5a85.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Account Lockout - 76b5e15c-493c-47dc-b813-01cbc74c5a85.json 1`] = `
 {
   "_id": "76b5e15c-493c-47dc-b813-01cbc74c5a85",
   "_outcomes": [
@@ -16222,7 +16222,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Identity Store Decision - a30b1258-4c35-4ebe-90f3-c11fced9b1e4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Identity Store Decision - a30b1258-4c35-4ebe-90f3-c11fced9b1e4.json 1`] = `
 {
   "_id": "a30b1258-4c35-4ebe-90f3-c11fced9b1e4",
   "_outcomes": [
@@ -16260,7 +16260,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
 {
   "_id": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
   "_outcomes": [
@@ -16280,7 +16280,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
 {
   "_id": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
   "_outcomes": [
@@ -16305,7 +16305,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
 {
   "_id": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
   "_outcomes": [
@@ -16344,7 +16344,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
 {
   "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
   "_outcomes": [
@@ -16365,7 +16365,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
 {
   "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
   "_outcomes": [
@@ -16387,7 +16387,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Login/nodes/Retry Limit Decision - feecdfb1-386c-423f-b4a0-05cf6b05f783.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Login/nodes/Retry Limit Decision - feecdfb1-386c-423f-b4a0-05cf6b05f783.json 1`] = `
 {
   "_id": "feecdfb1-386c-423f-b4a0-05cf6b05f783",
   "_outcomes": [
@@ -16412,7 +16412,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
 {
   "_id": "ProgressiveProfile",
   "_rev": "-1280941645",
@@ -16489,7 +16489,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
 {
   "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
   "_outcomes": [
@@ -16515,7 +16515,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
 {
   "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
   "_outcomes": [
@@ -16546,7 +16546,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
 {
   "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
   "_outcomes": [
@@ -16572,7 +16572,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
 {
   "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
   "_outcomes": [
@@ -16599,7 +16599,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
 {
   "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
   "_outcomes": [
@@ -16624,7 +16624,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/Registration.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/Registration.json 1`] = `
 {
   "_id": "Registration",
   "_rev": "2125060565",
@@ -16699,7 +16699,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
 {
   "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
   "_outcomes": [
@@ -16723,7 +16723,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Email Suspend Node - 6b70de2f-a625-4957-93d9-37005e33e6e1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Email Suspend Node - 6b70de2f-a625-4957-93d9-37005e33e6e1.json 1`] = `
 {
   "_id": "6b70de2f-a625-4957-93d9-37005e33e6e1",
   "_outcomes": [
@@ -16749,7 +16749,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
 {
   "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
   "_outcomes": [
@@ -16769,7 +16769,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
 {
   "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
   "_outcomes": [
@@ -16826,7 +16826,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
 {
   "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
   "_outcomes": [
@@ -16845,7 +16845,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
 {
   "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
   "_outcomes": [
@@ -16874,7 +16874,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
 {
   "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
   "_outcomes": [
@@ -16897,7 +16897,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
 {
   "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
   "_outcomes": [
@@ -16918,7 +16918,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
 {
   "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
   "_outcomes": [
@@ -16940,7 +16940,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/ResetPassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/ResetPassword.json 1`] = `
 {
   "_id": "ResetPassword",
   "_rev": "144168087",
@@ -17026,7 +17026,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
 {
   "_id": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
   "_outcomes": [
@@ -17052,7 +17052,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
 {
   "_id": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
   "_outcomes": [
@@ -17077,7 +17077,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
 {
   "_id": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
   "_outcomes": [
@@ -17110,7 +17110,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
 {
   "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
   "_outcomes": [
@@ -17135,7 +17135,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
 {
   "_id": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
   "_outcomes": [
@@ -17168,7 +17168,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
 {
   "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
   "_outcomes": [
@@ -17189,7 +17189,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
 {
   "_id": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
   "_outcomes": [
@@ -17216,7 +17216,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/UpdatePassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/UpdatePassword.json 1`] = `
 {
   "_id": "UpdatePassword",
   "_rev": "1654724708",
@@ -17323,7 +17323,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
 {
   "_id": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
   "_outcomes": [
@@ -17348,7 +17348,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
 {
   "_id": "7d1deabe-cd98-49c8-943f-ca12305775f3",
   "_outcomes": [
@@ -17371,7 +17371,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
 {
   "_id": "a3d97b53-e38a-4b24-aed0-a021050eb744",
   "_outcomes": [
@@ -17397,7 +17397,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
 {
   "_id": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
   "_outcomes": [
@@ -17418,7 +17418,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
 {
   "_id": "20237b34-26cb-4a0b-958f-abb422290d42",
   "_outcomes": [
@@ -17451,7 +17451,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
 {
   "_id": "fe2962fc-4db3-4066-8624-553649afc438",
   "_outcomes": [
@@ -17472,7 +17472,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
 {
   "_id": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
   "_outcomes": [
@@ -17505,7 +17505,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
 {
   "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
   "_outcomes": [
@@ -17526,7 +17526,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style": testDir14/realms/bravo/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style": ConfigJourneytestDir4/realms/bravo/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
 {
   "_id": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
   "_outcomes": [
@@ -17555,11 +17555,11 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -D testD
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style" 1`] = `0`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style" 1`] = `0`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style" 2`] = `""`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style" 2`] = `""`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Agent/Agent.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Agent/Agent.json 1`] = `
 {
   "_id": "Agent",
   "_rev": "-737774734",
@@ -17625,7 +17625,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Agent/nodes/Agent Data Store Decision - 6736a00a-fc65-438e-b4ea-23f66b4a8739.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Agent/nodes/Agent Data Store Decision - 6736a00a-fc65-438e-b4ea-23f66b4a8739.json 1`] = `
 {
   "_id": "6736a00a-fc65-438e-b4ea-23f66b4a8739",
   "_outcomes": [
@@ -17648,7 +17648,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080.json 1`] = `
 {
   "_id": "cbd1f1af-eb0a-4274-a762-adacf04c7080",
   "_outcomes": [
@@ -17683,7 +17683,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Password - 6072842f-5f7c-4b62-8ae2-4f18a5701ba4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Password - 6072842f-5f7c-4b62-8ae2-4f18a5701ba4.json 1`] = `
 {
   "_id": "6072842f-5f7c-4b62-8ae2-4f18a5701ba4",
   "_outcomes": [
@@ -17704,7 +17704,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Username - 2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Agent/nodes/Page Node - cbd1f1af-eb0a-4274-a762-adacf04c7080/Platform Username - 2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018.json 1`] = `
 {
   "_id": "2eaad2f9-5c4b-405f-bf3f-1e99bdc0d018",
   "_outcomes": [
@@ -17726,7 +17726,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Agent/nodes/Zero Page Login Collector - 51e2cd24-cf1f-4313-8af0-35ea9e04d2fe.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Agent/nodes/Zero Page Login Collector - 51e2cd24-cf1f-4313-8af0-35ea9e04d2fe.json 1`] = `
 {
   "_id": "51e2cd24-cf1f-4313-8af0-35ea9e04d2fe",
   "_outcomes": [
@@ -17753,7 +17753,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ForgottenUsername/ForgottenUsername.json 1`] = `
 {
   "_id": "ForgottenUsername",
   "_rev": "-830414370",
@@ -17829,7 +17829,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ForgottenUsername/nodes/Email Suspend Node - d9a79f01-2ce3-4be2-a28a-975f35c3c8ca.json 1`] = `
 {
   "_id": "d9a79f01-2ce3-4be2-a28a-975f35c3c8ca",
   "_outcomes": [
@@ -17855,7 +17855,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ForgottenUsername/nodes/Identify Existing User - bf9ea8d5-9802-4f26-9664-a21840faac23.json 1`] = `
 {
   "_id": "bf9ea8d5-9802-4f26-9664-a21840faac23",
   "_outcomes": [
@@ -17880,7 +17880,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ForgottenUsername/nodes/Inner Tree Evaluator - b93ce36e-1976-4610-b24f-8d6760b5463b.json 1`] = `
 {
   "_id": "b93ce36e-1976-4610-b24f-8d6760b5463b",
   "_outcomes": [
@@ -17905,7 +17905,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a.json 1`] = `
 {
   "_id": "5e2a7c95-94af-4b23-8724-deb13853726a",
   "_outcomes": [
@@ -17938,7 +17938,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ForgottenUsername/nodes/Page Node - 5e2a7c95-94af-4b23-8724-deb13853726a/Attribute Collector - 9f1e8d94-4922-481b-9e14-212b66548900.json 1`] = `
 {
   "_id": "9f1e8d94-4922-481b-9e14-212b66548900",
   "_outcomes": [
@@ -17963,7 +17963,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
 {
   "_id": "FrodoTest",
   "_rev": "-1175854005",
@@ -18077,7 +18077,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
 {
   "_id": "e2c39477-847a-4df2-9c5d-b449a752638b",
   "_outcomes": [
@@ -18111,7 +18111,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
 {
   "_id": "bf153f37-83dd-4f39-aa0c-74135430242e",
   "_outcomes": [
@@ -18137,7 +18137,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
 {
   "_id": "278bf084-9eea-46fe-8ce9-2600dde3b046",
   "_outcomes": [
@@ -18182,7 +18182,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
 {
   "_id": "804e6a68-1720-442b-926a-007e90f02782",
   "_outcomes": [
@@ -18203,7 +18203,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
 {
   "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
   "_outcomes": [
@@ -18231,7 +18231,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
 {
   "_id": "7a351800-fb7e-4145-903c-388554747556",
   "_outcomes": [
@@ -18253,7 +18253,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
 {
   "_id": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
   "_outcomes": [
@@ -18292,7 +18292,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
 {
   "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
   "_outcomes": [
@@ -18313,7 +18313,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
 {
   "_id": "038f9b2a-36b2-489b-9e03-386c9a62ea21",
   "_outcomes": [
@@ -18341,7 +18341,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
 {
   "_id": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
   "_outcomes": [
@@ -18380,7 +18380,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
 {
   "_id": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
   "_outcomes": [
@@ -18408,7 +18408,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
 {
   "_id": "fc7e47cd-c679-4211-8e05-a36654f23c67",
   "_outcomes": [
@@ -18446,7 +18446,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTestJourney13/FrodoTestJourney13.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTestJourney13/FrodoTestJourney13.json 1`] = `
 {
   "_id": "FrodoTestJourney13",
   "_rev": "1535600290",
@@ -18501,7 +18501,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c.json 1`] = `
 {
   "_id": "c847e93b-afa3-4d20-9a15-f75404ec353c",
   "_outcomes": [
@@ -18536,7 +18536,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Password - e4c5071f-acc8-47c9-b097-5c4144170742.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Password - e4c5071f-acc8-47c9-b097-5c4144170742.json 1`] = `
 {
   "_id": "e4c5071f-acc8-47c9-b097-5c4144170742",
   "_outcomes": [
@@ -18557,7 +18557,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Username - 64dceffc-2db4-468b-96d1-491824e037a2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTestJourney13/nodes/Login Page - c847e93b-afa3-4d20-9a15-f75404ec353c/Username - 64dceffc-2db4-468b-96d1-491824e037a2.json 1`] = `
 {
   "_id": "64dceffc-2db4-468b-96d1-491824e037a2",
   "_outcomes": [
@@ -18580,7 +18580,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/FrodoTestJourney13/nodes/Validate Credentials - bdca20b7-ada8-4906-8b3a-e59c313f6491.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/FrodoTestJourney13/nodes/Validate Credentials - bdca20b7-ada8-4906-8b3a-e59c313f6491.json 1`] = `
 {
   "_id": "bdca20b7-ada8-4906-8b3a-e59c313f6491",
   "_outcomes": [
@@ -18603,7 +18603,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/Login.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/Login.json 1`] = `
 {
   "_id": "Login",
   "_rev": "384176338",
@@ -18703,7 +18703,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Account Lockout - 51e8c4c1-3509-4635-90e6-d2cc31c4a6a5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Account Lockout - 51e8c4c1-3509-4635-90e6-d2cc31c4a6a5.json 1`] = `
 {
   "_id": "51e8c4c1-3509-4635-90e6-d2cc31c4a6a5",
   "_outcomes": [
@@ -18723,7 +18723,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Identity Store Decision - 7f0c2aee-8c74-4d02-82a6-9d4ed9d11708.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Identity Store Decision - 7f0c2aee-8c74-4d02-82a6-9d4ed9d11708.json 1`] = `
 {
   "_id": "7f0c2aee-8c74-4d02-82a6-9d4ed9d11708",
   "_outcomes": [
@@ -18761,7 +18761,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Increment Login Count - bba3e0d8-8525-4e82-bf48-ac17f7988917.json 1`] = `
 {
   "_id": "bba3e0d8-8525-4e82-bf48-ac17f7988917",
   "_outcomes": [
@@ -18781,7 +18781,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Inner Tree Evaluator - 33b24514-3e50-4180-8f08-ab6f4e51b07e.json 1`] = `
 {
   "_id": "33b24514-3e50-4180-8f08-ab6f4e51b07e",
   "_outcomes": [
@@ -18806,7 +18806,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8.json 1`] = `
 {
   "_id": "a12bc72f-ad97-4f1e-a789-a1fa3dd566c8",
   "_outcomes": [
@@ -18845,7 +18845,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Password - 0c80c39b-4813-4e67-b4fb-5a0bba85f994.json 1`] = `
 {
   "_id": "0c80c39b-4813-4e67-b4fb-5a0bba85f994",
   "_outcomes": [
@@ -18866,7 +18866,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Page Node - a12bc72f-ad97-4f1e-a789-a1fa3dd566c8/Platform Username - 7354982f-57b6-4b04-9ddc-f1dd1e1e07d0.json 1`] = `
 {
   "_id": "7354982f-57b6-4b04-9ddc-f1dd1e1e07d0",
   "_outcomes": [
@@ -18888,7 +18888,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Login/nodes/Retry Limit Decision - 2119f332-0f69-4088-a7a1-6582bf0f2001.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Login/nodes/Retry Limit Decision - 2119f332-0f69-4088-a7a1-6582bf0f2001.json 1`] = `
 {
   "_id": "2119f332-0f69-4088-a7a1-6582bf0f2001",
   "_outcomes": [
@@ -18913,7 +18913,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/OrphanedTest/OrphanedTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/OrphanedTest/OrphanedTest.json 1`] = `
 {
   "_id": "OrphanedTest",
   "_rev": "680738111",
@@ -18961,7 +18961,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/OrphanedTest/nodes/Identity Store Decision - 343e745f-923a-43c4-8675-649a490fd0a3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/OrphanedTest/nodes/Identity Store Decision - 343e745f-923a-43c4-8675-649a490fd0a3.json 1`] = `
 {
   "_id": "343e745f-923a-43c4-8675-649a490fd0a3",
   "_outcomes": [
@@ -18999,7 +18999,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/P1P-Test.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/P1P-Test.json 1`] = `
 {
   "_id": "P1P-Test",
   "_rev": "946402521",
@@ -19164,7 +19164,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540.json 1`] = `
 {
   "_id": "f1cb199e-9e9a-4761-bacf-bc717ca6c540",
   "_outcomes": [
@@ -19195,7 +19195,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540/Debug - de8fa10c-f4cc-44b7-b675-cdc75dcc600f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Exceeds Score Threshold - f1cb199e-9e9a-4761-bacf-bc717ca6c540/Debug - de8fa10c-f4cc-44b7-b675-cdc75dcc600f.json 1`] = `
 {
   "_id": "de8fa10c-f4cc-44b7-b675-cdc75dcc600f",
   "_outcomes": [
@@ -19219,7 +19219,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/FAILED - e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/FAILED - e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece.json 1`] = `
 {
   "_id": "e5f7bd1f-8dbb-4fb2-ae54-1e09047e8ece",
   "_outcomes": [
@@ -19239,7 +19239,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939.json 1`] = `
 {
   "_id": "084c3d2d-7d47-4f2e-81d1-57961d496939",
   "_outcomes": [
@@ -19270,7 +19270,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939/Debug - 2c8f0d12-c373-4a25-9a30-b3184888d163.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/High - 084c3d2d-7d47-4f2e-81d1-57961d496939/Debug - 2c8f0d12-c373-4a25-9a30-b3184888d163.json 1`] = `
 {
   "_id": "2c8f0d12-c373-4a25-9a30-b3184888d163",
   "_outcomes": [
@@ -19294,7 +19294,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Identity Store Decision - ef1929b1-255e-446e-a597-7d7a3c4bf63f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Identity Store Decision - ef1929b1-255e-446e-a597-7d7a3c4bf63f.json 1`] = `
 {
   "_id": "ef1929b1-255e-446e-a597-7d7a3c4bf63f",
   "_outcomes": [
@@ -19332,7 +19332,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Initialize Signals SDK - 6632fe0f-6395-4cc1-88d8-c9ca4a9061b6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Initialize Signals SDK - 6632fe0f-6395-4cc1-88d8-c9ca4a9061b6.json 1`] = `
 {
   "_id": "6632fe0f-6395-4cc1-88d8-c9ca4a9061b6",
   "_outcomes": [
@@ -19366,7 +19366,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5.json 1`] = `
 {
   "_id": "4fdf4255-0236-4527-ae6d-d10d2c0ee8d5",
   "_outcomes": [
@@ -19401,7 +19401,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Password - 6a428d9f-a221-44f6-a5c6-c6981f90f9fc.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Password - 6a428d9f-a221-44f6-a5c6-c6981f90f9fc.json 1`] = `
 {
   "_id": "6a428d9f-a221-44f6-a5c6-c6981f90f9fc",
   "_outcomes": [
@@ -19422,7 +19422,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Username - f74e82e2-72ab-4a1a-9188-655622794a37.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Login Page - 4fdf4255-0236-4527-ae6d-d10d2c0ee8d5/Username - f74e82e2-72ab-4a1a-9188-655622794a37.json 1`] = `
 {
   "_id": "f74e82e2-72ab-4a1a-9188-655622794a37",
   "_outcomes": [
@@ -19445,7 +19445,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4.json 1`] = `
 {
   "_id": "00a4835b-6e99-4938-9bb8-50d5569a68d4",
   "_outcomes": [
@@ -19476,7 +19476,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4/Debug - 843dd22b-a890-461b-9a16-33d8bd871396.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Low - 00a4835b-6e99-4938-9bb8-50d5569a68d4/Debug - 843dd22b-a890-461b-9a16-33d8bd871396.json 1`] = `
 {
   "_id": "843dd22b-a890-461b-9a16-33d8bd871396",
   "_outcomes": [
@@ -19500,7 +19500,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394.json 1`] = `
 {
   "_id": "37f190ea-fa18-4d44-941b-4e5ac325f394",
   "_outcomes": [
@@ -19531,7 +19531,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394/Debug - 8835fe59-3988-4121-8b15-ad16a7049d7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/Medium - 37f190ea-fa18-4d44-941b-4e5ac325f394/Debug - 8835fe59-3988-4121-8b15-ad16a7049d7a.json 1`] = `
 {
   "_id": "8835fe59-3988-4121-8b15-ad16a7049d7a",
   "_outcomes": [
@@ -19555,7 +19555,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576.json 1`] = `
 {
   "_id": "a0059e3b-de04-4f0f-a5ed-49525d1da576",
   "_outcomes": [
@@ -19586,7 +19586,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576/Debug - c1804982-10dc-4668-bd53-909107cc4039.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/P1P Client Error - a0059e3b-de04-4f0f-a5ed-49525d1da576/Debug - c1804982-10dc-4668-bd53-909107cc4039.json 1`] = `
 {
   "_id": "c1804982-10dc-4668-bd53-909107cc4039",
   "_outcomes": [
@@ -19610,7 +19610,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92.json 1`] = `
 {
   "_id": "8120e613-dee8-42b4-9668-71b8a25c1c92",
   "_outcomes": [
@@ -19641,7 +19641,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92/Debug - 52ab689c-491b-4117-b729-ff590b5d1f61.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/P1P Failure - 8120e613-dee8-42b4-9668-71b8a25c1c92/Debug - 52ab689c-491b-4117-b729-ff590b5d1f61.json 1`] = `
 {
   "_id": "52ab689c-491b-4117-b729-ff590b5d1f61",
   "_outcomes": [
@@ -19665,7 +19665,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/P1P Risk Decision - df827cfc-6e2d-4b9f-a8b1-d92c2910eb07.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/P1P Risk Decision - df827cfc-6e2d-4b9f-a8b1-d92c2910eb07.json 1`] = `
 {
   "_id": "df827cfc-6e2d-4b9f-a8b1-d92c2910eb07",
   "_outcomes": [
@@ -19719,7 +19719,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/P1P-Test/nodes/SUCCESS - 167b87dd-a97c-4e3b-82ba-581090fd7863.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/P1P-Test/nodes/SUCCESS - 167b87dd-a97c-4e3b-82ba-581090fd7863.json 1`] = `
 {
   "_id": "167b87dd-a97c-4e3b-82ba-581090fd7863",
   "_outcomes": [
@@ -19739,7 +19739,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/PrestonTest/PrestonTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/PrestonTest/PrestonTest.json 1`] = `
 {
   "_id": "PrestonTest",
   "_rev": "-2075247621",
@@ -19759,7 +19759,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json 1`] = `
 {
   "_id": "ProgressiveProfile",
   "_rev": "260694535",
@@ -19836,7 +19836,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json 1`] = `
 {
   "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
   "_outcomes": [
@@ -19862,7 +19862,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json 1`] = `
 {
   "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
   "_outcomes": [
@@ -19893,7 +19893,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json 1`] = `
 {
   "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
   "_outcomes": [
@@ -19919,7 +19919,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json 1`] = `
 {
   "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
   "_outcomes": [
@@ -19946,7 +19946,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json 1`] = `
 {
   "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
   "_outcomes": [
@@ -19971,7 +19971,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/RadioChoice/RadioChoice.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/RadioChoice/RadioChoice.json 1`] = `
 {
   "_id": "RadioChoice",
   "_rev": "1819878661",
@@ -20016,7 +20016,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e.json 1`] = `
 {
   "_id": "5d6cd20e-5074-43de-8832-fddd95fb078e",
   "_outcomes": [
@@ -20054,7 +20054,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e/Choice Collector - a566e474-99f3-46e4-9e70-682402bfaa84.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/RadioChoice/nodes/Page Node - 5d6cd20e-5074-43de-8832-fddd95fb078e/Choice Collector - a566e474-99f3-46e4-9e70-682402bfaa84.json 1`] = `
 {
   "_id": "a566e474-99f3-46e4-9e70-682402bfaa84",
   "_outcomes": [
@@ -20088,7 +20088,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/Registration.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/Registration.json 1`] = `
 {
   "_id": "Registration",
   "_rev": "388671950",
@@ -20163,7 +20163,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json 1`] = `
 {
   "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
   "_outcomes": [
@@ -20187,7 +20187,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Email Suspend Node - 466f8b54-07fb-4e31-a11d-a6842618cc37.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Email Suspend Node - 466f8b54-07fb-4e31-a11d-a6842618cc37.json 1`] = `
 {
   "_id": "466f8b54-07fb-4e31-a11d-a6842618cc37",
   "_outcomes": [
@@ -20213,7 +20213,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json 1`] = `
 {
   "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
   "_outcomes": [
@@ -20233,7 +20233,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json 1`] = `
 {
   "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
   "_outcomes": [
@@ -20291,7 +20291,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json 1`] = `
 {
   "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
   "_outcomes": [
@@ -20310,7 +20310,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json 1`] = `
 {
   "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
   "_outcomes": [
@@ -20339,7 +20339,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json 1`] = `
 {
   "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
   "_outcomes": [
@@ -20362,7 +20362,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json 1`] = `
 {
   "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
   "_outcomes": [
@@ -20383,7 +20383,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json 1`] = `
 {
   "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
   "_outcomes": [
@@ -20405,7 +20405,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/ResetPassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/ResetPassword.json 1`] = `
 {
   "_id": "ResetPassword",
   "_rev": "1685804267",
@@ -20491,7 +20491,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/nodes/Email Suspend Node - 06c97be5-7fdd-4739-aea1-ecc7fe082865.json 1`] = `
 {
   "_id": "06c97be5-7fdd-4739-aea1-ecc7fe082865",
   "_outcomes": [
@@ -20517,7 +20517,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/nodes/Identify Existing User - 21b8ddf3-0203-4ae1-ab05-51cf3a3a707a.json 1`] = `
 {
   "_id": "21b8ddf3-0203-4ae1-ab05-51cf3a3a707a",
   "_outcomes": [
@@ -20542,7 +20542,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b.json 1`] = `
 {
   "_id": "cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b",
   "_outcomes": [
@@ -20575,7 +20575,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/nodes/Page Node - cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b/Attribute Collector - 276afa7c-a680-4cf4-a5f6-d6c78191f5c9.json 1`] = `
 {
   "_id": "276afa7c-a680-4cf4-a5f6-d6c78191f5c9",
   "_outcomes": [
@@ -20600,7 +20600,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c.json 1`] = `
 {
   "_id": "e4c752f9-c625-48c9-9644-a58802fa9e9c",
   "_outcomes": [
@@ -20633,7 +20633,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/nodes/Page Node - e4c752f9-c625-48c9-9644-a58802fa9e9c/Platform Password - 009c19c8-9572-47bb-adb2-1f092c559a43.json 1`] = `
 {
   "_id": "009c19c8-9572-47bb-adb2-1f092c559a43",
   "_outcomes": [
@@ -20654,7 +20654,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/ResetPassword/nodes/Patch Object - 989f0bf8-a328-4217-b82b-5275d79ca8bd.json 1`] = `
 {
   "_id": "989f0bf8-a328-4217-b82b-5275d79ca8bd",
   "_outcomes": [
@@ -20681,7 +20681,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/SocialProviderHandler/SocialProviderHandler.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/SocialProviderHandler/SocialProviderHandler.json 1`] = `
 {
   "_id": "SocialProviderHandler",
   "_rev": "-2033719727",
@@ -20737,7 +20737,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/SocialProviderHandler/nodes/Legacy Social Provider Handler Node - 3af612be-340e-4dc9-80fb-62319a187b74.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/SocialProviderHandler/nodes/Legacy Social Provider Handler Node - 3af612be-340e-4dc9-80fb-62319a187b74.json 1`] = `
 {
   "_id": "3af612be-340e-4dc9-80fb-62319a187b74",
   "_outcomes": [
@@ -20765,7 +20765,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/SocialProviderHandler/nodes/Social Provider Handler Node - e15c8efe-b7a7-42bf-845e-861a9419af32.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/SocialProviderHandler/nodes/Social Provider Handler Node - e15c8efe-b7a7-42bf-845e-861a9419af32.json 1`] = `
 {
   "_id": "e15c8efe-b7a7-42bf-845e-861a9419af32",
   "_outcomes": [
@@ -20798,7 +20798,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/UpdatePassword.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/UpdatePassword.json 1`] = `
 {
   "_id": "UpdatePassword",
   "_rev": "-1098606408",
@@ -20905,7 +20905,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Attribute Present Decision - 0f0904e6-1da3-4cdb-9abf-0d2545016fab.json 1`] = `
 {
   "_id": "0f0904e6-1da3-4cdb-9abf-0d2545016fab",
   "_outcomes": [
@@ -20930,7 +20930,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Data Store Decision - 7d1deabe-cd98-49c8-943f-ca12305775f3.json 1`] = `
 {
   "_id": "7d1deabe-cd98-49c8-943f-ca12305775f3",
   "_outcomes": [
@@ -20953,7 +20953,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Email Suspend Node - a3d97b53-e38a-4b24-aed0-a021050eb744.json 1`] = `
 {
   "_id": "a3d97b53-e38a-4b24-aed0-a021050eb744",
   "_outcomes": [
@@ -20979,7 +20979,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Get Session Data - d1b79744-493a-44fe-bc26-7d324a8caa4e.json 1`] = `
 {
   "_id": "d1b79744-493a-44fe-bc26-7d324a8caa4e",
   "_outcomes": [
@@ -21000,7 +21000,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42.json 1`] = `
 {
   "_id": "20237b34-26cb-4a0b-958f-abb422290d42",
   "_outcomes": [
@@ -21033,7 +21033,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Page Node - 20237b34-26cb-4a0b-958f-abb422290d42/Platform Password - fe2962fc-4db3-4066-8624-553649afc438.json 1`] = `
 {
   "_id": "fe2962fc-4db3-4066-8624-553649afc438",
   "_outcomes": [
@@ -21054,7 +21054,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3.json 1`] = `
 {
   "_id": "d018fcd1-4e22-4160-8c41-63bee51c9cb3",
   "_outcomes": [
@@ -21087,7 +21087,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Page Node - d018fcd1-4e22-4160-8c41-63bee51c9cb3/Platform Password - 21a99653-a7a7-47ee-b650-f493a84bba09.json 1`] = `
 {
   "_id": "21a99653-a7a7-47ee-b650-f493a84bba09",
   "_outcomes": [
@@ -21108,7 +21108,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/UpdatePassword/nodes/Patch Object - 3990ce1f-cce6-435b-ae1c-f138e89411c1.json 1`] = `
 {
   "_id": "3990ce1f-cce6-435b-ae1c-f138e89411c1",
   "_outcomes": [
@@ -21137,7 +21137,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j00/j00.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j00/j00.json 1`] = `
 {
   "_id": "j00",
   "_rev": "2108856917",
@@ -21233,7 +21233,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j00/nodes/debug - ba503a1e-633e-4d0d-ba18-c9a9b1105b5b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j00/nodes/debug - ba503a1e-633e-4d0d-ba18-c9a9b1105b5b.json 1`] = `
 {
   "_id": "ba503a1e-633e-4d0d-ba18-c9a9b1105b5b",
   "_outcomes": [
@@ -21262,7 +21262,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j00/nodes/level - 3c1e8d61-0c48-44ba-86dc-52e9555b6aeb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j00/nodes/level - 3c1e8d61-0c48-44ba-86dc-52e9555b6aeb.json 1`] = `
 {
   "_id": "3c1e8d61-0c48-44ba-86dc-52e9555b6aeb",
   "_outcomes": [
@@ -21291,7 +21291,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j00/nodes/level - 39b48197-f4be-42b9-800a-866587b4b9b5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j00/nodes/level - 39b48197-f4be-42b9-800a-866587b4b9b5.json 1`] = `
 {
   "_id": "39b48197-f4be-42b9-800a-866587b4b9b5",
   "_outcomes": [
@@ -21320,7 +21320,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j00/nodes/mode - 513a2ab4-f0b8-4f94-b840-6fe14796cc84.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j00/nodes/mode - 513a2ab4-f0b8-4f94-b840-6fe14796cc84.json 1`] = `
 {
   "_id": "513a2ab4-f0b8-4f94-b840-6fe14796cc84",
   "_outcomes": [
@@ -21368,7 +21368,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j00/nodes/shared - 01d3785f-7fb4-44a7-9458-72c380a9818f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j00/nodes/shared - 01d3785f-7fb4-44a7-9458-72c380a9818f.json 1`] = `
 {
   "_id": "01d3785f-7fb4-44a7-9458-72c380a9818f",
   "_outcomes": [
@@ -21397,7 +21397,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j00/nodes/shared - d17ffaa1-2c61-4abd-9bb1-2559160d0a5c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j00/nodes/shared - d17ffaa1-2c61-4abd-9bb1-2559160d0a5c.json 1`] = `
 {
   "_id": "d17ffaa1-2c61-4abd-9bb1-2559160d0a5c",
   "_outcomes": [
@@ -21426,7 +21426,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j01/j01.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j01/j01.json 1`] = `
 {
   "_id": "j01",
   "_rev": "-1240740730",
@@ -21523,7 +21523,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j01/nodes/level - bdfbe97c-1ff4-4162-85bc-47f6f14b2c66.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j01/nodes/level - bdfbe97c-1ff4-4162-85bc-47f6f14b2c66.json 1`] = `
 {
   "_id": "bdfbe97c-1ff4-4162-85bc-47f6f14b2c66",
   "_outcomes": [
@@ -21552,7 +21552,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j01/nodes/level - e92d5139-b8a6-43dc-9b13-95ba1d0dc53c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j01/nodes/level - e92d5139-b8a6-43dc-9b13-95ba1d0dc53c.json 1`] = `
 {
   "_id": "e92d5139-b8a6-43dc-9b13-95ba1d0dc53c",
   "_outcomes": [
@@ -21581,7 +21581,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j01/nodes/mode - f129f0df-b49e-453b-97fb-db508e3893ce.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j01/nodes/mode - f129f0df-b49e-453b-97fb-db508e3893ce.json 1`] = `
 {
   "_id": "f129f0df-b49e-453b-97fb-db508e3893ce",
   "_outcomes": [
@@ -21629,7 +21629,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j01/nodes/nest - bb1e96af-f316-4eb0-b1c6-36b3f1af9e35.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j01/nodes/nest - bb1e96af-f316-4eb0-b1c6-36b3f1af9e35.json 1`] = `
 {
   "_id": "bb1e96af-f316-4eb0-b1c6-36b3f1af9e35",
   "_outcomes": [
@@ -21654,7 +21654,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j01/nodes/shared - 89ce5d57-82fa-4d58-8d15-0329f7dbd7e7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j01/nodes/shared - 89ce5d57-82fa-4d58-8d15-0329f7dbd7e7.json 1`] = `
 {
   "_id": "89ce5d57-82fa-4d58-8d15-0329f7dbd7e7",
   "_outcomes": [
@@ -21683,7 +21683,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j01/nodes/shared - 6674b4ac-dd89-4e13-9440-6f81194e3a22.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j01/nodes/shared - 6674b4ac-dd89-4e13-9440-6f81194e3a22.json 1`] = `
 {
   "_id": "6674b4ac-dd89-4e13-9440-6f81194e3a22",
   "_outcomes": [
@@ -21712,7 +21712,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j02/j02.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j02/j02.json 1`] = `
 {
   "_id": "j02",
   "_rev": "1006720127",
@@ -21809,7 +21809,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j02/nodes/level - 2dbd2d37-c659-48cf-8357-c9fc1166e3a7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j02/nodes/level - 2dbd2d37-c659-48cf-8357-c9fc1166e3a7.json 1`] = `
 {
   "_id": "2dbd2d37-c659-48cf-8357-c9fc1166e3a7",
   "_outcomes": [
@@ -21838,7 +21838,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j02/nodes/level - 4416aff7-3ebd-47e6-9831-c2f6bbe3ae24.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j02/nodes/level - 4416aff7-3ebd-47e6-9831-c2f6bbe3ae24.json 1`] = `
 {
   "_id": "4416aff7-3ebd-47e6-9831-c2f6bbe3ae24",
   "_outcomes": [
@@ -21867,7 +21867,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j02/nodes/mode - 59b06306-a886-443d-92df-7a27a60c394e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j02/nodes/mode - 59b06306-a886-443d-92df-7a27a60c394e.json 1`] = `
 {
   "_id": "59b06306-a886-443d-92df-7a27a60c394e",
   "_outcomes": [
@@ -21915,7 +21915,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j02/nodes/nest - 56899fef-92a1-4f2a-ade3-973c81eb3af1.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j02/nodes/nest - 56899fef-92a1-4f2a-ade3-973c81eb3af1.json 1`] = `
 {
   "_id": "56899fef-92a1-4f2a-ade3-973c81eb3af1",
   "_outcomes": [
@@ -21940,7 +21940,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j02/nodes/shared - cbb3d506-b267-4b99-9edd-363e90aac997.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j02/nodes/shared - cbb3d506-b267-4b99-9edd-363e90aac997.json 1`] = `
 {
   "_id": "cbb3d506-b267-4b99-9edd-363e90aac997",
   "_outcomes": [
@@ -21969,7 +21969,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j02/nodes/shared - e0983ead-4918-48f6-858d-9aff0f03759c.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j02/nodes/shared - e0983ead-4918-48f6-858d-9aff0f03759c.json 1`] = `
 {
   "_id": "e0983ead-4918-48f6-858d-9aff0f03759c",
   "_outcomes": [
@@ -21998,7 +21998,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j03/j03.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j03/j03.json 1`] = `
 {
   "_id": "j03",
   "_rev": "1203078238",
@@ -22095,7 +22095,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j03/nodes/level - 3a92300d-6d64-451d-8156-30cb51781026.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j03/nodes/level - 3a92300d-6d64-451d-8156-30cb51781026.json 1`] = `
 {
   "_id": "3a92300d-6d64-451d-8156-30cb51781026",
   "_outcomes": [
@@ -22124,7 +22124,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j03/nodes/level - 35a4f94b-c895-46b9-bc0a-93cf59233759.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j03/nodes/level - 35a4f94b-c895-46b9-bc0a-93cf59233759.json 1`] = `
 {
   "_id": "35a4f94b-c895-46b9-bc0a-93cf59233759",
   "_outcomes": [
@@ -22153,7 +22153,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j03/nodes/mode - e0cfbd13-6f1e-4924-9d2d-0f7c23507172.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j03/nodes/mode - e0cfbd13-6f1e-4924-9d2d-0f7c23507172.json 1`] = `
 {
   "_id": "e0cfbd13-6f1e-4924-9d2d-0f7c23507172",
   "_outcomes": [
@@ -22201,7 +22201,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j03/nodes/nest - bcb8c535-5ecd-4d3d-b970-26816de96bf2.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j03/nodes/nest - bcb8c535-5ecd-4d3d-b970-26816de96bf2.json 1`] = `
 {
   "_id": "bcb8c535-5ecd-4d3d-b970-26816de96bf2",
   "_outcomes": [
@@ -22226,7 +22226,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j03/nodes/shared - 6f9de973-9ed4-41f5-b43d-4036041e2b96.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j03/nodes/shared - 6f9de973-9ed4-41f5-b43d-4036041e2b96.json 1`] = `
 {
   "_id": "6f9de973-9ed4-41f5-b43d-4036041e2b96",
   "_outcomes": [
@@ -22255,7 +22255,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j03/nodes/shared - fae7424e-13c9-45bd-b3a2-045773671a3f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j03/nodes/shared - fae7424e-13c9-45bd-b3a2-045773671a3f.json 1`] = `
 {
   "_id": "fae7424e-13c9-45bd-b3a2-045773671a3f",
   "_outcomes": [
@@ -22284,7 +22284,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j04/j04.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j04/j04.json 1`] = `
 {
   "_id": "j04",
   "_rev": "125884797",
@@ -22381,7 +22381,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j04/nodes/level - 69ae8ec1-de43-44ac-98e5-733db80ac176.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j04/nodes/level - 69ae8ec1-de43-44ac-98e5-733db80ac176.json 1`] = `
 {
   "_id": "69ae8ec1-de43-44ac-98e5-733db80ac176",
   "_outcomes": [
@@ -22410,7 +22410,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j04/nodes/level - d10104e9-1f8d-4da6-a110-28d879d13959.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j04/nodes/level - d10104e9-1f8d-4da6-a110-28d879d13959.json 1`] = `
 {
   "_id": "d10104e9-1f8d-4da6-a110-28d879d13959",
   "_outcomes": [
@@ -22439,7 +22439,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j04/nodes/mode - 040b6c89-313b-4664-92e0-6732017384b8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j04/nodes/mode - 040b6c89-313b-4664-92e0-6732017384b8.json 1`] = `
 {
   "_id": "040b6c89-313b-4664-92e0-6732017384b8",
   "_outcomes": [
@@ -22487,7 +22487,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j04/nodes/nest - 00e75aa0-2f9b-4895-9257-d515286fd64b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j04/nodes/nest - 00e75aa0-2f9b-4895-9257-d515286fd64b.json 1`] = `
 {
   "_id": "00e75aa0-2f9b-4895-9257-d515286fd64b",
   "_outcomes": [
@@ -22512,7 +22512,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j04/nodes/shared - 9603ef52-30f0-4ddc-b3c0-28dac83c7bdb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j04/nodes/shared - 9603ef52-30f0-4ddc-b3c0-28dac83c7bdb.json 1`] = `
 {
   "_id": "9603ef52-30f0-4ddc-b3c0-28dac83c7bdb",
   "_outcomes": [
@@ -22541,7 +22541,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j04/nodes/shared - f5c317ce-fabd-4a10-9907-c71cea037844.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j04/nodes/shared - f5c317ce-fabd-4a10-9907-c71cea037844.json 1`] = `
 {
   "_id": "f5c317ce-fabd-4a10-9907-c71cea037844",
   "_outcomes": [
@@ -22570,7 +22570,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j05/j05.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j05/j05.json 1`] = `
 {
   "_id": "j05",
   "_rev": "-1683838231",
@@ -22667,7 +22667,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j05/nodes/level - 3c106772-ace7-4808-8f3a-9840de8f67f0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j05/nodes/level - 3c106772-ace7-4808-8f3a-9840de8f67f0.json 1`] = `
 {
   "_id": "3c106772-ace7-4808-8f3a-9840de8f67f0",
   "_outcomes": [
@@ -22696,7 +22696,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j05/nodes/level - e90ae257-c279-46e0-9b43-5ecd89784d77.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j05/nodes/level - e90ae257-c279-46e0-9b43-5ecd89784d77.json 1`] = `
 {
   "_id": "e90ae257-c279-46e0-9b43-5ecd89784d77",
   "_outcomes": [
@@ -22725,7 +22725,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j05/nodes/mode - 622179cb-98f1-484a-820d-9a0df6e45e95.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j05/nodes/mode - 622179cb-98f1-484a-820d-9a0df6e45e95.json 1`] = `
 {
   "_id": "622179cb-98f1-484a-820d-9a0df6e45e95",
   "_outcomes": [
@@ -22773,7 +22773,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j05/nodes/nest - f17ecb7c-abc3-4523-9943-4cbdd90305cb.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j05/nodes/nest - f17ecb7c-abc3-4523-9943-4cbdd90305cb.json 1`] = `
 {
   "_id": "f17ecb7c-abc3-4523-9943-4cbdd90305cb",
   "_outcomes": [
@@ -22798,7 +22798,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j05/nodes/shared - 11f1c31c-50a9-4717-8213-420f6932481f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j05/nodes/shared - 11f1c31c-50a9-4717-8213-420f6932481f.json 1`] = `
 {
   "_id": "11f1c31c-50a9-4717-8213-420f6932481f",
   "_outcomes": [
@@ -22827,7 +22827,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j05/nodes/shared - a0782616-84b7-4bf5-87ed-a01fb3018563.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j05/nodes/shared - a0782616-84b7-4bf5-87ed-a01fb3018563.json 1`] = `
 {
   "_id": "a0782616-84b7-4bf5-87ed-a01fb3018563",
   "_outcomes": [
@@ -22856,7 +22856,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j06/j06.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j06/j06.json 1`] = `
 {
   "_id": "j06",
   "_rev": "-1311195611",
@@ -22953,7 +22953,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j06/nodes/level - 2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j06/nodes/level - 2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3.json 1`] = `
 {
   "_id": "2de08e9e-bf7b-4fa1-8265-59a8e4a3f7c3",
   "_outcomes": [
@@ -22982,7 +22982,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j06/nodes/level - fe8f27df-8a27-4d88-9196-834ce398b2b7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j06/nodes/level - fe8f27df-8a27-4d88-9196-834ce398b2b7.json 1`] = `
 {
   "_id": "fe8f27df-8a27-4d88-9196-834ce398b2b7",
   "_outcomes": [
@@ -23011,7 +23011,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j06/nodes/mode - 44b8651c-7c1e-41f1-b9a6-2e441b0ce05a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j06/nodes/mode - 44b8651c-7c1e-41f1-b9a6-2e441b0ce05a.json 1`] = `
 {
   "_id": "44b8651c-7c1e-41f1-b9a6-2e441b0ce05a",
   "_outcomes": [
@@ -23059,7 +23059,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j06/nodes/nest - 409c251f-c23b-411d-9009-d3b3d26d1b90.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j06/nodes/nest - 409c251f-c23b-411d-9009-d3b3d26d1b90.json 1`] = `
 {
   "_id": "409c251f-c23b-411d-9009-d3b3d26d1b90",
   "_outcomes": [
@@ -23084,7 +23084,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j06/nodes/shared - 1d59caff-243c-45bd-b7d0-6dcc563989c5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j06/nodes/shared - 1d59caff-243c-45bd-b7d0-6dcc563989c5.json 1`] = `
 {
   "_id": "1d59caff-243c-45bd-b7d0-6dcc563989c5",
   "_outcomes": [
@@ -23113,7 +23113,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j06/nodes/shared - da878771-421c-463f-aad7-4d5f2ad5e59a.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j06/nodes/shared - da878771-421c-463f-aad7-4d5f2ad5e59a.json 1`] = `
 {
   "_id": "da878771-421c-463f-aad7-4d5f2ad5e59a",
   "_outcomes": [
@@ -23142,7 +23142,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j07/j07.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j07/j07.json 1`] = `
 {
   "_id": "j07",
   "_rev": "-1925267397",
@@ -23239,7 +23239,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j07/nodes/level - d90dd9f8-8b12-4e90-abaf-228ecc0174a7.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j07/nodes/level - d90dd9f8-8b12-4e90-abaf-228ecc0174a7.json 1`] = `
 {
   "_id": "d90dd9f8-8b12-4e90-abaf-228ecc0174a7",
   "_outcomes": [
@@ -23268,7 +23268,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j07/nodes/level - f2fe740c-cd75-460a-8baa-fe4b52ecc947.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j07/nodes/level - f2fe740c-cd75-460a-8baa-fe4b52ecc947.json 1`] = `
 {
   "_id": "f2fe740c-cd75-460a-8baa-fe4b52ecc947",
   "_outcomes": [
@@ -23297,7 +23297,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j07/nodes/mode - 13b12fe6-cf53-46a4-a83d-0a3c1fda814f.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j07/nodes/mode - 13b12fe6-cf53-46a4-a83d-0a3c1fda814f.json 1`] = `
 {
   "_id": "13b12fe6-cf53-46a4-a83d-0a3c1fda814f",
   "_outcomes": [
@@ -23345,7 +23345,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j07/nodes/nest - e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j07/nodes/nest - e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9.json 1`] = `
 {
   "_id": "e62d7a4d-2012-4a2a-a6ef-d6a0e0d552d9",
   "_outcomes": [
@@ -23370,7 +23370,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j07/nodes/shared - ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j07/nodes/shared - ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0.json 1`] = `
 {
   "_id": "ac6ee166-73c0-4f73-b8db-4fe8ff6a25c0",
   "_outcomes": [
@@ -23399,7 +23399,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j07/nodes/shared - d9a06d3a-7e3f-4244-9a32-63ffa0d26e00.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j07/nodes/shared - d9a06d3a-7e3f-4244-9a32-63ffa0d26e00.json 1`] = `
 {
   "_id": "d9a06d3a-7e3f-4244-9a32-63ffa0d26e00",
   "_outcomes": [
@@ -23428,7 +23428,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j08/j08.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j08/j08.json 1`] = `
 {
   "_id": "j08",
   "_rev": "-282238685",
@@ -23525,7 +23525,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j08/nodes/level - 87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j08/nodes/level - 87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d.json 1`] = `
 {
   "_id": "87ced99b-bfa5-40d4-ba07-c8fc31f6cc6d",
   "_outcomes": [
@@ -23554,7 +23554,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j08/nodes/level - 8096649e-973e-4209-88ce-e1d87ae2bb96.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j08/nodes/level - 8096649e-973e-4209-88ce-e1d87ae2bb96.json 1`] = `
 {
   "_id": "8096649e-973e-4209-88ce-e1d87ae2bb96",
   "_outcomes": [
@@ -23583,7 +23583,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j08/nodes/mode - d429b2b5-b215-46a5-b239-4994df65cb8b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j08/nodes/mode - d429b2b5-b215-46a5-b239-4994df65cb8b.json 1`] = `
 {
   "_id": "d429b2b5-b215-46a5-b239-4994df65cb8b",
   "_outcomes": [
@@ -23631,7 +23631,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j08/nodes/nest - 66026170-5088-4fcd-a6c8-ed89d7a5c79d.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j08/nodes/nest - 66026170-5088-4fcd-a6c8-ed89d7a5c79d.json 1`] = `
 {
   "_id": "66026170-5088-4fcd-a6c8-ed89d7a5c79d",
   "_outcomes": [
@@ -23656,7 +23656,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j08/nodes/shared - 042b600b-71cb-45a8-93ae-a6f57b16a6e5.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j08/nodes/shared - 042b600b-71cb-45a8-93ae-a6f57b16a6e5.json 1`] = `
 {
   "_id": "042b600b-71cb-45a8-93ae-a6f57b16a6e5",
   "_outcomes": [
@@ -23685,7 +23685,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j08/nodes/shared - 948e21f4-c512-450a-9d42-e0d629217834.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j08/nodes/shared - 948e21f4-c512-450a-9d42-e0d629217834.json 1`] = `
 {
   "_id": "948e21f4-c512-450a-9d42-e0d629217834",
   "_outcomes": [
@@ -23714,7 +23714,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j09/j09.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j09/j09.json 1`] = `
 {
   "_id": "j09",
   "_rev": "-1396884723",
@@ -23811,7 +23811,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j09/nodes/level - 56b82371-0c61-4dc3-8d06-c1158415b8f9.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j09/nodes/level - 56b82371-0c61-4dc3-8d06-c1158415b8f9.json 1`] = `
 {
   "_id": "56b82371-0c61-4dc3-8d06-c1158415b8f9",
   "_outcomes": [
@@ -23840,7 +23840,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j09/nodes/level - bb294e05-6b6b-4478-b46f-b8d9e7711c66.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j09/nodes/level - bb294e05-6b6b-4478-b46f-b8d9e7711c66.json 1`] = `
 {
   "_id": "bb294e05-6b6b-4478-b46f-b8d9e7711c66",
   "_outcomes": [
@@ -23869,7 +23869,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j09/nodes/mode - 251f35c3-1a32-4520-be10-1f4af9600935.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j09/nodes/mode - 251f35c3-1a32-4520-be10-1f4af9600935.json 1`] = `
 {
   "_id": "251f35c3-1a32-4520-be10-1f4af9600935",
   "_outcomes": [
@@ -23917,7 +23917,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j09/nodes/nest - 6df24fdd-0b6c-4def-bf42-77af998f28b8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j09/nodes/nest - 6df24fdd-0b6c-4def-bf42-77af998f28b8.json 1`] = `
 {
   "_id": "6df24fdd-0b6c-4def-bf42-77af998f28b8",
   "_outcomes": [
@@ -23942,7 +23942,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j09/nodes/shared - 8c5e9cb5-471b-4dd6-b150-ecaaeda98195.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j09/nodes/shared - 8c5e9cb5-471b-4dd6-b150-ecaaeda98195.json 1`] = `
 {
   "_id": "8c5e9cb5-471b-4dd6-b150-ecaaeda98195",
   "_outcomes": [
@@ -23971,7 +23971,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j09/nodes/shared - f57cf53c-b4c6-48f7-84e8-91f535a2e8f8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j09/nodes/shared - f57cf53c-b4c6-48f7-84e8-91f535a2e8f8.json 1`] = `
 {
   "_id": "f57cf53c-b4c6-48f7-84e8-91f535a2e8f8",
   "_outcomes": [
@@ -24000,7 +24000,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j10/j10.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j10/j10.json 1`] = `
 {
   "_id": "j10",
   "_rev": "1630303400",
@@ -24097,7 +24097,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j10/nodes/level - 8d7d64ee-da20-461f-a2ca-206b7479dd67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j10/nodes/level - 8d7d64ee-da20-461f-a2ca-206b7479dd67.json 1`] = `
 {
   "_id": "8d7d64ee-da20-461f-a2ca-206b7479dd67",
   "_outcomes": [
@@ -24126,7 +24126,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j10/nodes/level - 300feda0-3248-49a9-b60f-01df802b2229.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j10/nodes/level - 300feda0-3248-49a9-b60f-01df802b2229.json 1`] = `
 {
   "_id": "300feda0-3248-49a9-b60f-01df802b2229",
   "_outcomes": [
@@ -24155,7 +24155,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j10/nodes/mode - c91d626e-1156-41bd-b1fb-d292f640fba6.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j10/nodes/mode - c91d626e-1156-41bd-b1fb-d292f640fba6.json 1`] = `
 {
   "_id": "c91d626e-1156-41bd-b1fb-d292f640fba6",
   "_outcomes": [
@@ -24203,7 +24203,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j10/nodes/nest - c7fcf7ae-1ab5-474b-b5b0-272e10468fbd.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j10/nodes/nest - c7fcf7ae-1ab5-474b-b5b0-272e10468fbd.json 1`] = `
 {
   "_id": "c7fcf7ae-1ab5-474b-b5b0-272e10468fbd",
   "_outcomes": [
@@ -24228,7 +24228,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j10/nodes/shared - 40afb384-e9b6-4dcb-acde-04de109474c8.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j10/nodes/shared - 40afb384-e9b6-4dcb-acde-04de109474c8.json 1`] = `
 {
   "_id": "40afb384-e9b6-4dcb-acde-04de109474c8",
   "_outcomes": [
@@ -24257,7 +24257,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/j10/nodes/shared - 97ef9d96-99e7-4d2d-b6c6-4177b5397ead.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/j10/nodes/shared - 97ef9d96-99e7-4d2d-b6c6-4177b5397ead.json 1`] = `
 {
   "_id": "97ef9d96-99e7-4d2d-b6c6-4177b5397ead",
   "_outcomes": [
@@ -24286,7 +24286,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style": testDir12/realms/alpha/journeys/test/test.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style": ConfigJourneytestDir2/realms/alpha/journeys/test/test.json 1`] = `
 {
   "_id": "test",
   "_rev": "1505940492",
@@ -24316,11 +24316,11 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style" 1`] = `0`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style" 1`] = `0`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style" 2`] = `""`;
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style" 2`] = `""`;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/FrodoTest.json 1`] = `
 {
   "_id": "FrodoTest",
   "_rev": "-1175854005",
@@ -24434,7 +24434,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Check Username - e2c39477-847a-4df2-9c5d-b449a752638b.json 1`] = `
 {
   "_id": "e2c39477-847a-4df2-9c5d-b449a752638b",
   "_outcomes": [
@@ -24468,7 +24468,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Email Template Node - bf153f37-83dd-4f39-aa0c-74135430242e.json 1`] = `
 {
   "_id": "bf153f37-83dd-4f39-aa0c-74135430242e",
   "_outcomes": [
@@ -24494,7 +24494,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046.json 1`] = `
 {
   "_id": "278bf084-9eea-46fe-8ce9-2600dde3b046",
   "_outcomes": [
@@ -24539,7 +24539,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Password - 804e6a68-1720-442b-926a-007e90f02782.json 1`] = `
 {
   "_id": "804e6a68-1720-442b-926a-007e90f02782",
   "_outcomes": [
@@ -24560,7 +24560,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Select IDP - 228a44d5-fd78-4278-8999-fdd470ea7ebf.json 1`] = `
 {
   "_id": "228a44d5-fd78-4278-8999-fdd470ea7ebf",
   "_outcomes": [
@@ -24588,7 +24588,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Login Page - 278bf084-9eea-46fe-8ce9-2600dde3b046/Username - 7a351800-fb7e-4145-903c-388554747556.json 1`] = `
 {
   "_id": "7a351800-fb7e-4145-903c-388554747556",
   "_outcomes": [
@@ -24610,7 +24610,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3.json 1`] = `
 {
   "_id": "731c5810-020b-45c8-a7fc-3c21903ae2b3",
   "_outcomes": [
@@ -24649,7 +24649,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Password - dd16c8d4-baca-4ae0-bcd8-fb98b9040524.json 1`] = `
 {
   "_id": "dd16c8d4-baca-4ae0-bcd8-fb98b9040524",
   "_outcomes": [
@@ -24670,7 +24670,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Login Page - 731c5810-020b-45c8-a7fc-3c21903ae2b3/Select IDP - 038f9b2a-36b2-489b-9e03-386c9a62ea21.json 1`] = `
 {
   "_id": "038f9b2a-36b2-489b-9e03-386c9a62ea21",
   "_outcomes": [
@@ -24698,7 +24698,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/SAML2 Authentication - 64157fca-bd5b-4405-a4c8-64ffd98a5461.json 1`] = `
 {
   "_id": "64157fca-bd5b-4405-a4c8-64ffd98a5461",
   "_outcomes": [
@@ -24737,7 +24737,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Social Login - d5cc2d52-6ce4-452d-85ea-3a5b50218b67.json 1`] = `
 {
   "_id": "d5cc2d52-6ce4-452d-85ea-3a5b50218b67",
   "_outcomes": [
@@ -24765,7 +24765,7 @@ exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha
 }
 `;
 
-exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style": testDir13/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
+exports[`frodo config-manager pulls "frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style": ConfigJourneytestDir3/realms/alpha/journeys/FrodoTest/nodes/Validate Creds - fc7e47cd-c679-4211-8e05-a36654f23c67.json 1`] = `
 {
   "_id": "fc7e47cd-c679-4211-8e05-a36654f23c67",
   "_outcomes": [

--- a/test/e2e/__snapshots__/config-manager-push-journeys.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/config-manager-push-journeys.e2e.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys --directory test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import journeys into a specific realm" 1`] = `""`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys --directory test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import journeys into a specific realm" 2`] = `
+"Experimental feature in use: 'frodo config-manager push journeys'. This feature may change without notice.
+✔ Resolved all alpha realm dependencies.
+• Finished importing alpha realm journeys
+"
+`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import the journeys into forgeops" 1`] = `""`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import the journeys into forgeops" 2`] = `
+"Experimental feature in use: 'frodo config-manager push journeys'. This feature may change without notice.
+✔ Resolved all alpha realm dependencies.
+• Finished importing alpha realm journeys
+✔ Resolved all / realm dependencies.
+• Finished importing / realm journeys
+"
+`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -d -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should resolve dependencies when importing to  forgeops" 1`] = `""`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -d -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should resolve dependencies when importing to  forgeops" 2`] = `
+"Experimental feature in use: 'frodo config-manager push journeys'. This feature may change without notice.
+✔ Resolved all alpha realm dependencies.
+• Finished importing alpha realm journeys
+✔ Resolved all / realm dependencies.
+• Finished importing / realm journeys
+"
+`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -n ProgressiveProfile -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import a specific journey by name into forgeops" 1`] = `""`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -n ProgressiveProfile -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import a specific journey by name into forgeops" 2`] = `
+"Experimental feature in use: 'frodo config-manager push journeys'. This feature may change without notice.
+✔ Resolved all alpha realm dependencies.
+• Finished importing alpha realm journeys
+"
+`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -n Test -d -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import a journey with dependencies" 1`] = `""`;
+
+exports[`frodo config-manager push journeys "frodo config-manager push journeys -n Test -d -D test/e2e/exports/fr-config-manager/forgeops -m forgeops": should import a journey with dependencies" 2`] = `
+"Experimental feature in use: 'frodo config-manager push journeys'. This feature may change without notice.
+✔ Resolved all / realm dependencies.
+• Finished importing / realm journeys
+"
+`;

--- a/test/e2e/config-manager-export-journeys.e2e.test.js
+++ b/test/e2e/config-manager-export-journeys.e2e.test.js
@@ -47,10 +47,10 @@
  */
 
 /*
-FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -D testDir11
-FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -r alpha -D testDir12
-FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13
-FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -D testDir14 --pull-dependencies
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -D ConfigJourneytestDir1
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://openam-frodo-dev.forgeblocks.com/am frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies
 
 */
 
@@ -64,23 +64,23 @@ process.env['FRODO_CONNECTION_PROFILES_PATH'] =
 const env = getEnv(c);
 
 describe('frodo config-manager pulls', () => {
-  test('"frodo config-manager pull journeys -D testDir11": should export the journeys in fr-config-manager style"', async () => {
-      const dirName = 'testDir11';
+  test('"frodo config-manager pull journeys -D ConfigJourneytestDir1": should export the journeys in fr-config-manager style"', async () => {
+      const dirName = 'ConfigJourneytestDir1';
       const CMD = `frodo config-manager pull journeys -D ${dirName}`;
       await testExport(CMD, env, undefined, undefined, dirName, false);
     });
-    test('"frodo config-manager pull journeys -r alpha -D testDir12": should export the journeys in alpha realm in fr-config-manager style"', async () => {
-      const dirName = 'testDir12';
+    test('"frodo config-manager pull journeys -r alpha -D ConfigJourneytestDir2": should export the journeys in alpha realm in fr-config-manager style"', async () => {
+      const dirName = 'ConfigJourneytestDir2';
       const CMD = `frodo config-manager pull journeys -r alpha -D ${dirName}`;
       await testExport(CMD, env, undefined, undefined, dirName, false);
     });
-    test('"frodo config-manager pull journeys -r alpha -n FrodoTest -D testDir13": should export journey with name: FrodoTest in fr-config-manager style"', async () => {
-      const dirName = 'testDir13';
+    test('"frodo config-manager pull journeys -r alpha -n FrodoTest -D ConfigJourneytestDir3": should export journey with name: FrodoTest in fr-config-manager style"', async () => {
+      const dirName = 'ConfigJourneytestDir3';
       const CMD = `frodo config-manager pull journeys -r alpha -n FrodoTest -D ${dirName}`;
       await testExport(CMD, env, undefined, undefined, dirName, false);
     });
-    test('"frodo config-manager pull journeys -D testDir14 --pull-dependencies": should export the journeys in fr-config-manager style"', async () => {
-      const dirName = 'testDir14';
+    test('"frodo config-manager pull journeys -D ConfigJourneytestDir4 --pull-dependencies": should export the journeys in fr-config-manager style"', async () => {
+      const dirName = 'ConfigJourneytestDir4';
       const CMD = `frodo config-manager pull journeys -D ${dirName} --pull-dependencies`;
       await testExport(CMD, env, undefined, undefined, dirName, false);
     });

--- a/test/e2e/config-manager-push-journeys.e2e.test.js
+++ b/test/e2e/config-manager-push-journeys.e2e.test.js
@@ -1,0 +1,92 @@
+/**
+ * Follow this process to write e2e tests for the CLI project:
+ *
+ * 1. Test if all the necessary mocks for your tests already exist.
+ *    In mock mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=1 frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    If your command completes without errors and with the expected results,
+ *    all the required mocks already exist and you are good to write your
+ *    test and skip to step #4.
+ *
+ *    If, however, your command fails and you see errors like the one below,
+ *    you know you need to record the mock responses first:
+ *
+ *    [Polly] [adapter:node-http] Recording for the following request is not found and `recordIfMissing` is `false`.
+ *
+ * 2. Record mock responses for your exact command.
+ *    In mock record mode, run the command you want to test with the same arguments
+ *    and parameters exactly as you want to test it, for example:
+ *
+ *    $ FRODO_MOCK=record frodo conn save https://openam-frodo-dev.forgeblocks.com/am volker.scheuber@forgerock.com Sup3rS3cr3t!
+ *
+ *    Wait until you see all the Polly instances (mock recording adapters) have
+ *    shutdown before you try to run step #1 again.
+ *    Messages like these indicate mock recording adapters shutting down:
+ *
+ *    Polly instance 'conn/4' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 2s...
+ *    Polly instance 'conn/save/3' stopping in 3s...
+ *    Polly instance 'conn/4' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopping in 2s...
+ *    Polly instance 'conn/4' stopped.
+ *    Polly instance 'conn/save/3' stopping in 1s...
+ *    Polly instance 'conn/save/3' stopped.
+ *
+ * 3. Validate your freshly recorded mock responses are complete and working.
+ *    Re-run the exact command you want to test in mock mode (see step #1).
+ *
+ * 4. Write your test.
+ *    Make sure to use the exact command including number of arguments and params.
+ *
+ * 5. Commit both your test and your new recordings to the repository.
+ *    Your tests are likely going to reside outside the frodo-lib project but
+ *    the recordings must be committed to the frodo-lib project.
+ */
+
+/*
+// ForgeOps
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push journeys -D test/e2e/exports/fr-config-manager/forgeops -m forgeops
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push journeys -n ProgressiveProfile -D test/e2e/exports/fr-config-manager/forgeops -m forgeops
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push journeys -d -D test/e2e/exports/fr-config-manager/forgeops -m forgeops
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push journeys -n Test -d -D test/e2e/exports/fr-config-manager/forgeops -m forgeops
+FRODO_MOCK=record FRODO_NO_CACHE=1 FRODO_HOST=https://nightly.gcp.forgeops.com/am frodo config-manager push journeys --directory test/e2e/exports/fr-config-manager/forgeops -m forgeops
+*/
+
+import { getEnv, testSuccess } from './utils/TestUtils';
+import { forgeops_connection as fc } from './utils/TestConfig';
+
+
+process.env['FRODO_MOCK'] = '1';
+const forgeopsEnv = getEnv(fc);
+
+const allDirectory = "test/e2e/exports/fr-config-manager/forgeops";
+describe('frodo config-manager push journeys', () => {
+    test(`"frodo config-manager push journeys -D ${allDirectory} -m forgeops": should import the journeys into forgeops"`, async () => {
+        const CMD = `frodo config-manager push journeys -D ${allDirectory} -m forgeops`;
+        await testSuccess(CMD, forgeopsEnv);
+    });
+    test(`"frodo config-manager push journeys -n ProgressiveProfile -D ${allDirectory} -m forgeops": should import a specific journey by name into forgeops"`, async () => {
+        const CMD = `frodo config-manager push journeys -n ProgressiveProfile -D ${allDirectory} -m forgeops`;
+        await testSuccess(CMD, forgeopsEnv);
+    });
+    test(`"frodo config-manager push journeys -d -D ${allDirectory} -m forgeops": should resolve dependencies when importing to  forgeops"`, async () => {
+        const CMD = `frodo config-manager push journeys -d -D ${allDirectory} -m forgeops`;
+        await testSuccess(CMD, forgeopsEnv);
+    });
+    test(`"frodo config-manager push journeys -n Test -d -D ${allDirectory} -m forgeops": should import a journey with dependencies"`, async () => {
+        const CMD = `frodo config-manager push journeys -n Test -d  -D ${allDirectory} -m forgeops`;
+        await testSuccess(CMD, forgeopsEnv);
+    });
+    test(`"frodo config-manager push journeys --directory ${allDirectory} -m forgeops": should import journeys into a specific realm"`, async () => {
+        const CMD = `frodo config-manager push journeys --directory ${allDirectory} -m forgeops`;
+        await testSuccess(CMD, {
+            env: {
+                ...forgeopsEnv.env,
+                FRODO_REALM: 'alpha'
+            }
+        });
+    });
+});

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/ProgressiveProfile.json
@@ -1,0 +1,68 @@
+{
+  "_id": "ProgressiveProfile",
+  "_rev": "2039065517",
+  "description": "Prompt for missing preferences on 3rd login",
+  "enabled": true,
+  "entryNodeId": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
+  "innerTreeOnly": false,
+  "mustRun": false,
+  "noSession": false,
+  "nodes": {
+    "423a959a-a1b9-498a-b0f7-596b6b6e775a": {
+      "connections": {
+        "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+      },
+      "displayName": "Patch Object",
+      "nodeType": "PatchObjectNode",
+      "x": 766,
+      "y": 36
+    },
+    "8afdaec3-275e-4301-bb53-34f03e6a4b29": {
+      "connections": {
+        "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "true": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e"
+      },
+      "displayName": "Login Count Decision",
+      "nodeType": "LoginCountDecisionNode",
+      "x": 152,
+      "y": 36
+    },
+    "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e": {
+      "connections": {
+        "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+        "true": "a5aecad8-854a-4ed5-b719-ff6c90e858c0"
+      },
+      "displayName": "Query Filter Decision",
+      "nodeType": "QueryFilterDecisionNode",
+      "x": 357,
+      "y": 36
+    },
+    "a5aecad8-854a-4ed5-b719-ff6c90e858c0": {
+      "connections": {
+        "outcome": "423a959a-a1b9-498a-b0f7-596b6b6e775a"
+      },
+      "displayName": "Page Node",
+      "nodeType": "PageNode",
+      "x": 555,
+      "y": 20
+    }
+  },
+  "staticNodes": {
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 802,
+      "y": 312
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 919,
+      "y": 171
+    },
+    "startNode": {
+      "x": 50,
+      "y": 58.5
+    }
+  },
+  "uiConfig": {
+    "categories": "[\"Progressive Profile\"]"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Login Count Decision - 8afdaec3-275e-4301-bb53-34f03e6a4b29.json
@@ -1,0 +1,22 @@
+{
+  "_id": "8afdaec3-275e-4301-bb53-34f03e6a4b29",
+  "_outcomes": [
+    {
+      "displayName": "True",
+      "id": "true"
+    },
+    {
+      "displayName": "False",
+      "id": "false"
+    }
+  ],
+  "_rev": "-1679047423",
+  "_type": {
+    "_id": "LoginCountDecisionNode",
+    "collection": true,
+    "name": "Login Count Decision"
+  },
+  "amount": 3,
+  "identityAttribute": "userName",
+  "interval": "AT"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0.json
@@ -1,0 +1,26 @@
+{
+  "_id": "a5aecad8-854a-4ed5-b719-ff6c90e858c0",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "380010937",
+  "_type": {
+    "_id": "PageNode",
+    "collection": true,
+    "name": "Page Node"
+  },
+  "nodes": [
+    {
+      "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
+      "displayName": "Attribute Collector",
+      "nodeType": "AttributeCollectorNode"
+    }
+  ],
+  "pageDescription": {},
+  "pageHeader": {
+    "en": "Please select your preferences"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Page Node - a5aecad8-854a-4ed5-b719-ff6c90e858c0/Attribute Collector - 0a042e10-b22e-4e02-86c4-65e26e775f7a.json
@@ -1,0 +1,22 @@
+{
+  "_id": "0a042e10-b22e-4e02-86c4-65e26e775f7a",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "-1210529544",
+  "_type": {
+    "_id": "AttributeCollectorNode",
+    "collection": true,
+    "name": "Attribute Collector"
+  },
+  "attributesToCollect": [
+    "preferences/updates",
+    "preferences/marketing"
+  ],
+  "identityAttribute": "userName",
+  "required": false,
+  "validateInputs": false
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Patch Object - 423a959a-a1b9-498a-b0f7-596b6b6e775a.json
@@ -1,0 +1,23 @@
+{
+  "_id": "423a959a-a1b9-498a-b0f7-596b6b6e775a",
+  "_outcomes": [
+    {
+      "displayName": "Patched",
+      "id": "PATCHED"
+    },
+    {
+      "displayName": "Failed",
+      "id": "FAILURE"
+    }
+  ],
+  "_rev": "1653653564",
+  "_type": {
+    "_id": "PatchObjectNode",
+    "collection": true,
+    "name": "Patch Object"
+  },
+  "identityAttribute": "userName",
+  "identityResource": "managed/user",
+  "ignoredFields": [],
+  "patchAsObject": false
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/ProgressiveProfile/nodes/Query Filter Decision - a1f45b44-5bf7-4c57-aa3f-75c619c7db8e.json
@@ -1,0 +1,21 @@
+{
+  "_id": "a1f45b44-5bf7-4c57-aa3f-75c619c7db8e",
+  "_outcomes": [
+    {
+      "displayName": "True",
+      "id": "true"
+    },
+    {
+      "displayName": "False",
+      "id": "false"
+    }
+  ],
+  "_rev": "-1852493841",
+  "_type": {
+    "_id": "QueryFilterDecisionNode",
+    "collection": true,
+    "name": "Query Filter Decision"
+  },
+  "identityAttribute": "userName",
+  "queryFilter": "!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/Registration.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/Registration.json
@@ -1,0 +1,58 @@
+{
+  "_id": "Registration",
+  "_rev": "-285075550",
+  "description": "Platform Registration Tree",
+  "enabled": true,
+  "entryNodeId": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
+  "identityResource": "managed/user",
+  "innerTreeOnly": false,
+  "mustRun": false,
+  "noSession": false,
+  "nodes": {
+    "0c091c49-f3af-48fb-ac6f-07fba0499dd6": {
+      "connections": {
+        "outcome": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237"
+      },
+      "displayName": "Page Node",
+      "nodeType": "PageNode",
+      "x": 261,
+      "y": 168
+    },
+    "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b": {
+      "connections": {
+        "outcome": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+      },
+      "displayName": "Increment Login Count",
+      "nodeType": "IncrementLoginCountNode",
+      "x": 681,
+      "y": 144
+    },
+    "ad5dcbb3-7335-49b7-b3e7-7d850bb88237": {
+      "connections": {
+        "CREATED": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
+        "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a"
+      },
+      "displayName": "Create Object",
+      "nodeType": "CreateObjectNode",
+      "x": 537,
+      "y": 206
+    }
+  },
+  "staticNodes": {
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 905,
+      "y": 171
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 741,
+      "y": 293
+    },
+    "startNode": {
+      "x": 50,
+      "y": 25
+    }
+  },
+  "uiConfig": {
+    "categories": "[\"Registration\"]"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Create Object - ad5dcbb3-7335-49b7-b3e7-7d850bb88237.json
@@ -1,0 +1,20 @@
+{
+  "_id": "ad5dcbb3-7335-49b7-b3e7-7d850bb88237",
+  "_outcomes": [
+    {
+      "displayName": "Created",
+      "id": "CREATED"
+    },
+    {
+      "displayName": "Failed",
+      "id": "FAILURE"
+    }
+  ],
+  "_rev": "-246787506",
+  "_type": {
+    "_id": "CreateObjectNode",
+    "collection": true,
+    "name": "Create Object"
+  },
+  "identityResource": "managed/user"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Increment Login Count - 97a15eb2-a015-4b6d-81a0-be78c3aa1a3b.json
@@ -1,0 +1,16 @@
+{
+  "_id": "97a15eb2-a015-4b6d-81a0-be78c3aa1a3b",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "-841385771",
+  "_type": {
+    "_id": "IncrementLoginCountNode",
+    "collection": true,
+    "name": "Increment Login Count"
+  },
+  "identityAttribute": "userName"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6.json
@@ -1,0 +1,48 @@
+{
+  "_id": "0c091c49-f3af-48fb-ac6f-07fba0499dd6",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "762531723",
+  "_type": {
+    "_id": "PageNode",
+    "collection": true,
+    "name": "Page Node"
+  },
+  "nodes": [
+    {
+      "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
+      "displayName": "Platform Username",
+      "nodeType": "ValidatedUsernameNode"
+    },
+    {
+      "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
+      "displayName": "Attribute Collector",
+      "nodeType": "AttributeCollectorNode"
+    },
+    {
+      "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
+      "displayName": "Platform Password",
+      "nodeType": "ValidatedPasswordNode"
+    },
+    {
+      "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
+      "displayName": "KBA Definition",
+      "nodeType": "KbaCreateNode"
+    },
+    {
+      "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
+      "displayName": "Accept Terms and Conditions",
+      "nodeType": "AcceptTermsAndConditionsNode"
+    }
+  ],
+  "pageDescription": {
+    "en": "Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>"
+  },
+  "pageHeader": {
+    "en": "Sign Up"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Accept Terms and Conditions - b4a0e915-c15d-4b83-9c9d-18347d645976.json
@@ -1,0 +1,15 @@
+{
+  "_id": "b4a0e915-c15d-4b83-9c9d-18347d645976",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "1508860909",
+  "_type": {
+    "_id": "AcceptTermsAndConditionsNode",
+    "collection": true,
+    "name": "Accept Terms and Conditions"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Attribute Collector - d3ce2036-1523-4ce8-b1a2-895a2a036667.json
@@ -1,0 +1,25 @@
+{
+  "_id": "d3ce2036-1523-4ce8-b1a2-895a2a036667",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "-1158802257",
+  "_type": {
+    "_id": "AttributeCollectorNode",
+    "collection": true,
+    "name": "Attribute Collector"
+  },
+  "attributesToCollect": [
+    "givenName",
+    "sn",
+    "mail",
+    "preferences/marketing",
+    "preferences/updates"
+  ],
+  "identityAttribute": "userName",
+  "required": true,
+  "validateInputs": true
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/KBA Definition - 120c69d3-90b4-4ad4-b7af-380e8b119340.json
@@ -1,0 +1,19 @@
+{
+  "_id": "120c69d3-90b4-4ad4-b7af-380e8b119340",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "-8134977",
+  "_type": {
+    "_id": "KbaCreateNode",
+    "collection": true,
+    "name": "KBA Definition"
+  },
+  "allowUserDefinedQuestions": true,
+  "message": {
+    "en": "Select a security question"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Password - 3d8709a1-f09f-4d1f-8094-2850e472c1db.json
@@ -1,0 +1,17 @@
+{
+  "_id": "3d8709a1-f09f-4d1f-8094-2850e472c1db",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "-1470058997",
+  "_type": {
+    "_id": "ValidatedPasswordNode",
+    "collection": true,
+    "name": "Platform Password"
+  },
+  "passwordAttribute": "password",
+  "validateInput": true
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/journeys/Registration/nodes/Page Node - 0c091c49-f3af-48fb-ac6f-07fba0499dd6/Platform Username - 7fcaf48e-a754-4959-858b-05b2933b825f.json
@@ -1,0 +1,17 @@
+{
+  "_id": "7fcaf48e-a754-4959-858b-05b2933b825f",
+  "_outcomes": [
+    {
+      "displayName": "Outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "1966656034",
+  "_type": {
+    "_id": "ValidatedUsernameNode",
+    "collection": true,
+    "name": "Platform Username"
+  },
+  "usernameAttribute": "userName",
+  "validateInput": true
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/scripts/scripts-config/0575fa2f-12cf-42e3-8fe3-0b45d99d3aa8.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/scripts/scripts-config/0575fa2f-12cf-42e3-8fe3-0b45d99d3aa8.json
@@ -1,0 +1,16 @@
+{
+  "_id": "0575fa2f-12cf-42e3-8fe3-0b45d99d3aa8",
+  "context": "SCRIPTED_DECISION_NODE",
+  "createdBy": "id=amadmin,ou=user,ou=am-config",
+  "creationDate": 1784302526002,
+  "default": false,
+  "description": "null",
+  "evaluatorVersion": "2.0",
+  "language": "JAVASCRIPT",
+  "lastModifiedBy": "id=amadmin,ou=user,ou=am-config",
+  "lastModifiedDate": 1784302526002,
+  "name": "PaseUsername",
+  "script": {
+    "file": "scripts-content/SCRIPTED_DECISION_NODE/PaseUsername.js"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/scripts/scripts-content/SCRIPTED_DECISION_NODE/PaseUsername.js
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/alpha/scripts/scripts-content/SCRIPTED_DECISION_NODE/PaseUsername.js
@@ -1,0 +1,20 @@
+var SCRIPT_OUTCOMES = {
+    OUTCOME: 'outcome'
+};
+
+function main() {
+    var username = nodeState.get('username');
+    if (username.trim().toLowerCase().startsWith('fcpsedu\\')) {
+        username = username.substring(username.indexOf('\\') + 1);
+    }
+    if (username.trim().toLowerCase().endsWith('@fcpsschools.net')) {
+        username = username.substring(0, username.lastIndexOf('@'));
+    }
+    nodeState.putShared('username', username);
+    nodeState.putShared('objectAttributes', {
+        userName: username
+    });
+    action.goTo(SCRIPT_OUTCOMES.OUTCOME);
+}
+
+main();

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/InnerTest.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/InnerTest.json
@@ -1,0 +1,59 @@
+{
+  "_id": "InnerTest",
+  "_rev": "-1762283053",
+  "description": "Inner Test Journey",
+  "enabled": true,
+  "entryNodeId": "5d969de4-98c8-44ab-9df1-4de9170205eb",
+  "identityResource": "managed/user",
+  "innerTreeOnly": true,
+  "mustRun": false,
+  "noSession": false,
+  "nodes": {
+    "5d969de4-98c8-44ab-9df1-4de9170205eb": {
+      "connections": {
+        "outcome": "fd51424b-2a28-41a9-bc3e-44c2adc61a62"
+      },
+      "displayName": "Debug",
+      "nodeType": "ScriptedDecisionNode",
+      "x": 210,
+      "y": 154.5
+    },
+    "af596d89-e0ae-41c9-b1f5-e7318f517e2d": {
+      "connections": {
+        "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+      },
+      "displayName": "Test Next Gen",
+      "nodeType": "ScriptedDecisionNode",
+      "x": 726,
+      "y": 128
+    },
+    "fd51424b-2a28-41a9-bc3e-44c2adc61a62": {
+      "connections": {
+        "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "true": "af596d89-e0ae-41c9-b1f5-e7318f517e2d"
+      },
+      "displayName": "Test Groovy",
+      "nodeType": "ScriptedDecisionNode",
+      "x": 468,
+      "y": 128
+    }
+  },
+  "staticNodes": {
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 984,
+      "y": 80
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 984,
+      "y": 230
+    },
+    "startNode": {
+      "x": 70,
+      "y": 155
+    }
+  },
+  "uiConfig": {
+    "categories": "[\"Test\",\"Inner\"]"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/nodes/Debug - 5d969de4-98c8-44ab-9df1-4de9170205eb.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/nodes/Debug - 5d969de4-98c8-44ab-9df1-4de9170205eb.json
@@ -1,0 +1,25 @@
+{
+  "_id": "5d969de4-98c8-44ab-9df1-4de9170205eb",
+  "_outcomes": [
+    {
+      "displayName": "outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "-1660489373",
+  "_type": {
+    "_id": "ScriptedDecisionNode",
+    "collection": true,
+    "name": "Scripted Decision"
+  },
+  "inputs": [
+    "*"
+  ],
+  "outcomes": [
+    "outcome"
+  ],
+  "outputs": [
+    "*"
+  ],
+  "script": "9b75654f-2553-4627-9938-b14a5f62ce81"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/nodes/Test Groovy - fd51424b-2a28-41a9-bc3e-44c2adc61a62.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/nodes/Test Groovy - fd51424b-2a28-41a9-bc3e-44c2adc61a62.json
@@ -1,0 +1,30 @@
+{
+  "_id": "fd51424b-2a28-41a9-bc3e-44c2adc61a62",
+  "_outcomes": [
+    {
+      "displayName": "true",
+      "id": "true"
+    },
+    {
+      "displayName": "false",
+      "id": "false"
+    }
+  ],
+  "_rev": "-890383722",
+  "_type": {
+    "_id": "ScriptedDecisionNode",
+    "collection": true,
+    "name": "Scripted Decision"
+  },
+  "inputs": [
+    "*"
+  ],
+  "outcomes": [
+    "true",
+    "false"
+  ],
+  "outputs": [
+    "*"
+  ],
+  "script": "bd027bdf-002d-42e2-a549-d5fdb0d6605a"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/nodes/Test Next Gen - af596d89-e0ae-41c9-b1f5-e7318f517e2d.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/InnerTest/nodes/Test Next Gen - af596d89-e0ae-41c9-b1f5-e7318f517e2d.json
@@ -1,0 +1,30 @@
+{
+  "_id": "af596d89-e0ae-41c9-b1f5-e7318f517e2d",
+  "_outcomes": [
+    {
+      "displayName": "true",
+      "id": "true"
+    },
+    {
+      "displayName": "false",
+      "id": "false"
+    }
+  ],
+  "_rev": "919944373",
+  "_type": {
+    "_id": "ScriptedDecisionNode",
+    "collection": true,
+    "name": "Scripted Decision"
+  },
+  "inputs": [
+    "*"
+  ],
+  "outcomes": [
+    "true",
+    "false"
+  ],
+  "outputs": [
+    "*"
+  ],
+  "script": "3d27b6d3-0f41-410a-9975-2e9df43d885e"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/Test.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/Test.json
@@ -1,0 +1,80 @@
+{
+  "_id": "Test",
+  "_rev": "2131508795",
+  "description": "Test journey",
+  "enabled": true,
+  "entryNodeId": "02e10086-108c-441c-b14b-cc2054ef7483",
+  "identityResource": "managed/user",
+  "innerTreeOnly": false,
+  "mustRun": false,
+  "noSession": false,
+  "nodes": {
+    "02e10086-108c-441c-b14b-cc2054ef7483": {
+      "connections": {
+        "False": "0dd3743e-2aaf-4a4a-9e83-a64490303a10",
+        "True": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+      },
+      "displayName": "Has Session",
+      "nodeType": "designer-c605506774a848f7877b4d17a453bd39",
+      "x": 210,
+      "y": 155
+    },
+    "0dd3743e-2aaf-4a4a-9e83-a64490303a10": {
+      "connections": {
+        "Script Error": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "Success": "1bfea910-5d16-4439-b0db-70c3245644e1"
+      },
+      "displayName": "Vector ALU",
+      "nodeType": "designer-c15e2efb3deb4d4ea338c74a6440b69f",
+      "x": 440,
+      "y": 80
+    },
+    "1bfea910-5d16-4439-b0db-70c3245644e1": {
+      "connections": {
+        "Script Error": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "Success": "e78ff99e-59f8-4302-93b7-1770f18b4ae7"
+      },
+      "displayName": "ALU",
+      "nodeType": "designer-c6063fb2f5dc42dd9772bedc93898bd8",
+      "x": 670,
+      "y": 155
+    },
+    "a77ddb64-45af-4f7b-a734-8a8294f53294": {
+      "connections": {
+        "error": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+        "true": "e301438c-0bd0-429c-ab0c-66126501069a"
+      },
+      "displayName": "Inner Test",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "x": 1172,
+      "y": 141.5
+    },
+    "e78ff99e-59f8-4302-93b7-1770f18b4ae7": {
+      "connections": {
+        "outcome": "a77ddb64-45af-4f7b-a734-8a8294f53294"
+      },
+      "displayName": "My Page",
+      "nodeType": "PageNode",
+      "x": 900,
+      "y": 107.5
+    }
+  },
+  "staticNodes": {
+    "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+      "x": 440,
+      "y": 284
+    },
+    "e301438c-0bd0-429c-ab0c-66126501069a": {
+      "x": 1454,
+      "y": 182
+    },
+    "startNode": {
+      "x": 70,
+      "y": 182
+    }
+  },
+  "uiConfig": {
+    "categories": "[\"Test\"]"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/ALU - 1bfea910-5d16-4439-b0db-70c3245644e1.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/ALU - 1bfea910-5d16-4439-b0db-70c3245644e1.json
@@ -1,0 +1,20 @@
+{
+  "_id": "1bfea910-5d16-4439-b0db-70c3245644e1",
+  "_outcomes": [
+    {
+      "displayName": "Success",
+      "id": "Success"
+    },
+    {
+      "displayName": "Script Error",
+      "id": "Script Error"
+    }
+  ],
+  "_rev": "71843373",
+  "_type": {
+    "_id": "designer-c6063fb2f5dc42dd9772bedc93898bd8",
+    "collection": true,
+    "name": "ALU"
+  },
+  "operator": "ADD"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/Has Session - 02e10086-108c-441c-b14b-cc2054ef7483.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/Has Session - 02e10086-108c-441c-b14b-cc2054ef7483.json
@@ -1,0 +1,19 @@
+{
+  "_id": "02e10086-108c-441c-b14b-cc2054ef7483",
+  "_outcomes": [
+    {
+      "displayName": "True",
+      "id": "True"
+    },
+    {
+      "displayName": "False",
+      "id": "False"
+    }
+  ],
+  "_rev": "1815890486",
+  "_type": {
+    "_id": "designer-c605506774a848f7877b4d17a453bd39",
+    "collection": true,
+    "name": "Has Session"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/Inner Test - a77ddb64-45af-4f7b-a734-8a8294f53294.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/Inner Test - a77ddb64-45af-4f7b-a734-8a8294f53294.json
@@ -1,0 +1,25 @@
+{
+  "_id": "a77ddb64-45af-4f7b-a734-8a8294f53294",
+  "_outcomes": [
+    {
+      "displayName": "True",
+      "id": "true"
+    },
+    {
+      "displayName": "False",
+      "id": "false"
+    },
+    {
+      "displayName": "Error",
+      "id": "error"
+    }
+  ],
+  "_rev": "-998861558",
+  "_type": {
+    "_id": "InnerTreeEvaluatorNode",
+    "collection": true,
+    "name": "Inner Tree Evaluator"
+  },
+  "displayErrorOutcome": true,
+  "tree": "InnerTest"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/My Page - e78ff99e-59f8-4302-93b7-1770f18b4ae7.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/My Page - e78ff99e-59f8-4302-93b7-1770f18b4ae7.json
@@ -1,0 +1,34 @@
+{
+  "_id": "e78ff99e-59f8-4302-93b7-1770f18b4ae7",
+  "_outcomes": [
+    {
+      "displayName": "outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "942720118",
+  "_type": {
+    "_id": "PageNode",
+    "collection": true,
+    "name": "Page Node"
+  },
+  "nodes": [
+    {
+      "_id": "df153624-6d66-4e82-9b62-8cee4d62ab8f",
+      "displayName": "Display State",
+      "nodeType": "designer-8ab9f1aad4b4460a9c45d15fb148e221"
+    },
+    {
+      "_id": "cccb0cb9-a134-4f52-a499-55d4f095ac81",
+      "displayName": "Hello World!",
+      "nodeType": "designer-ef81b1a52c914710b3388caebfe7233a"
+    }
+  ],
+  "pageDescription": {
+    "en": "Description"
+  },
+  "pageHeader": {
+    "en": "Header"
+  },
+  "stage": "{\"submitButtonText\":{\"en\":\"Submit Button\"},\"pageFooter\":{\"en\":\"Footer\"},\"themeId\":\"a9bc15cf-8d9c-4bfb-8979-67a5f5823227\"}"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/My Page - e78ff99e-59f8-4302-93b7-1770f18b4ae7/Display State - df153624-6d66-4e82-9b62-8cee4d62ab8f.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/My Page - e78ff99e-59f8-4302-93b7-1770f18b4ae7/Display State - df153624-6d66-4e82-9b62-8cee4d62ab8f.json
@@ -1,0 +1,16 @@
+{
+  "_id": "df153624-6d66-4e82-9b62-8cee4d62ab8f",
+  "_outcomes": [
+    {
+      "displayName": "outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "1300434121",
+  "_type": {
+    "_id": "designer-8ab9f1aad4b4460a9c45d15fb148e221",
+    "collection": true,
+    "name": "Display State"
+  },
+  "displayFormat": "TABLE"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/My Page - e78ff99e-59f8-4302-93b7-1770f18b4ae7/Hello World! - cccb0cb9-a134-4f52-a499-55d4f095ac81.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/My Page - e78ff99e-59f8-4302-93b7-1770f18b4ae7/Hello World! - cccb0cb9-a134-4f52-a499-55d4f095ac81.json
@@ -1,0 +1,20 @@
+{
+  "_id": "cccb0cb9-a134-4f52-a499-55d4f095ac81",
+  "_outcomes": [
+    {
+      "displayName": "outcome",
+      "id": "outcome"
+    }
+  ],
+  "_rev": "-248191681",
+  "_type": {
+    "_id": "designer-ef81b1a52c914710b3388caebfe7233a",
+    "collection": true,
+    "name": "Display Callback"
+  },
+  "callback": "TEXT_OUTPUT_CALLBACK",
+  "options": {
+    "message": "Hello World!",
+    "messageType": "0"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/Vector ALU - 0dd3743e-2aaf-4a4a-9e83-a64490303a10.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/journeys/Test/nodes/Vector ALU - 0dd3743e-2aaf-4a4a-9e83-a64490303a10.json
@@ -1,0 +1,30 @@
+{
+  "_id": "0dd3743e-2aaf-4a4a-9e83-a64490303a10",
+  "_outcomes": [
+    {
+      "displayName": "Success",
+      "id": "Success"
+    },
+    {
+      "displayName": "Script Error",
+      "id": "Script Error"
+    }
+  ],
+  "_rev": "1826892730",
+  "_type": {
+    "_id": "designer-c15e2efb3deb4d4ea338c74a6440b69f",
+    "collection": true,
+    "name": "Vector ALU"
+  },
+  "a": [
+    1,
+    2,
+    3
+  ],
+  "b": [
+    4,
+    5,
+    6
+  ],
+  "operator": "CROSS"
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-config/3d27b6d3-0f41-410a-9975-2e9df43d885e.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-config/3d27b6d3-0f41-410a-9975-2e9df43d885e.json
@@ -1,0 +1,16 @@
+{
+  "_id": "3d27b6d3-0f41-410a-9975-2e9df43d885e",
+  "context": "SCRIPTED_DECISION_NODE",
+  "createdBy": "id=amadmin,ou=user,ou=am-config",
+  "creationDate": 1784906961115,
+  "default": false,
+  "description": "null",
+  "evaluatorVersion": "2.0",
+  "language": "JAVASCRIPT",
+  "lastModifiedBy": "id=amadmin,ou=user,ou=am-config",
+  "lastModifiedDate": 1784906961115,
+  "name": "Test Next Gen",
+  "script": {
+    "file": "scripts-content/SCRIPTED_DECISION_NODE/Test Next Gen.js"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-config/9b75654f-2553-4627-9938-b14a5f62ce81.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-config/9b75654f-2553-4627-9938-b14a5f62ce81.json
@@ -1,0 +1,16 @@
+{
+  "_id": "9b75654f-2553-4627-9938-b14a5f62ce81",
+  "context": "AUTHENTICATION_TREE_DECISION_NODE",
+  "createdBy": "id=amadmin,ou=user,ou=am-config",
+  "creationDate": 1784906960447,
+  "default": false,
+  "description": "Debug script that prints the shared state",
+  "evaluatorVersion": "1.0",
+  "language": "JAVASCRIPT",
+  "lastModifiedBy": "id=amadmin,ou=user,ou=am-config",
+  "lastModifiedDate": 1784906960447,
+  "name": "Debug",
+  "script": {
+    "file": "scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Debug.js"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-config/bd027bdf-002d-42e2-a549-d5fdb0d6605a.json
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-config/bd027bdf-002d-42e2-a549-d5fdb0d6605a.json
@@ -1,0 +1,16 @@
+{
+  "_id": "bd027bdf-002d-42e2-a549-d5fdb0d6605a",
+  "context": "AUTHENTICATION_TREE_DECISION_NODE",
+  "createdBy": "id=amadmin,ou=user,ou=am-config",
+  "creationDate": 1784906961100,
+  "default": false,
+  "description": "Test",
+  "evaluatorVersion": "1.0",
+  "language": "GROOVY",
+  "lastModifiedBy": "id=amadmin,ou=user,ou=am-config",
+  "lastModifiedDate": 1784906961100,
+  "name": "Test Groovy Script",
+  "script": {
+    "file": "scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Test Groovy Script.js"
+  }
+}

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Debug.js
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Debug.js
@@ -1,0 +1,22 @@
+var fr = JavaImporter(
+    org.forgerock.openam.auth.node.api.Action,
+    javax.security.auth.callback.TextOutputCallback,
+);
+
+var scriptOutcomes = {
+    OUTCOME: 'outcome',
+};
+
+function main() {
+    if (callbacks.isEmpty()) {
+        var debugState = {
+            sharedState: sharedState,
+            transientState: transientState
+        };
+        action = fr.Action.send(new fr.TextOutputCallback(0, `<pre style="text-align: left;">${JSON.stringify(debugState, null, 2)}</pre>`)).build();
+        return;
+    }
+    outcome = scriptOutcomes.OUTCOME;
+}
+
+main();

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Test Groovy Script.js
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-content/AUTHENTICATION_TREE_DECISION_NODE/Test Groovy Script.js
@@ -1,0 +1,6 @@
+/*
+  - Data made available by nodes that have already executed are available in the sharedState variable.
+  - The script should set outcome to either "true" or "false".
+ */
+
+outcome = "true";

--- a/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-content/SCRIPTED_DECISION_NODE/Test Next Gen.js
+++ b/test/e2e/exports/fr-config-manager/forgeops/realms/root/scripts/scripts-content/SCRIPTED_DECISION_NODE/Test Next Gen.js
@@ -1,0 +1,6 @@
+/*
+  - Data made available by nodes that have already executed are available in the sharedState variable.
+  - The script should set outcome to either "true" or "false".
+ */
+
+outcome = "true";

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_D_m_314327836/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_D_m_314327836/am_1076162899/recording.har
@@ -1,0 +1,5168 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 367,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 585,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 585,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-2120245986\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"true\",\"forgotUsername\":\"true\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"true\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "585"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.003Z",
+        "time": 27,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 27
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "<username>"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "<password>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 494,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 693,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.036Z",
+        "time": 21,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 21
+        }
+      },
+      {
+        "_id": "6a3744385d3fd7416ea7089e610fa7e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-07-24T16:02:13Z\",\"maxIdleExpirationTime\":\"2026-07-24T16:32:13Z\",\"maxSessionExpirationTime\":\"2026-07-24T18:02:12Z\",\"properties\":{\"AMCtxId\":\"ac50ecb2-03a1-4d64-b223-6b1ec81a8354-21488\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.066Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 517,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.080Z",
+        "time": 4,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4
+        }
+      },
+      {
+        "_id": "1b5684afd52c9eaef24954b59c4a12b3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 608,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 14371,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 14371,
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"2074770462\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"description\":\"Reset Password Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}}},{\"_id\":\"Agent\",\"_rev\":\"1224733603\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Agent\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"35cb0861-c160-47ff-808c-3429ba18772c\":{\"connections\":{\"outcome\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":350,\"y\":200},\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\":{\"connections\":{\"false\":\"35cb0861-c160-47ff-808c-3429ba18772c\",\"true\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25},\"7a910023-cad2-4f49-9ce0-1a0c711613d3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Agent Data Store Decision\",\"nodeType\":\"AgentDataStoreDecisionNode\",\"x\":700,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"amsterService\",\"_rev\":\"-1822894604\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Amster utility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Amster Jwt Decision Node\",\"nodeType\":\"AmsterJwtDecisionNode\",\"x\":200,\"y\":30}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":500,\"y\":130},\"startNode\":{\"x\":50,\"y\":30}}},{\"_id\":\"Test\",\"_rev\":\"1763194779\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"cccb0cb9-a134-4f52-a499-55d4f095ac81\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Hello World!\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"x\":1136,\"y\":181.5},\"df153624-6d66-4e82-9b62-8cee4d62ab8f\":{\"connections\":{\"outcome\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\"},\"displayName\":\"Display State\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"x\":900,\"y\":181.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1390,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}},{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}},{\"_id\":\"ldapService\",\"_rev\":\"-1985350877\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\",\"innerTreeOnly\":false,\"description\":\"Authentication tree replacing old default chain for backward compatibility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"6c8349cc-7260-3e62-a3b1-396831a8398a\":{\"connections\":{\"outcome\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":500,\"y\":25},\"c81e728d-9d4c-3f63-af06-7f89cc14862d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":800,\"y\":25},\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\":{\"connections\":{\"false\":\"6c8349cc-7260-3e62-a3b1-396831a8398a\",\"true\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ForgottenUsername\",\"_rev\":\"-15270298\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"description\":\"Forgotten Username Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":139,\"y\":146},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":767,\"y\":188},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":324,\"y\":152},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":563,\"y\":193}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"TestJourney\",\"_rev\":\"2029200158\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"innerTreeOnly\":false,\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[]\"},\"nodes\":{\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":726,\"y\":242.015625},\"1b879025-76c8-4660-8b33-7c0c1f284482\":{\"connections\":{\"outcome\":\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":496.34375,\"y\":188.015625},\"7d97831d-feb8-42d4-b665-f3bd596555ce\":{\"connections\":{\"outcome\":\"1b879025-76c8-4660-8b33-7c0c1f284482\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":199.34375,\"y\":149.015625},\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\":{\"connections\":{\"false\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Message Node\",\"nodeType\":\"MessageNode\",\"x\":1002,\"y\":145.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1413,\"y\":101},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1453,\"y\":305},\"startNode\":{\"x\":50,\"y\":250}}},{\"_id\":\"UpdatePassword\",\"_rev\":\"1509374777\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"description\":\"Update password using active session\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"Login\",\"_rev\":\"1920854130\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"description\":\"Platform Login Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":315,\"y\":140},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":815,\"y\":180},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":564,\"y\":132}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1008,\"y\":186},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":624,\"y\":267},\"startNode\":{\"x\":50,\"y\":25}}}],\"resultCount\":11,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.167Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "d663e422cad83e6d294e6d397d78eccd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 330,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "330"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AttributeCollectorNode\",\"collection\":true,\"name\":\"Attribute Collector\"},\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"required\":false,\"validateInputs\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AttributeCollectorNode/0a042e10-b22e-4e02-86c4-65e26e775f7a"
+        },
+        "response": {
+          "bodySize": 351,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 351,
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_rev\":\"-1210529544\",\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"validateInputs\":false,\"required\":false,\"_type\":{\"_id\":\"AttributeCollectorNode\",\"name\":\"Attribute Collector\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "351"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.183Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "9f50669cef70f1d266b118bacae869a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 279,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "279"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"collection\":true,\"name\":\"Login Count Decision\"},\"amount\":3,\"identityAttribute\":\"userName\",\"interval\":\"AT\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/LoginCountDecisionNode/8afdaec3-275e-4301-bb53-34f03e6a4b29"
+        },
+        "response": {
+          "bodySize": 300,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 300,
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_rev\":\"-1679047423\",\"interval\":\"AT\",\"identityAttribute\":\"userName\",\"amount\":3,\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"name\":\"Login Count Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "300"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.202Z",
+        "time": 22,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 22
+        }
+      },
+      {
+        "_id": "5bf7a3c05d0d0c056989843ee2145a5f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 368,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "368"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"displayName\":\"Attribute Collector\",\"nodeType\":\"AttributeCollectorNode\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PageNode/a5aecad8-854a-4ed5-b719-ff6c90e858c0"
+        },
+        "response": {
+          "bodySize": 387,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 387,
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_rev\":\"380010937\",\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"nodeType\":\"AttributeCollectorNode\",\"displayName\":\"Attribute Collector\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "387"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 627,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.230Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "de387377a7d1bddbfddef87b12edd95c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 321,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "321"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_outcomes\":[{\"displayName\":\"Patched\",\"id\":\"PATCHED\"},{\"displayName\":\"Failed\",\"id\":\"FAILURE\"}],\"_type\":{\"_id\":\"PatchObjectNode\",\"collection\":true,\"name\":\"Patch Object\"},\"identityAttribute\":\"userName\",\"identityResource\":\"managed/user\",\"ignoredFields\":[],\"patchAsObject\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PatchObjectNode/423a959a-a1b9-498a-b0f7-596b6b6e775a"
+        },
+        "response": {
+          "bodySize": 341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 341,
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_rev\":\"1653653564\",\"identityResource\":\"managed/user\",\"patchAsObject\":false,\"ignoredFields\":[],\"identityAttribute\":\"userName\",\"_type\":{\"_id\":\"PatchObjectNode\",\"name\":\"Patch Object\",\"collection\":true},\"_outcomes\":[{\"id\":\"PATCHED\",\"displayName\":\"Patched\"},{\"id\":\"FAILURE\",\"displayName\":\"Failed\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "341"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.248Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "bf8abff157b418baf082abf1eea8d367",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 357,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "357"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"collection\":true,\"name\":\"Query Filter Decision\"},\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/QueryFilterDecisionNode/a1f45b44-5bf7-4c57-aa3f-75c619c7db8e"
+        },
+        "response": {
+          "bodySize": 378,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 378,
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_rev\":\"-1852493841\",\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\",\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"name\":\"Query Filter Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "378"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.269Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "7cd28cef37196c568770627ac6ea91e4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1345,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1345"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"ProgressiveProfile\",\"description\":\"Prompt for missing preferences on 3rd login\",\"enabled\":true,\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"identityResource\":\"managed/user\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/ProgressiveProfile"
+        },
+        "response": {
+          "bodySize": 1365,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1365,
+            "text": "{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1365"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.289Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "eb402c29429bf97094f16f932bc2309f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 203,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "203"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AcceptTermsAndConditionsNode\",\"collection\":true,\"name\":\"Accept Terms and Conditions\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AcceptTermsAndConditionsNode/b4a0e915-c15d-4b83-9c9d-18347d645976"
+        },
+        "response": {
+          "bodySize": 223,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 223,
+            "text": "{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"_rev\":\"1508860909\",\"_type\":{\"_id\":\"AcceptTermsAndConditionsNode\",\"name\":\"Accept Terms and Conditions\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "223"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.304Z",
+        "time": 8,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 8
+        }
+      },
+      {
+        "_id": "36b21aa1bc294f78f1ca34bd202512c2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 352,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "352"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AttributeCollectorNode\",\"collection\":true,\"name\":\"Attribute Collector\"},\"attributesToCollect\":[\"givenName\",\"sn\",\"mail\",\"preferences/marketing\",\"preferences/updates\"],\"identityAttribute\":\"userName\",\"required\":true,\"validateInputs\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AttributeCollectorNode/d3ce2036-1523-4ce8-b1a2-895a2a036667"
+        },
+        "response": {
+          "bodySize": 373,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 373,
+            "text": "{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"_rev\":\"-1158802257\",\"attributesToCollect\":[\"givenName\",\"sn\",\"mail\",\"preferences/marketing\",\"preferences/updates\"],\"identityAttribute\":\"userName\",\"validateInputs\":true,\"required\":true,\"_type\":{\"_id\":\"AttributeCollectorNode\",\"name\":\"Attribute Collector\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "373"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.318Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "5568f99587cdb4ad5698eda16a68abff",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 254,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "254"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 662,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"KbaCreateNode\",\"collection\":true,\"name\":\"KBA Definition\"},\"allowUserDefinedQuestions\":true,\"message\":{\"en\":\"Select a security question\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/KbaCreateNode/120c69d3-90b4-4ad4-b7af-380e8b119340"
+        },
+        "response": {
+          "bodySize": 272,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 272,
+            "text": "{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"_rev\":\"-8134977\",\"message\":{\"en\":\"Select a security question\"},\"allowUserDefinedQuestions\":true,\"_type\":{\"_id\":\"KbaCreateNode\",\"name\":\"KBA Definition\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "272"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.332Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "ca4d8e41f37bdd8385c1f9650c6df366",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 238,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "238"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 670,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ValidatedPasswordNode\",\"collection\":true,\"name\":\"Platform Password\"},\"passwordAttribute\":\"password\",\"validateInput\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/ValidatedPasswordNode/3d8709a1-f09f-4d1f-8094-2850e472c1db"
+        },
+        "response": {
+          "bodySize": 259,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 259,
+            "text": "{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"_rev\":\"-1470058997\",\"passwordAttribute\":\"password\",\"validateInput\":true,\"_type\":{\"_id\":\"ValidatedPasswordNode\",\"name\":\"Platform Password\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "259"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.348Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "5bb4b35c45ac8f313597e0627af411d9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 238,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "238"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 670,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ValidatedUsernameNode\",\"collection\":true,\"name\":\"Platform Username\"},\"usernameAttribute\":\"userName\",\"validateInput\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/ValidatedUsernameNode/7fcaf48e-a754-4959-858b-05b2933b825f"
+        },
+        "response": {
+          "bodySize": 258,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 258,
+            "text": "{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"_rev\":\"1966656034\",\"usernameAttribute\":\"userName\",\"validateInput\":true,\"_type\":{\"_id\":\"ValidatedUsernameNode\",\"name\":\"Platform Username\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "258"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.367Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "29d2ae85418190df3c497979f6614909",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 251,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "251"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\",\"_outcomes\":[{\"displayName\":\"Created\",\"id\":\"CREATED\"},{\"displayName\":\"Failed\",\"id\":\"FAILURE\"}],\"_type\":{\"_id\":\"CreateObjectNode\",\"collection\":true,\"name\":\"Create Object\"},\"identityResource\":\"managed/user\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/CreateObjectNode/ad5dcbb3-7335-49b7-b3e7-7d850bb88237"
+        },
+        "response": {
+          "bodySize": 271,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 271,
+            "text": "{\"_id\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\",\"_rev\":\"-246787506\",\"identityResource\":\"managed/user\",\"_type\":{\"_id\":\"CreateObjectNode\",\"name\":\"Create Object\",\"collection\":true},\"_outcomes\":[{\"id\":\"CREATED\",\"displayName\":\"Created\"},{\"id\":\"FAILURE\",\"displayName\":\"Failed\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "271"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.383Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      },
+      {
+        "_id": "5dd9ed00720d6b432f318680314e1102",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 223,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "223"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"IncrementLoginCountNode\",\"collection\":true,\"name\":\"Increment Login Count\"},\"identityAttribute\":\"userName\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/IncrementLoginCountNode/97a15eb2-a015-4b6d-81a0-be78c3aa1a3b"
+        },
+        "response": {
+          "bodySize": 243,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 243,
+            "text": "{\"_id\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"_rev\":\"-841385771\",\"identityAttribute\":\"userName\",\"_type\":{\"_id\":\"IncrementLoginCountNode\",\"name\":\"Increment Login Count\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "243"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.397Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "790f49120b2a4bedf3a70f1390822f9e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 916,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "916"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"displayName\":\"Platform Username\",\"nodeType\":\"ValidatedUsernameNode\"},{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"displayName\":\"Attribute Collector\",\"nodeType\":\"AttributeCollectorNode\"},{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"displayName\":\"Platform Password\",\"nodeType\":\"ValidatedPasswordNode\"},{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"displayName\":\"KBA Definition\",\"nodeType\":\"KbaCreateNode\"},{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"displayName\":\"Accept Terms and Conditions\",\"nodeType\":\"AcceptTermsAndConditionsNode\"}],\"pageDescription\":{\"en\":\"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>\"},\"pageHeader\":{\"en\":\"Sign Up\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PageNode/0c091c49-f3af-48fb-ac6f-07fba0499dd6"
+        },
+        "response": {
+          "bodySize": 935,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 935,
+            "text": "{\"_id\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"_rev\":\"762531723\",\"nodes\":[{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"nodeType\":\"ValidatedUsernameNode\",\"displayName\":\"Platform Username\"},{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"nodeType\":\"AttributeCollectorNode\",\"displayName\":\"Attribute Collector\"},{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"nodeType\":\"ValidatedPasswordNode\",\"displayName\":\"Platform Password\"},{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"nodeType\":\"KbaCreateNode\",\"displayName\":\"KBA Definition\"},{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"nodeType\":\"AcceptTermsAndConditionsNode\",\"displayName\":\"Accept Terms and Conditions\"}],\"pageDescription\":{\"en\":\"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>\"},\"pageHeader\":{\"en\":\"Sign Up\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "935"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.414Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "ef594d6e195f232722a7318404c7480e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1036,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1036"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 625,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"Registration\",\"description\":\"Platform Registration Tree\",\"enabled\":true,\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}},\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/Registration"
+        },
+        "response": {
+          "bodySize": 1056,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1056,
+            "text": "{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1056"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.431Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      },
+      {
+        "_id": "aed97a9b5b18b5ca1d2a1f407b85f7b1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 595,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 15873,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 15873,
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-1854762395\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"description\":\"Reset Password Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}}},{\"_id\":\"Agent\",\"_rev\":\"1590168042\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Agent\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"35cb0861-c160-47ff-808c-3429ba18772c\":{\"connections\":{\"outcome\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":350,\"y\":200},\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\":{\"connections\":{\"false\":\"35cb0861-c160-47ff-808c-3429ba18772c\",\"true\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25},\"7a910023-cad2-4f49-9ce0-1a0c711613d3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Agent Data Store Decision\",\"nodeType\":\"AgentDataStoreDecisionNode\",\"x\":700,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"InnerTest\",\"_rev\":\"-1762283053\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"innerTreeOnly\":true,\"description\":\"Inner Test Journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"},\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}}},{\"_id\":\"amsterService\",\"_rev\":\"-1457460165\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Amster utility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Amster Jwt Decision Node\",\"nodeType\":\"AmsterJwtDecisionNode\",\"x\":200,\"y\":30}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":500,\"y\":130},\"startNode\":{\"x\":50,\"y\":30}}},{\"_id\":\"Test\",\"_rev\":\"2131508795\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}},{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}},{\"_id\":\"ldapService\",\"_rev\":\"-1619916438\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\",\"innerTreeOnly\":false,\"description\":\"Authentication tree replacing old default chain for backward compatibility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"6c8349cc-7260-3e62-a3b1-396831a8398a\":{\"connections\":{\"outcome\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":500,\"y\":25},\"c81e728d-9d4c-3f63-af06-7f89cc14862d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":800,\"y\":25},\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\":{\"connections\":{\"false\":\"6c8349cc-7260-3e62-a3b1-396831a8398a\",\"true\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ForgottenUsername\",\"_rev\":\"350164141\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"description\":\"Forgotten Username Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":139,\"y\":146},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":767,\"y\":188},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":324,\"y\":152},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":563,\"y\":193}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"TestJourney\",\"_rev\":\"-1352788891\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"innerTreeOnly\":false,\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[]\"},\"nodes\":{\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\":{\"connections\":{\"false\":\"804d3377-fbfe-4b05-902a-1ffcfdadb49e\",\"true\":\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":973,\"y\":224.015625},\"1b879025-76c8-4660-8b33-7c0c1f284482\":{\"connections\":{\"outcome\":\"abbaa271-85e9-4ad4-a0f5-d01dda4c35ef\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":442.34375,\"y\":235.015625},\"7d97831d-feb8-42d4-b665-f3bd596555ce\":{\"connections\":{\"outcome\":\"1b879025-76c8-4660-8b33-7c0c1f284482\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":199.34375,\"y\":149.015625},\"804d3377-fbfe-4b05-902a-1ffcfdadb49e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\"},\"displayName\":\"UserDoesNotExist\",\"nodeType\":\"MessageNode\",\"x\":1261,\"y\":359.015625},\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Message Node\",\"nodeType\":\"MessageNode\",\"x\":1322,\"y\":163.015625},\"abbaa271-85e9-4ad4-a0f5-d01dda4c35ef\":{\"connections\":{\"true\":\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\"},\"displayName\":\"DoesUserExist\",\"nodeType\":\"designer-user\",\"x\":711.765625,\"y\":252.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1946,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1818,\"y\":322},\"startNode\":{\"x\":50,\"y\":250}}},{\"_id\":\"UpdatePassword\",\"_rev\":\"1874809216\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"description\":\"Update password using active session\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"Login\",\"_rev\":\"-2008678727\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"description\":\"Platform Login Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":315,\"y\":140},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":815,\"y\":180},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":564,\"y\":132}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1008,\"y\":186},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":624,\"y\":267},\"startNode\":{\"x\":50,\"y\":25}}}],\"resultCount\":12,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.447Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "fb1b184542b1448c03c21dd9e044a557",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 287,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "287"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"outcome\"],\"outputs\":[\"*\"],\"script\":\"9b75654f-2553-4627-9938-b14a5f62ce81\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/5d969de4-98c8-44ab-9df1-4de9170205eb"
+        },
+        "response": {
+          "bodySize": 308,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 308,
+            "text": "{\"_id\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"_rev\":\"-1660489373\",\"script\":\"9b75654f-2553-4627-9938-b14a5f62ce81\",\"outcomes\":[\"outcome\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "308"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.463Z",
+        "time": 21,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 21
+        }
+      },
+      {
+        "_id": "cd186bee6882923ebc1de3568ad76ebc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 323,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "323"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\",\"_outcomes\":[{\"displayName\":\"true\",\"id\":\"true\"},{\"displayName\":\"false\",\"id\":\"false\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"script\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/fd51424b-2a28-41a9-bc3e-44c2adc61a62"
+        },
+        "response": {
+          "bodySize": 343,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 343,
+            "text": "{\"_id\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\",\"_rev\":\"-890383722\",\"script\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\",\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"true\"},{\"id\":\"false\",\"displayName\":\"false\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "343"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.489Z",
+        "time": 17,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 17
+        }
+      },
+      {
+        "_id": "634f4bc4772ea6429f15af12cb41e7a0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 323,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "323"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\",\"_outcomes\":[{\"displayName\":\"true\",\"id\":\"true\"},{\"displayName\":\"false\",\"id\":\"false\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"script\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/af596d89-e0ae-41c9-b1f5-e7318f517e2d"
+        },
+        "response": {
+          "bodySize": 342,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 342,
+            "text": "{\"_id\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\",\"_rev\":\"919944373\",\"script\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\",\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"true\"},{\"id\":\"false\",\"displayName\":\"false\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "342"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.511Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "53eeaecac33e81ef38d7c8b0de06907d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1066,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1066"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 609,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"InnerTest\",\"description\":\"Inner Test Journey\",\"enabled\":true,\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":true,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}},\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees/InnerTest"
+        },
+        "response": {
+          "bodySize": 1087,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1087,
+            "text": "{\"_id\":\"InnerTest\",\"_rev\":\"-1762283053\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"innerTreeOnly\":true,\"description\":\"Inner Test Journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"},\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1087"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.533Z",
+        "time": 16,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 16
+        }
+      },
+      {
+        "_id": "d5b2c0840d57b2b0eb02b12160a60382",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 226,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "226"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"collection\":true,\"name\":\"Display State\"},\"displayFormat\":\"TABLE\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-8ab9f1aad4b4460a9c45d15fb148e221/df153624-6d66-4e82-9b62-8cee4d62ab8f"
+        },
+        "response": {
+          "bodySize": 246,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 246,
+            "text": "{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"_rev\":\"1300434121\",\"displayFormat\":\"TABLE\",\"_type\":{\"_id\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"name\":\"Display State\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "246"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.558Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "84b90775da82fcb50bfa0db951972301",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 294,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "294"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"collection\":true,\"name\":\"Display Callback\"},\"callback\":\"TEXT_OUTPUT_CALLBACK\",\"options\":{\"message\":\"Hello World!\",\"messageType\":\"0\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-ef81b1a52c914710b3388caebfe7233a/cccb0cb9-a134-4f52-a499-55d4f095ac81"
+        },
+        "response": {
+          "bodySize": 314,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 314,
+            "text": "{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"_rev\":\"-248191681\",\"callback\":\"TEXT_OUTPUT_CALLBACK\",\"options\":{\"message\":\"Hello World!\",\"messageType\":\"0\"},\"_type\":{\"_id\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"name\":\"Display Callback\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "314"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.577Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "7b455d0b474bd76766ff8820b93c3145",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 260,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "260"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"1bfea910-5d16-4439-b0db-70c3245644e1\",\"_outcomes\":[{\"displayName\":\"Success\",\"id\":\"Success\"},{\"displayName\":\"Script Error\",\"id\":\"Script Error\"}],\"_type\":{\"_id\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"collection\":true,\"name\":\"ALU\"},\"operator\":\"ADD\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c6063fb2f5dc42dd9772bedc93898bd8/1bfea910-5d16-4439-b0db-70c3245644e1"
+        },
+        "response": {
+          "bodySize": 278,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 278,
+            "text": "{\"_id\":\"1bfea910-5d16-4439-b0db-70c3245644e1\",\"_rev\":\"71843373\",\"operator\":\"ADD\",\"_type\":{\"_id\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"name\":\"ALU\",\"collection\":true},\"_outcomes\":[{\"id\":\"Success\",\"displayName\":\"Success\"},{\"id\":\"Script Error\",\"displayName\":\"Script Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "278"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.595Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "0cb5165a45eb34813b96bb9128c27698",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 231,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "231"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"True\"},{\"displayName\":\"False\",\"id\":\"False\"}],\"_type\":{\"_id\":\"designer-c605506774a848f7877b4d17a453bd39\",\"collection\":true,\"name\":\"Has Session\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c605506774a848f7877b4d17a453bd39/02e10086-108c-441c-b14b-cc2054ef7483"
+        },
+        "response": {
+          "bodySize": 251,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 251,
+            "text": "{\"_id\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"_rev\":\"1815890486\",\"_type\":{\"_id\":\"designer-c605506774a848f7877b4d17a453bd39\",\"name\":\"Has Session\",\"collection\":true},\"_outcomes\":[{\"id\":\"True\",\"displayName\":\"True\"},{\"id\":\"False\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "251"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.612Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "dc375c86ec31d265bf7ca0cad2a56772",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 304,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "304"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 658,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"},{\"displayName\":\"Error\",\"id\":\"error\"}],\"_type\":{\"_id\":\"InnerTreeEvaluatorNode\",\"collection\":true,\"name\":\"Inner Tree Evaluator\"},\"displayErrorOutcome\":true,\"tree\":\"InnerTest\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/InnerTreeEvaluatorNode/a77ddb64-45af-4f7b-a734-8a8294f53294"
+        },
+        "response": {
+          "bodySize": 324,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 324,
+            "text": "{\"_id\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\",\"_rev\":\"-998861558\",\"displayErrorOutcome\":true,\"tree\":\"InnerTest\",\"_type\":{\"_id\":\"InnerTreeEvaluatorNode\",\"name\":\"Inner Tree Evaluator\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"},{\"id\":\"error\",\"displayName\":\"Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "324"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.629Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "f267f8e3d4d260de5b341a6f37972491",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 654,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "654"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"displayName\":\"Display State\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\"},{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"displayName\":\"Hello World!\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\"}],\"pageDescription\":{\"en\":\"Description\"},\"pageHeader\":{\"en\":\"Header\"},\"stage\":\"{\\\"submitButtonText\\\":{\\\"en\\\":\\\"Submit Button\\\"},\\\"pageFooter\\\":{\\\"en\\\":\\\"Footer\\\"},\\\"themeId\\\":\\\"a9bc15cf-8d9c-4bfb-8979-67a5f5823227\\\"}\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/PageNode/e78ff99e-59f8-4302-93b7-1770f18b4ae7"
+        },
+        "response": {
+          "bodySize": 673,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 673,
+            "text": "{\"_id\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\",\"_rev\":\"942720118\",\"nodes\":[{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"displayName\":\"Display State\"},{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"displayName\":\"Hello World!\"}],\"pageDescription\":{\"en\":\"Description\"},\"stage\":\"{\\\"submitButtonText\\\":{\\\"en\\\":\\\"Submit Button\\\"},\\\"pageFooter\\\":{\\\"en\\\":\\\"Footer\\\"},\\\"themeId\\\":\\\"a9bc15cf-8d9c-4bfb-8979-67a5f5823227\\\"}\",\"pageHeader\":{\"en\":\"Header\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "673"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.647Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "41b7d3c748449dfd1fb5b60fa8bfca37",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 293,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "293"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"_outcomes\":[{\"displayName\":\"Success\",\"id\":\"Success\"},{\"displayName\":\"Script Error\",\"id\":\"Script Error\"}],\"_type\":{\"_id\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"collection\":true,\"name\":\"Vector ALU\"},\"a\":[1,2,3],\"b\":[4,5,6],\"operator\":\"CROSS\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c15e2efb3deb4d4ea338c74a6440b69f/0dd3743e-2aaf-4a4a-9e83-a64490303a10"
+        },
+        "response": {
+          "bodySize": 313,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 313,
+            "text": "{\"_id\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"_rev\":\"1826892730\",\"a\":[1,2,3],\"operator\":\"CROSS\",\"b\":[4,5,6],\"_type\":{\"_id\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"name\":\"Vector ALU\",\"collection\":true},\"_outcomes\":[{\"id\":\"Success\",\"displayName\":\"Success\"},{\"id\":\"Script Error\",\"displayName\":\"Script Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "313"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.665Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "a8e6d62af4ac47c99d148821710c85d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1616,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1616"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 604,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"Test\",\"description\":\"Test journey\",\"enabled\":true,\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}},\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees/Test"
+        },
+        "response": {
+          "bodySize": 1636,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1636,
+            "text": "{\"_id\":\"Test\",\"_rev\":\"2131508795\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1636"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.684Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_D_m_314327836/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_D_m_314327836/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 562,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=yMFqEy3DBCbeL2Zu8pzCC_moY7g.*AAJTSQACMDIAAlNLABxhN0xRTzU0Qk1JZ0VkWE9nSVpkMjFvZWlHT009AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=1d_8W3oFSxisWKj_SerlEweJDMD7rwRbiQC5M7aTPTI&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=cia3w3IQ_FDNfMDh2WlK3OWBkLg&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 673,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=cia3w3IQ_FDNfMDh2WlK3OWBkLg&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.093Z",
+        "time": 16,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 16
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=cia3w3IQ_FDNfMDh2WlK3OWBkLg&code_verifier=-pv2kG9LxV-acYP0VVj8aeS6l1og5lMFzBvINQItLjk"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:14.117Z",
+        "time": 42,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 42
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_d_D_m_639961791/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_d_D_m_639961791/am_1076162899/recording.har
@@ -1,0 +1,5627 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_d_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 367,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 585,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 585,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-2120245986\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"true\",\"forgotUsername\":\"true\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"true\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "585"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.510Z",
+        "time": 31,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 31
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "<username>"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "<password>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 494,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 693,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.555Z",
+        "time": 20,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 20
+        }
+      },
+      {
+        "_id": "6a3744385d3fd7416ea7089e610fa7e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-07-24T16:03:06Z\",\"maxIdleExpirationTime\":\"2026-07-24T16:33:06Z\",\"maxSessionExpirationTime\":\"2026-07-24T18:03:05Z\",\"properties\":{\"AMCtxId\":\"ac50ecb2-03a1-4d64-b223-6b1ec81a8354-21947\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 609,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.582Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 517,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.599Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "1b5684afd52c9eaef24954b59c4a12b3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 608,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 14371,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 14371,
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"2074770462\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"description\":\"Reset Password Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}}},{\"_id\":\"Agent\",\"_rev\":\"1224733603\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Agent\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"35cb0861-c160-47ff-808c-3429ba18772c\":{\"connections\":{\"outcome\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":350,\"y\":200},\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\":{\"connections\":{\"false\":\"35cb0861-c160-47ff-808c-3429ba18772c\",\"true\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25},\"7a910023-cad2-4f49-9ce0-1a0c711613d3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Agent Data Store Decision\",\"nodeType\":\"AgentDataStoreDecisionNode\",\"x\":700,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"amsterService\",\"_rev\":\"-1822894604\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Amster utility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Amster Jwt Decision Node\",\"nodeType\":\"AmsterJwtDecisionNode\",\"x\":200,\"y\":30}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":500,\"y\":130},\"startNode\":{\"x\":50,\"y\":30}}},{\"_id\":\"Test\",\"_rev\":\"1763194779\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"cccb0cb9-a134-4f52-a499-55d4f095ac81\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Hello World!\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"x\":1136,\"y\":181.5},\"df153624-6d66-4e82-9b62-8cee4d62ab8f\":{\"connections\":{\"outcome\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\"},\"displayName\":\"Display State\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"x\":900,\"y\":181.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1390,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}},{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}},{\"_id\":\"ldapService\",\"_rev\":\"-1985350877\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\",\"innerTreeOnly\":false,\"description\":\"Authentication tree replacing old default chain for backward compatibility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"6c8349cc-7260-3e62-a3b1-396831a8398a\":{\"connections\":{\"outcome\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":500,\"y\":25},\"c81e728d-9d4c-3f63-af06-7f89cc14862d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":800,\"y\":25},\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\":{\"connections\":{\"false\":\"6c8349cc-7260-3e62-a3b1-396831a8398a\",\"true\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ForgottenUsername\",\"_rev\":\"-15270298\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"description\":\"Forgotten Username Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":139,\"y\":146},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":767,\"y\":188},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":324,\"y\":152},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":563,\"y\":193}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"TestJourney\",\"_rev\":\"2029200158\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"innerTreeOnly\":false,\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[]\"},\"nodes\":{\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":726,\"y\":242.015625},\"1b879025-76c8-4660-8b33-7c0c1f284482\":{\"connections\":{\"outcome\":\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":496.34375,\"y\":188.015625},\"7d97831d-feb8-42d4-b665-f3bd596555ce\":{\"connections\":{\"outcome\":\"1b879025-76c8-4660-8b33-7c0c1f284482\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":199.34375,\"y\":149.015625},\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\":{\"connections\":{\"false\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Message Node\",\"nodeType\":\"MessageNode\",\"x\":1002,\"y\":145.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1413,\"y\":101},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1453,\"y\":305},\"startNode\":{\"x\":50,\"y\":250}}},{\"_id\":\"UpdatePassword\",\"_rev\":\"1509374777\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"description\":\"Update password using active session\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"Login\",\"_rev\":\"1920854130\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"description\":\"Platform Login Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":315,\"y\":140},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":815,\"y\":180},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":564,\"y\":132}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1008,\"y\":186},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":624,\"y\":267},\"startNode\":{\"x\":50,\"y\":25}}}],\"resultCount\":11,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.686Z",
+        "time": 8,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 8
+        }
+      },
+      {
+        "_id": "d663e422cad83e6d294e6d397d78eccd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 330,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "330"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AttributeCollectorNode\",\"collection\":true,\"name\":\"Attribute Collector\"},\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"required\":false,\"validateInputs\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AttributeCollectorNode/0a042e10-b22e-4e02-86c4-65e26e775f7a"
+        },
+        "response": {
+          "bodySize": 351,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 351,
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_rev\":\"-1210529544\",\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"validateInputs\":false,\"required\":false,\"_type\":{\"_id\":\"AttributeCollectorNode\",\"name\":\"Attribute Collector\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "351"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.703Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "9f50669cef70f1d266b118bacae869a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 279,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "279"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"collection\":true,\"name\":\"Login Count Decision\"},\"amount\":3,\"identityAttribute\":\"userName\",\"interval\":\"AT\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/LoginCountDecisionNode/8afdaec3-275e-4301-bb53-34f03e6a4b29"
+        },
+        "response": {
+          "bodySize": 300,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 300,
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_rev\":\"-1679047423\",\"interval\":\"AT\",\"identityAttribute\":\"userName\",\"amount\":3,\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"name\":\"Login Count Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "300"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.722Z",
+        "time": 15,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 15
+        }
+      },
+      {
+        "_id": "5bf7a3c05d0d0c056989843ee2145a5f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 368,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "368"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"displayName\":\"Attribute Collector\",\"nodeType\":\"AttributeCollectorNode\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PageNode/a5aecad8-854a-4ed5-b719-ff6c90e858c0"
+        },
+        "response": {
+          "bodySize": 387,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 387,
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_rev\":\"380010937\",\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"nodeType\":\"AttributeCollectorNode\",\"displayName\":\"Attribute Collector\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "387"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.754Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "de387377a7d1bddbfddef87b12edd95c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 321,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "321"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_outcomes\":[{\"displayName\":\"Patched\",\"id\":\"PATCHED\"},{\"displayName\":\"Failed\",\"id\":\"FAILURE\"}],\"_type\":{\"_id\":\"PatchObjectNode\",\"collection\":true,\"name\":\"Patch Object\"},\"identityAttribute\":\"userName\",\"identityResource\":\"managed/user\",\"ignoredFields\":[],\"patchAsObject\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PatchObjectNode/423a959a-a1b9-498a-b0f7-596b6b6e775a"
+        },
+        "response": {
+          "bodySize": 341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 341,
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_rev\":\"1653653564\",\"identityResource\":\"managed/user\",\"patchAsObject\":false,\"ignoredFields\":[],\"identityAttribute\":\"userName\",\"_type\":{\"_id\":\"PatchObjectNode\",\"name\":\"Patch Object\",\"collection\":true},\"_outcomes\":[{\"id\":\"PATCHED\",\"displayName\":\"Patched\"},{\"id\":\"FAILURE\",\"displayName\":\"Failed\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "341"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.773Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "bf8abff157b418baf082abf1eea8d367",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 357,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "357"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"collection\":true,\"name\":\"Query Filter Decision\"},\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/QueryFilterDecisionNode/a1f45b44-5bf7-4c57-aa3f-75c619c7db8e"
+        },
+        "response": {
+          "bodySize": 378,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 378,
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_rev\":\"-1852493841\",\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\",\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"name\":\"Query Filter Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "378"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.789Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "7cd28cef37196c568770627ac6ea91e4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1345,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1345"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"ProgressiveProfile\",\"description\":\"Prompt for missing preferences on 3rd login\",\"enabled\":true,\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"identityResource\":\"managed/user\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/ProgressiveProfile"
+        },
+        "response": {
+          "bodySize": 1365,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1365,
+            "text": "{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1365"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.804Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "eb402c29429bf97094f16f932bc2309f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 203,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "203"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AcceptTermsAndConditionsNode\",\"collection\":true,\"name\":\"Accept Terms and Conditions\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AcceptTermsAndConditionsNode/b4a0e915-c15d-4b83-9c9d-18347d645976"
+        },
+        "response": {
+          "bodySize": 223,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 223,
+            "text": "{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"_rev\":\"1508860909\",\"_type\":{\"_id\":\"AcceptTermsAndConditionsNode\",\"name\":\"Accept Terms and Conditions\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "223"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.820Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "36b21aa1bc294f78f1ca34bd202512c2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 352,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "352"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AttributeCollectorNode\",\"collection\":true,\"name\":\"Attribute Collector\"},\"attributesToCollect\":[\"givenName\",\"sn\",\"mail\",\"preferences/marketing\",\"preferences/updates\"],\"identityAttribute\":\"userName\",\"required\":true,\"validateInputs\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AttributeCollectorNode/d3ce2036-1523-4ce8-b1a2-895a2a036667"
+        },
+        "response": {
+          "bodySize": 373,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 373,
+            "text": "{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"_rev\":\"-1158802257\",\"attributesToCollect\":[\"givenName\",\"sn\",\"mail\",\"preferences/marketing\",\"preferences/updates\"],\"identityAttribute\":\"userName\",\"validateInputs\":true,\"required\":true,\"_type\":{\"_id\":\"AttributeCollectorNode\",\"name\":\"Attribute Collector\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "373"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.834Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "5568f99587cdb4ad5698eda16a68abff",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 254,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "254"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 662,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"KbaCreateNode\",\"collection\":true,\"name\":\"KBA Definition\"},\"allowUserDefinedQuestions\":true,\"message\":{\"en\":\"Select a security question\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/KbaCreateNode/120c69d3-90b4-4ad4-b7af-380e8b119340"
+        },
+        "response": {
+          "bodySize": 272,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 272,
+            "text": "{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"_rev\":\"-8134977\",\"message\":{\"en\":\"Select a security question\"},\"allowUserDefinedQuestions\":true,\"_type\":{\"_id\":\"KbaCreateNode\",\"name\":\"KBA Definition\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "272"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.850Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "ca4d8e41f37bdd8385c1f9650c6df366",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 238,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "238"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 670,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ValidatedPasswordNode\",\"collection\":true,\"name\":\"Platform Password\"},\"passwordAttribute\":\"password\",\"validateInput\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/ValidatedPasswordNode/3d8709a1-f09f-4d1f-8094-2850e472c1db"
+        },
+        "response": {
+          "bodySize": 259,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 259,
+            "text": "{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"_rev\":\"-1470058997\",\"passwordAttribute\":\"password\",\"validateInput\":true,\"_type\":{\"_id\":\"ValidatedPasswordNode\",\"name\":\"Platform Password\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "259"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.866Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "5bb4b35c45ac8f313597e0627af411d9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 238,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "238"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 670,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ValidatedUsernameNode\",\"collection\":true,\"name\":\"Platform Username\"},\"usernameAttribute\":\"userName\",\"validateInput\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/ValidatedUsernameNode/7fcaf48e-a754-4959-858b-05b2933b825f"
+        },
+        "response": {
+          "bodySize": 258,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 258,
+            "text": "{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"_rev\":\"1966656034\",\"usernameAttribute\":\"userName\",\"validateInput\":true,\"_type\":{\"_id\":\"ValidatedUsernameNode\",\"name\":\"Platform Username\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "258"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.884Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "29d2ae85418190df3c497979f6614909",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 251,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "251"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\",\"_outcomes\":[{\"displayName\":\"Created\",\"id\":\"CREATED\"},{\"displayName\":\"Failed\",\"id\":\"FAILURE\"}],\"_type\":{\"_id\":\"CreateObjectNode\",\"collection\":true,\"name\":\"Create Object\"},\"identityResource\":\"managed/user\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/CreateObjectNode/ad5dcbb3-7335-49b7-b3e7-7d850bb88237"
+        },
+        "response": {
+          "bodySize": 271,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 271,
+            "text": "{\"_id\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\",\"_rev\":\"-246787506\",\"identityResource\":\"managed/user\",\"_type\":{\"_id\":\"CreateObjectNode\",\"name\":\"Create Object\",\"collection\":true},\"_outcomes\":[{\"id\":\"CREATED\",\"displayName\":\"Created\"},{\"id\":\"FAILURE\",\"displayName\":\"Failed\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "271"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.901Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "5dd9ed00720d6b432f318680314e1102",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 223,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "223"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"IncrementLoginCountNode\",\"collection\":true,\"name\":\"Increment Login Count\"},\"identityAttribute\":\"userName\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/IncrementLoginCountNode/97a15eb2-a015-4b6d-81a0-be78c3aa1a3b"
+        },
+        "response": {
+          "bodySize": 243,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 243,
+            "text": "{\"_id\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"_rev\":\"-841385771\",\"identityAttribute\":\"userName\",\"_type\":{\"_id\":\"IncrementLoginCountNode\",\"name\":\"Increment Login Count\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "243"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.917Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "790f49120b2a4bedf3a70f1390822f9e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 916,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "916"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"displayName\":\"Platform Username\",\"nodeType\":\"ValidatedUsernameNode\"},{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"displayName\":\"Attribute Collector\",\"nodeType\":\"AttributeCollectorNode\"},{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"displayName\":\"Platform Password\",\"nodeType\":\"ValidatedPasswordNode\"},{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"displayName\":\"KBA Definition\",\"nodeType\":\"KbaCreateNode\"},{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"displayName\":\"Accept Terms and Conditions\",\"nodeType\":\"AcceptTermsAndConditionsNode\"}],\"pageDescription\":{\"en\":\"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>\"},\"pageHeader\":{\"en\":\"Sign Up\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PageNode/0c091c49-f3af-48fb-ac6f-07fba0499dd6"
+        },
+        "response": {
+          "bodySize": 935,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 935,
+            "text": "{\"_id\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"_rev\":\"762531723\",\"nodes\":[{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"nodeType\":\"ValidatedUsernameNode\",\"displayName\":\"Platform Username\"},{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"nodeType\":\"AttributeCollectorNode\",\"displayName\":\"Attribute Collector\"},{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"nodeType\":\"ValidatedPasswordNode\",\"displayName\":\"Platform Password\"},{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"nodeType\":\"KbaCreateNode\",\"displayName\":\"KBA Definition\"},{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"nodeType\":\"AcceptTermsAndConditionsNode\",\"displayName\":\"Accept Terms and Conditions\"}],\"pageDescription\":{\"en\":\"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>\"},\"pageHeader\":{\"en\":\"Sign Up\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "935"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.932Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "ef594d6e195f232722a7318404c7480e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1036,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1036"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 625,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"Registration\",\"description\":\"Platform Registration Tree\",\"enabled\":true,\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}},\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/Registration"
+        },
+        "response": {
+          "bodySize": 1056,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1056,
+            "text": "{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1056"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.951Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "aed97a9b5b18b5ca1d2a1f407b85f7b1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 595,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 15873,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 15873,
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-1854762395\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"description\":\"Reset Password Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}}},{\"_id\":\"Agent\",\"_rev\":\"1590168042\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Agent\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"35cb0861-c160-47ff-808c-3429ba18772c\":{\"connections\":{\"outcome\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":350,\"y\":200},\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\":{\"connections\":{\"false\":\"35cb0861-c160-47ff-808c-3429ba18772c\",\"true\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25},\"7a910023-cad2-4f49-9ce0-1a0c711613d3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Agent Data Store Decision\",\"nodeType\":\"AgentDataStoreDecisionNode\",\"x\":700,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"InnerTest\",\"_rev\":\"-1762283053\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"innerTreeOnly\":true,\"description\":\"Inner Test Journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"},\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}}},{\"_id\":\"amsterService\",\"_rev\":\"-1457460165\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Amster utility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Amster Jwt Decision Node\",\"nodeType\":\"AmsterJwtDecisionNode\",\"x\":200,\"y\":30}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":500,\"y\":130},\"startNode\":{\"x\":50,\"y\":30}}},{\"_id\":\"Test\",\"_rev\":\"2131508795\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}},{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}},{\"_id\":\"ldapService\",\"_rev\":\"-1619916438\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\",\"innerTreeOnly\":false,\"description\":\"Authentication tree replacing old default chain for backward compatibility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"6c8349cc-7260-3e62-a3b1-396831a8398a\":{\"connections\":{\"outcome\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":500,\"y\":25},\"c81e728d-9d4c-3f63-af06-7f89cc14862d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":800,\"y\":25},\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\":{\"connections\":{\"false\":\"6c8349cc-7260-3e62-a3b1-396831a8398a\",\"true\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ForgottenUsername\",\"_rev\":\"350164141\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"description\":\"Forgotten Username Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":139,\"y\":146},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":767,\"y\":188},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":324,\"y\":152},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":563,\"y\":193}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"TestJourney\",\"_rev\":\"-1352788891\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"innerTreeOnly\":false,\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[]\"},\"nodes\":{\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\":{\"connections\":{\"false\":\"804d3377-fbfe-4b05-902a-1ffcfdadb49e\",\"true\":\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":973,\"y\":224.015625},\"1b879025-76c8-4660-8b33-7c0c1f284482\":{\"connections\":{\"outcome\":\"abbaa271-85e9-4ad4-a0f5-d01dda4c35ef\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":442.34375,\"y\":235.015625},\"7d97831d-feb8-42d4-b665-f3bd596555ce\":{\"connections\":{\"outcome\":\"1b879025-76c8-4660-8b33-7c0c1f284482\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":199.34375,\"y\":149.015625},\"804d3377-fbfe-4b05-902a-1ffcfdadb49e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\"},\"displayName\":\"UserDoesNotExist\",\"nodeType\":\"MessageNode\",\"x\":1261,\"y\":359.015625},\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Message Node\",\"nodeType\":\"MessageNode\",\"x\":1322,\"y\":163.015625},\"abbaa271-85e9-4ad4-a0f5-d01dda4c35ef\":{\"connections\":{\"true\":\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\"},\"displayName\":\"DoesUserExist\",\"nodeType\":\"designer-user\",\"x\":711.765625,\"y\":252.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1946,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1818,\"y\":322},\"startNode\":{\"x\":50,\"y\":250}}},{\"_id\":\"UpdatePassword\",\"_rev\":\"1874809216\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"description\":\"Update password using active session\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"Login\",\"_rev\":\"-2008678727\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"description\":\"Platform Login Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":315,\"y\":140},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":815,\"y\":180},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":564,\"y\":132}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1008,\"y\":186},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":624,\"y\":267},\"startNode\":{\"x\":50,\"y\":25}}}],\"resultCount\":12,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.972Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "3170c9714f4c5f92d6fa82fd4dede3bf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1157,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1157"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 590,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"9b75654f-2553-4627-9938-b14a5f62ce81\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906960447,\"default\":false,\"description\":\"Debug script that prints the shared state\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784906960447,\"name\":\"Debug\",\"script\":\"dmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKKTsKCnZhciBzY3JpcHRPdXRjb21lcyA9IHsKICAgIE9VVENPTUU6ICdvdXRjb21lJywKfTsKCmZ1bmN0aW9uIG1haW4oKSB7CiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkgewogICAgICAgIHZhciBkZWJ1Z1N0YXRlID0gewogICAgICAgICAgICBzaGFyZWRTdGF0ZTogc2hhcmVkU3RhdGUsCiAgICAgICAgICAgIHRyYW5zaWVudFN0YXRlOiB0cmFuc2llbnRTdGF0ZQogICAgICAgIH07CiAgICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQobmV3IGZyLlRleHRPdXRwdXRDYWxsYmFjaygwLCBgPHByZSBzdHlsZT0idGV4dC1hbGlnbjogbGVmdDsiPiR7SlNPTi5zdHJpbmdpZnkoZGVidWdTdGF0ZSwgbnVsbCwgMil9PC9wcmU+YCkpLmJ1aWxkKCk7CiAgICAgICAgcmV0dXJuOwogICAgfQogICAgb3V0Y29tZSA9IHNjcmlwdE91dGNvbWVzLk9VVENPTUU7Cn0KCm1haW4oKTsK\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/scripts/9b75654f-2553-4627-9938-b14a5f62ce81"
+        },
+        "response": {
+          "bodySize": 1157,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1157,
+            "text": "{\"_id\":\"9b75654f-2553-4627-9938-b14a5f62ce81\",\"name\":\"Debug\",\"description\":\"Debug script that prints the shared state\",\"script\":\"dmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKKTsKCnZhciBzY3JpcHRPdXRjb21lcyA9IHsKICAgIE9VVENPTUU6ICdvdXRjb21lJywKfTsKCmZ1bmN0aW9uIG1haW4oKSB7CiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkgewogICAgICAgIHZhciBkZWJ1Z1N0YXRlID0gewogICAgICAgICAgICBzaGFyZWRTdGF0ZTogc2hhcmVkU3RhdGUsCiAgICAgICAgICAgIHRyYW5zaWVudFN0YXRlOiB0cmFuc2llbnRTdGF0ZQogICAgICAgIH07CiAgICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQobmV3IGZyLlRleHRPdXRwdXRDYWxsYmFjaygwLCBgPHByZSBzdHlsZT0idGV4dC1hbGlnbjogbGVmdDsiPiR7SlNPTi5zdHJpbmdpZnkoZGVidWdTdGF0ZSwgbnVsbCwgMil9PC9wcmU+YCkpLmJ1aWxkKCk7CiAgICAgICAgcmV0dXJuOwogICAgfQogICAgb3V0Y29tZSA9IHNjcmlwdE91dGNvbWVzLk9VVENPTUU7Cn0KCm1haW4oKTsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906960447,\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784908986905,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1157"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 609,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.986Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "436cf155a105359b03d5e6e0479de38b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 629,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "629"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961100,\"default\":false,\"description\":\"Test\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784906961100,\"name\":\"Test Groovy Script\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/scripts/bd027bdf-002d-42e2-a549-d5fdb0d6605a"
+        },
+        "response": {
+          "bodySize": 629,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 629,
+            "text": "{\"_id\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\",\"name\":\"Test Groovy Script\",\"description\":\"Test\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961100,\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784908986926,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "629"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.005Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "491201c0171b4ed0c996e2f7090d8135",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 617,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "617"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\",\"context\":\"SCRIPTED_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961115,\"default\":false,\"description\":\"null\",\"evaluatorVersion\":\"2.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784906961115,\"name\":\"Test Next Gen\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/scripts/3d27b6d3-0f41-410a-9975-2e9df43d885e"
+        },
+        "response": {
+          "bodySize": 617,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 617,
+            "text": "{\"_id\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\",\"name\":\"Test Next Gen\",\"description\":\"null\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SCRIPTED_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961115,\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784908986950,\"evaluatorVersion\":\"2.0\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "617"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 609,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.023Z",
+        "time": 17,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 17
+        }
+      },
+      {
+        "_id": "fb1b184542b1448c03c21dd9e044a557",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 287,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "287"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"outcome\"],\"outputs\":[\"*\"],\"script\":\"9b75654f-2553-4627-9938-b14a5f62ce81\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/5d969de4-98c8-44ab-9df1-4de9170205eb"
+        },
+        "response": {
+          "bodySize": 308,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 308,
+            "text": "{\"_id\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"_rev\":\"-1660489373\",\"script\":\"9b75654f-2553-4627-9938-b14a5f62ce81\",\"outcomes\":[\"outcome\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "308"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.047Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "cd186bee6882923ebc1de3568ad76ebc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 323,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "323"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\",\"_outcomes\":[{\"displayName\":\"true\",\"id\":\"true\"},{\"displayName\":\"false\",\"id\":\"false\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"script\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/fd51424b-2a28-41a9-bc3e-44c2adc61a62"
+        },
+        "response": {
+          "bodySize": 343,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 343,
+            "text": "{\"_id\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\",\"_rev\":\"-890383722\",\"script\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\",\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"true\"},{\"id\":\"false\",\"displayName\":\"false\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "343"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.066Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "634f4bc4772ea6429f15af12cb41e7a0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 323,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "323"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\",\"_outcomes\":[{\"displayName\":\"true\",\"id\":\"true\"},{\"displayName\":\"false\",\"id\":\"false\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"script\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/af596d89-e0ae-41c9-b1f5-e7318f517e2d"
+        },
+        "response": {
+          "bodySize": 342,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 342,
+            "text": "{\"_id\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\",\"_rev\":\"919944373\",\"script\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\",\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"true\"},{\"id\":\"false\",\"displayName\":\"false\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "342"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.083Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "53eeaecac33e81ef38d7c8b0de06907d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1066,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1066"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 609,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"InnerTest\",\"description\":\"Inner Test Journey\",\"enabled\":true,\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":true,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}},\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees/InnerTest"
+        },
+        "response": {
+          "bodySize": 1087,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1087,
+            "text": "{\"_id\":\"InnerTest\",\"_rev\":\"-1762283053\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"innerTreeOnly\":true,\"description\":\"Inner Test Journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"},\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1087"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.098Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "d5b2c0840d57b2b0eb02b12160a60382",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 226,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "226"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"collection\":true,\"name\":\"Display State\"},\"displayFormat\":\"TABLE\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-8ab9f1aad4b4460a9c45d15fb148e221/df153624-6d66-4e82-9b62-8cee4d62ab8f"
+        },
+        "response": {
+          "bodySize": 246,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 246,
+            "text": "{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"_rev\":\"1300434121\",\"displayFormat\":\"TABLE\",\"_type\":{\"_id\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"name\":\"Display State\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "246"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.113Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "84b90775da82fcb50bfa0db951972301",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 294,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "294"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"collection\":true,\"name\":\"Display Callback\"},\"callback\":\"TEXT_OUTPUT_CALLBACK\",\"options\":{\"message\":\"Hello World!\",\"messageType\":\"0\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-ef81b1a52c914710b3388caebfe7233a/cccb0cb9-a134-4f52-a499-55d4f095ac81"
+        },
+        "response": {
+          "bodySize": 314,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 314,
+            "text": "{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"_rev\":\"-248191681\",\"callback\":\"TEXT_OUTPUT_CALLBACK\",\"options\":{\"message\":\"Hello World!\",\"messageType\":\"0\"},\"_type\":{\"_id\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"name\":\"Display Callback\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "314"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.130Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "7b455d0b474bd76766ff8820b93c3145",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 260,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "260"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"1bfea910-5d16-4439-b0db-70c3245644e1\",\"_outcomes\":[{\"displayName\":\"Success\",\"id\":\"Success\"},{\"displayName\":\"Script Error\",\"id\":\"Script Error\"}],\"_type\":{\"_id\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"collection\":true,\"name\":\"ALU\"},\"operator\":\"ADD\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c6063fb2f5dc42dd9772bedc93898bd8/1bfea910-5d16-4439-b0db-70c3245644e1"
+        },
+        "response": {
+          "bodySize": 278,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 278,
+            "text": "{\"_id\":\"1bfea910-5d16-4439-b0db-70c3245644e1\",\"_rev\":\"71843373\",\"operator\":\"ADD\",\"_type\":{\"_id\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"name\":\"ALU\",\"collection\":true},\"_outcomes\":[{\"id\":\"Success\",\"displayName\":\"Success\"},{\"id\":\"Script Error\",\"displayName\":\"Script Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "278"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.151Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      },
+      {
+        "_id": "0cb5165a45eb34813b96bb9128c27698",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 231,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "231"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"True\"},{\"displayName\":\"False\",\"id\":\"False\"}],\"_type\":{\"_id\":\"designer-c605506774a848f7877b4d17a453bd39\",\"collection\":true,\"name\":\"Has Session\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c605506774a848f7877b4d17a453bd39/02e10086-108c-441c-b14b-cc2054ef7483"
+        },
+        "response": {
+          "bodySize": 251,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 251,
+            "text": "{\"_id\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"_rev\":\"1815890486\",\"_type\":{\"_id\":\"designer-c605506774a848f7877b4d17a453bd39\",\"name\":\"Has Session\",\"collection\":true},\"_outcomes\":[{\"id\":\"True\",\"displayName\":\"True\"},{\"id\":\"False\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "251"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.165Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "dc375c86ec31d265bf7ca0cad2a56772",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 304,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "304"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 658,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"},{\"displayName\":\"Error\",\"id\":\"error\"}],\"_type\":{\"_id\":\"InnerTreeEvaluatorNode\",\"collection\":true,\"name\":\"Inner Tree Evaluator\"},\"displayErrorOutcome\":true,\"tree\":\"InnerTest\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/InnerTreeEvaluatorNode/a77ddb64-45af-4f7b-a734-8a8294f53294"
+        },
+        "response": {
+          "bodySize": 324,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 324,
+            "text": "{\"_id\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\",\"_rev\":\"-998861558\",\"displayErrorOutcome\":true,\"tree\":\"InnerTest\",\"_type\":{\"_id\":\"InnerTreeEvaluatorNode\",\"name\":\"Inner Tree Evaluator\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"},{\"id\":\"error\",\"displayName\":\"Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "324"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.177Z",
+        "time": 17,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 17
+        }
+      },
+      {
+        "_id": "f267f8e3d4d260de5b341a6f37972491",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 654,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "654"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"displayName\":\"Display State\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\"},{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"displayName\":\"Hello World!\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\"}],\"pageDescription\":{\"en\":\"Description\"},\"pageHeader\":{\"en\":\"Header\"},\"stage\":\"{\\\"submitButtonText\\\":{\\\"en\\\":\\\"Submit Button\\\"},\\\"pageFooter\\\":{\\\"en\\\":\\\"Footer\\\"},\\\"themeId\\\":\\\"a9bc15cf-8d9c-4bfb-8979-67a5f5823227\\\"}\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/PageNode/e78ff99e-59f8-4302-93b7-1770f18b4ae7"
+        },
+        "response": {
+          "bodySize": 673,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 673,
+            "text": "{\"_id\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\",\"_rev\":\"942720118\",\"nodes\":[{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"displayName\":\"Display State\"},{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"displayName\":\"Hello World!\"}],\"pageDescription\":{\"en\":\"Description\"},\"stage\":\"{\\\"submitButtonText\\\":{\\\"en\\\":\\\"Submit Button\\\"},\\\"pageFooter\\\":{\\\"en\\\":\\\"Footer\\\"},\\\"themeId\\\":\\\"a9bc15cf-8d9c-4bfb-8979-67a5f5823227\\\"}\",\"pageHeader\":{\"en\":\"Header\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "673"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.199Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "41b7d3c748449dfd1fb5b60fa8bfca37",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 293,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "293"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"_outcomes\":[{\"displayName\":\"Success\",\"id\":\"Success\"},{\"displayName\":\"Script Error\",\"id\":\"Script Error\"}],\"_type\":{\"_id\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"collection\":true,\"name\":\"Vector ALU\"},\"a\":[1,2,3],\"b\":[4,5,6],\"operator\":\"CROSS\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c15e2efb3deb4d4ea338c74a6440b69f/0dd3743e-2aaf-4a4a-9e83-a64490303a10"
+        },
+        "response": {
+          "bodySize": 313,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 313,
+            "text": "{\"_id\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"_rev\":\"1826892730\",\"a\":[1,2,3],\"operator\":\"CROSS\",\"b\":[4,5,6],\"_type\":{\"_id\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"name\":\"Vector ALU\",\"collection\":true},\"_outcomes\":[{\"id\":\"Success\",\"displayName\":\"Success\"},{\"id\":\"Script Error\",\"displayName\":\"Script Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "313"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.217Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "a8e6d62af4ac47c99d148821710c85d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1616,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1616"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 604,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"Test\",\"description\":\"Test journey\",\"enabled\":true,\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}},\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees/Test"
+        },
+        "response": {
+          "bodySize": 1636,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1636,
+            "text": "{\"_id\":\"Test\",\"_rev\":\"2131508795\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1636"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:07.231Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_d_D_m_639961791/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_d_D_m_639961791/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_d_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 562,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=9_e0GNMrt9x_Mo6X61MSWZfR40A.*AAJTSQACMDIAAlNLABxrN0t3dDV3Mm5kOHpJTnRBMDR1MlBaRHhiUW89AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=cumvtfswjvxo0pdtTgaybWh_ZDcIGXm3lgHJNk-Wm5o&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=y6bXCL-s7gR0iO1BKm6W8RnE0L0&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 673,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=y6bXCL-s7gR0iO1BKm6W8RnE0L0&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.610Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=y6bXCL-s7gR0iO1BKm6W8RnE0L0&code_verifier=btIKx2LPOXhdMugIQcVtRdZQ-PKRDfXmBo3aeMW2x1A"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:06.630Z",
+        "time": 47,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 47
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_directory_m_3384805835/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_directory_m_3384805835/am_1076162899/recording.har
@@ -1,0 +1,3135 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_directory_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 367,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 585,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 585,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-2120245986\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"true\",\"forgotUsername\":\"true\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"true\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "585"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.642Z",
+        "time": 26,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 26
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "<username>"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "<password>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 494,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 692,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.677Z",
+        "time": 20,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 20
+        }
+      },
+      {
+        "_id": "7a2803b95b7b030f104baf5a89ef50c3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 434,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-07-24T16:04:07Z\",\"maxIdleExpirationTime\":\"2026-07-24T16:34:07Z\",\"maxSessionExpirationTime\":\"2026-07-24T18:04:06Z\",\"properties\":{\"AMCtxId\":\"ac50ecb2-03a1-4d64-b223-6b1ec81a8354-22515\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.708Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 517,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.720Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "1b5684afd52c9eaef24954b59c4a12b3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 608,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 14371,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 14371,
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"2074770462\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"description\":\"Reset Password Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}}},{\"_id\":\"Agent\",\"_rev\":\"1224733603\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Agent\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"35cb0861-c160-47ff-808c-3429ba18772c\":{\"connections\":{\"outcome\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":350,\"y\":200},\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\":{\"connections\":{\"false\":\"35cb0861-c160-47ff-808c-3429ba18772c\",\"true\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25},\"7a910023-cad2-4f49-9ce0-1a0c711613d3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Agent Data Store Decision\",\"nodeType\":\"AgentDataStoreDecisionNode\",\"x\":700,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"amsterService\",\"_rev\":\"-1822894604\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Amster utility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Amster Jwt Decision Node\",\"nodeType\":\"AmsterJwtDecisionNode\",\"x\":200,\"y\":30}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":500,\"y\":130},\"startNode\":{\"x\":50,\"y\":30}}},{\"_id\":\"Test\",\"_rev\":\"1763194779\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"cccb0cb9-a134-4f52-a499-55d4f095ac81\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Hello World!\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"x\":1136,\"y\":181.5},\"df153624-6d66-4e82-9b62-8cee4d62ab8f\":{\"connections\":{\"outcome\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\"},\"displayName\":\"Display State\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"x\":900,\"y\":181.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1390,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}},{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}},{\"_id\":\"ldapService\",\"_rev\":\"-1985350877\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\",\"innerTreeOnly\":false,\"description\":\"Authentication tree replacing old default chain for backward compatibility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"6c8349cc-7260-3e62-a3b1-396831a8398a\":{\"connections\":{\"outcome\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":500,\"y\":25},\"c81e728d-9d4c-3f63-af06-7f89cc14862d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":800,\"y\":25},\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\":{\"connections\":{\"false\":\"6c8349cc-7260-3e62-a3b1-396831a8398a\",\"true\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ForgottenUsername\",\"_rev\":\"-15270298\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"description\":\"Forgotten Username Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":139,\"y\":146},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":767,\"y\":188},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":324,\"y\":152},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":563,\"y\":193}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"TestJourney\",\"_rev\":\"2029200158\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"innerTreeOnly\":false,\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[]\"},\"nodes\":{\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":726,\"y\":242.015625},\"1b879025-76c8-4660-8b33-7c0c1f284482\":{\"connections\":{\"outcome\":\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":496.34375,\"y\":188.015625},\"7d97831d-feb8-42d4-b665-f3bd596555ce\":{\"connections\":{\"outcome\":\"1b879025-76c8-4660-8b33-7c0c1f284482\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":199.34375,\"y\":149.015625},\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\":{\"connections\":{\"false\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Message Node\",\"nodeType\":\"MessageNode\",\"x\":1002,\"y\":145.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1413,\"y\":101},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1453,\"y\":305},\"startNode\":{\"x\":50,\"y\":250}}},{\"_id\":\"UpdatePassword\",\"_rev\":\"1509374777\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"description\":\"Update password using active session\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"Login\",\"_rev\":\"1920854130\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"description\":\"Platform Login Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":315,\"y\":140},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":815,\"y\":180},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":564,\"y\":132}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1008,\"y\":186},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":624,\"y\":267},\"startNode\":{\"x\":50,\"y\":25}}}],\"resultCount\":11,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.799Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "d663e422cad83e6d294e6d397d78eccd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 330,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "330"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AttributeCollectorNode\",\"collection\":true,\"name\":\"Attribute Collector\"},\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"required\":false,\"validateInputs\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AttributeCollectorNode/0a042e10-b22e-4e02-86c4-65e26e775f7a"
+        },
+        "response": {
+          "bodySize": 351,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 351,
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_rev\":\"-1210529544\",\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"validateInputs\":false,\"required\":false,\"_type\":{\"_id\":\"AttributeCollectorNode\",\"name\":\"Attribute Collector\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "351"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.811Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "9f50669cef70f1d266b118bacae869a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 279,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "279"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"collection\":true,\"name\":\"Login Count Decision\"},\"amount\":3,\"identityAttribute\":\"userName\",\"interval\":\"AT\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/LoginCountDecisionNode/8afdaec3-275e-4301-bb53-34f03e6a4b29"
+        },
+        "response": {
+          "bodySize": 300,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 300,
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_rev\":\"-1679047423\",\"interval\":\"AT\",\"identityAttribute\":\"userName\",\"amount\":3,\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"name\":\"Login Count Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "300"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.828Z",
+        "time": 23,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 23
+        }
+      },
+      {
+        "_id": "5bf7a3c05d0d0c056989843ee2145a5f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 368,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "368"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"displayName\":\"Attribute Collector\",\"nodeType\":\"AttributeCollectorNode\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PageNode/a5aecad8-854a-4ed5-b719-ff6c90e858c0"
+        },
+        "response": {
+          "bodySize": 387,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 387,
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_rev\":\"380010937\",\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"nodeType\":\"AttributeCollectorNode\",\"displayName\":\"Attribute Collector\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "387"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.858Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "de387377a7d1bddbfddef87b12edd95c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 321,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "321"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_outcomes\":[{\"displayName\":\"Patched\",\"id\":\"PATCHED\"},{\"displayName\":\"Failed\",\"id\":\"FAILURE\"}],\"_type\":{\"_id\":\"PatchObjectNode\",\"collection\":true,\"name\":\"Patch Object\"},\"identityAttribute\":\"userName\",\"identityResource\":\"managed/user\",\"ignoredFields\":[],\"patchAsObject\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PatchObjectNode/423a959a-a1b9-498a-b0f7-596b6b6e775a"
+        },
+        "response": {
+          "bodySize": 341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 341,
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_rev\":\"1653653564\",\"identityResource\":\"managed/user\",\"patchAsObject\":false,\"ignoredFields\":[],\"identityAttribute\":\"userName\",\"_type\":{\"_id\":\"PatchObjectNode\",\"name\":\"Patch Object\",\"collection\":true},\"_outcomes\":[{\"id\":\"PATCHED\",\"displayName\":\"Patched\"},{\"id\":\"FAILURE\",\"displayName\":\"Failed\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "341"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.876Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "bf8abff157b418baf082abf1eea8d367",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 357,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "357"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"collection\":true,\"name\":\"Query Filter Decision\"},\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/QueryFilterDecisionNode/a1f45b44-5bf7-4c57-aa3f-75c619c7db8e"
+        },
+        "response": {
+          "bodySize": 378,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 378,
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_rev\":\"-1852493841\",\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\",\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"name\":\"Query Filter Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "378"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.894Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      },
+      {
+        "_id": "7cd28cef37196c568770627ac6ea91e4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1345,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1345"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"ProgressiveProfile\",\"description\":\"Prompt for missing preferences on 3rd login\",\"enabled\":true,\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"identityResource\":\"managed/user\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/ProgressiveProfile"
+        },
+        "response": {
+          "bodySize": 1365,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1365,
+            "text": "{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1365"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.910Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      },
+      {
+        "_id": "eb402c29429bf97094f16f932bc2309f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 203,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "203"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AcceptTermsAndConditionsNode\",\"collection\":true,\"name\":\"Accept Terms and Conditions\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AcceptTermsAndConditionsNode/b4a0e915-c15d-4b83-9c9d-18347d645976"
+        },
+        "response": {
+          "bodySize": 223,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 223,
+            "text": "{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"_rev\":\"1508860909\",\"_type\":{\"_id\":\"AcceptTermsAndConditionsNode\",\"name\":\"Accept Terms and Conditions\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "223"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.924Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "36b21aa1bc294f78f1ca34bd202512c2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 352,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "352"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AttributeCollectorNode\",\"collection\":true,\"name\":\"Attribute Collector\"},\"attributesToCollect\":[\"givenName\",\"sn\",\"mail\",\"preferences/marketing\",\"preferences/updates\"],\"identityAttribute\":\"userName\",\"required\":true,\"validateInputs\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AttributeCollectorNode/d3ce2036-1523-4ce8-b1a2-895a2a036667"
+        },
+        "response": {
+          "bodySize": 373,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 373,
+            "text": "{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"_rev\":\"-1158802257\",\"attributesToCollect\":[\"givenName\",\"sn\",\"mail\",\"preferences/marketing\",\"preferences/updates\"],\"identityAttribute\":\"userName\",\"validateInputs\":true,\"required\":true,\"_type\":{\"_id\":\"AttributeCollectorNode\",\"name\":\"Attribute Collector\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "373"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.936Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "5568f99587cdb4ad5698eda16a68abff",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 254,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "254"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 662,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"KbaCreateNode\",\"collection\":true,\"name\":\"KBA Definition\"},\"allowUserDefinedQuestions\":true,\"message\":{\"en\":\"Select a security question\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/KbaCreateNode/120c69d3-90b4-4ad4-b7af-380e8b119340"
+        },
+        "response": {
+          "bodySize": 272,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 272,
+            "text": "{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"_rev\":\"-8134977\",\"message\":{\"en\":\"Select a security question\"},\"allowUserDefinedQuestions\":true,\"_type\":{\"_id\":\"KbaCreateNode\",\"name\":\"KBA Definition\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "272"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.957Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "ca4d8e41f37bdd8385c1f9650c6df366",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 238,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "238"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 670,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ValidatedPasswordNode\",\"collection\":true,\"name\":\"Platform Password\"},\"passwordAttribute\":\"password\",\"validateInput\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/ValidatedPasswordNode/3d8709a1-f09f-4d1f-8094-2850e472c1db"
+        },
+        "response": {
+          "bodySize": 259,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 259,
+            "text": "{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"_rev\":\"-1470058997\",\"passwordAttribute\":\"password\",\"validateInput\":true,\"_type\":{\"_id\":\"ValidatedPasswordNode\",\"name\":\"Platform Password\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "259"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.972Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "5bb4b35c45ac8f313597e0627af411d9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 238,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "238"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 670,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ValidatedUsernameNode\",\"collection\":true,\"name\":\"Platform Username\"},\"usernameAttribute\":\"userName\",\"validateInput\":true}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/ValidatedUsernameNode/7fcaf48e-a754-4959-858b-05b2933b825f"
+        },
+        "response": {
+          "bodySize": 258,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 258,
+            "text": "{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"_rev\":\"1966656034\",\"usernameAttribute\":\"userName\",\"validateInput\":true,\"_type\":{\"_id\":\"ValidatedUsernameNode\",\"name\":\"Platform Username\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "258"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.990Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "29d2ae85418190df3c497979f6614909",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 251,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "251"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 665,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\",\"_outcomes\":[{\"displayName\":\"Created\",\"id\":\"CREATED\"},{\"displayName\":\"Failed\",\"id\":\"FAILURE\"}],\"_type\":{\"_id\":\"CreateObjectNode\",\"collection\":true,\"name\":\"Create Object\"},\"identityResource\":\"managed/user\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/CreateObjectNode/ad5dcbb3-7335-49b7-b3e7-7d850bb88237"
+        },
+        "response": {
+          "bodySize": 271,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 271,
+            "text": "{\"_id\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\",\"_rev\":\"-246787506\",\"identityResource\":\"managed/user\",\"_type\":{\"_id\":\"CreateObjectNode\",\"name\":\"Create Object\",\"collection\":true},\"_outcomes\":[{\"id\":\"CREATED\",\"displayName\":\"Created\"},{\"id\":\"FAILURE\",\"displayName\":\"Failed\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "271"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:08.007Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "5dd9ed00720d6b432f318680314e1102",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 223,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "223"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"IncrementLoginCountNode\",\"collection\":true,\"name\":\"Increment Login Count\"},\"identityAttribute\":\"userName\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/IncrementLoginCountNode/97a15eb2-a015-4b6d-81a0-be78c3aa1a3b"
+        },
+        "response": {
+          "bodySize": 243,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 243,
+            "text": "{\"_id\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"_rev\":\"-841385771\",\"identityAttribute\":\"userName\",\"_type\":{\"_id\":\"IncrementLoginCountNode\",\"name\":\"Increment Login Count\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "243"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:08.025Z",
+        "time": 11,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 11
+        }
+      },
+      {
+        "_id": "790f49120b2a4bedf3a70f1390822f9e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 916,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "916"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"displayName\":\"Platform Username\",\"nodeType\":\"ValidatedUsernameNode\"},{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"displayName\":\"Attribute Collector\",\"nodeType\":\"AttributeCollectorNode\"},{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"displayName\":\"Platform Password\",\"nodeType\":\"ValidatedPasswordNode\"},{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"displayName\":\"KBA Definition\",\"nodeType\":\"KbaCreateNode\"},{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"displayName\":\"Accept Terms and Conditions\",\"nodeType\":\"AcceptTermsAndConditionsNode\"}],\"pageDescription\":{\"en\":\"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>\"},\"pageHeader\":{\"en\":\"Sign Up\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PageNode/0c091c49-f3af-48fb-ac6f-07fba0499dd6"
+        },
+        "response": {
+          "bodySize": 935,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 935,
+            "text": "{\"_id\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"_rev\":\"762531723\",\"nodes\":[{\"_id\":\"7fcaf48e-a754-4959-858b-05b2933b825f\",\"nodeType\":\"ValidatedUsernameNode\",\"displayName\":\"Platform Username\"},{\"_id\":\"d3ce2036-1523-4ce8-b1a2-895a2a036667\",\"nodeType\":\"AttributeCollectorNode\",\"displayName\":\"Attribute Collector\"},{\"_id\":\"3d8709a1-f09f-4d1f-8094-2850e472c1db\",\"nodeType\":\"ValidatedPasswordNode\",\"displayName\":\"Platform Password\"},{\"_id\":\"120c69d3-90b4-4ad4-b7af-380e8b119340\",\"nodeType\":\"KbaCreateNode\",\"displayName\":\"KBA Definition\"},{\"_id\":\"b4a0e915-c15d-4b83-9c9d-18347d645976\",\"nodeType\":\"AcceptTermsAndConditionsNode\",\"displayName\":\"Accept Terms and Conditions\"}],\"pageDescription\":{\"en\":\"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>\"},\"pageHeader\":{\"en\":\"Sign Up\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "935"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:08.044Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "ef594d6e195f232722a7318404c7480e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1036,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1036"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 625,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"Registration\",\"description\":\"Platform Registration Tree\",\"enabled\":true,\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}},\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/Registration"
+        },
+        "response": {
+          "bodySize": 1056,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1056,
+            "text": "{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1056"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:08.063Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_directory_m_3384805835/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_directory_m_3384805835/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_directory_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 562,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=T1OcxBiR_GZbiZmNypc6KzCfZIk.*AAJTSQACMDIAAlNLABxDdkpLOE5YTHNjTkJnTXJralFUMlVUdFpFTEk9AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=6PyQunx5kZAT4KDHJMtje1iCdkdybcMtkfuv7attX3U&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=PmYMB6XExIWlNFxLhu2x59Z0CKA&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=PmYMB6XExIWlNFxLhu2x59Z0CKA&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.731Z",
+        "time": 16,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 16
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=PmYMB6XExIWlNFxLhu2x59Z0CKA&code_verifier=geiM5qx2Zt-OVQegUi4XW7C3UpGibwiL6VtxgmCwsxI"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:04:07.754Z",
+        "time": 38,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 38
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_D_m_1348920437/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_D_m_1348920437/am_1076162899/recording.har
@@ -1,0 +1,1722 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_n_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 367,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 585,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 585,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-2120245986\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"true\",\"forgotUsername\":\"true\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"true\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "585"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.268Z",
+        "time": 29,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 29
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "<username>"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "<password>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 494,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 693,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.303Z",
+        "time": 19,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 19
+        }
+      },
+      {
+        "_id": "6a3744385d3fd7416ea7089e610fa7e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-07-24T16:02:41Z\",\"maxIdleExpirationTime\":\"2026-07-24T16:32:41Z\",\"maxSessionExpirationTime\":\"2026-07-24T18:02:40Z\",\"properties\":{\"AMCtxId\":\"ac50ecb2-03a1-4d64-b223-6b1ec81a8354-21811\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.329Z",
+        "time": 6,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 517,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.343Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "1b5684afd52c9eaef24954b59c4a12b3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 608,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 14371,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 14371,
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"2074770462\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"description\":\"Reset Password Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}}},{\"_id\":\"Agent\",\"_rev\":\"1224733603\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Agent\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"35cb0861-c160-47ff-808c-3429ba18772c\":{\"connections\":{\"outcome\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":350,\"y\":200},\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\":{\"connections\":{\"false\":\"35cb0861-c160-47ff-808c-3429ba18772c\",\"true\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25},\"7a910023-cad2-4f49-9ce0-1a0c711613d3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Agent Data Store Decision\",\"nodeType\":\"AgentDataStoreDecisionNode\",\"x\":700,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"amsterService\",\"_rev\":\"-1822894604\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Amster utility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Amster Jwt Decision Node\",\"nodeType\":\"AmsterJwtDecisionNode\",\"x\":200,\"y\":30}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":500,\"y\":130},\"startNode\":{\"x\":50,\"y\":30}}},{\"_id\":\"Test\",\"_rev\":\"1763194779\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"cccb0cb9-a134-4f52-a499-55d4f095ac81\":{\"connections\":{\"outcome\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Hello World!\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"x\":1136,\"y\":181.5},\"df153624-6d66-4e82-9b62-8cee4d62ab8f\":{\"connections\":{\"outcome\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\"},\"displayName\":\"Display State\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"x\":900,\"y\":181.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1390,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}},{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}},{\"_id\":\"ldapService\",\"_rev\":\"-1985350877\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\",\"innerTreeOnly\":false,\"description\":\"Authentication tree replacing old default chain for backward compatibility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"6c8349cc-7260-3e62-a3b1-396831a8398a\":{\"connections\":{\"outcome\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":500,\"y\":25},\"c81e728d-9d4c-3f63-af06-7f89cc14862d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":800,\"y\":25},\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\":{\"connections\":{\"false\":\"6c8349cc-7260-3e62-a3b1-396831a8398a\",\"true\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ForgottenUsername\",\"_rev\":\"-15270298\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"description\":\"Forgotten Username Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":139,\"y\":146},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":767,\"y\":188},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":324,\"y\":152},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":563,\"y\":193}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"TestJourney\",\"_rev\":\"2029200158\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"innerTreeOnly\":false,\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[]\"},\"nodes\":{\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":726,\"y\":242.015625},\"1b879025-76c8-4660-8b33-7c0c1f284482\":{\"connections\":{\"outcome\":\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":496.34375,\"y\":188.015625},\"7d97831d-feb8-42d4-b665-f3bd596555ce\":{\"connections\":{\"outcome\":\"1b879025-76c8-4660-8b33-7c0c1f284482\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":199.34375,\"y\":149.015625},\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\":{\"connections\":{\"false\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Message Node\",\"nodeType\":\"MessageNode\",\"x\":1002,\"y\":145.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1413,\"y\":101},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1453,\"y\":305},\"startNode\":{\"x\":50,\"y\":250}}},{\"_id\":\"UpdatePassword\",\"_rev\":\"1509374777\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"description\":\"Update password using active session\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"Login\",\"_rev\":\"1920854130\",\"identityResource\":\"managed/alpha_user\",\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"description\":\"Platform Login Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":315,\"y\":140},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":815,\"y\":180},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":564,\"y\":132}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1008,\"y\":186},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":624,\"y\":267},\"startNode\":{\"x\":50,\"y\":25}}}],\"resultCount\":11,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.430Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "d663e422cad83e6d294e6d397d78eccd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 330,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "330"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"AttributeCollectorNode\",\"collection\":true,\"name\":\"Attribute Collector\"},\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"required\":false,\"validateInputs\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/AttributeCollectorNode/0a042e10-b22e-4e02-86c4-65e26e775f7a"
+        },
+        "response": {
+          "bodySize": 351,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 351,
+            "text": "{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"_rev\":\"-1210529544\",\"attributesToCollect\":[\"preferences/updates\",\"preferences/marketing\"],\"identityAttribute\":\"userName\",\"validateInputs\":false,\"required\":false,\"_type\":{\"_id\":\"AttributeCollectorNode\",\"name\":\"Attribute Collector\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "351"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.446Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "9f50669cef70f1d266b118bacae869a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 279,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "279"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"collection\":true,\"name\":\"Login Count Decision\"},\"amount\":3,\"identityAttribute\":\"userName\",\"interval\":\"AT\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/LoginCountDecisionNode/8afdaec3-275e-4301-bb53-34f03e6a4b29"
+        },
+        "response": {
+          "bodySize": 300,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 300,
+            "text": "{\"_id\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"_rev\":\"-1679047423\",\"interval\":\"AT\",\"identityAttribute\":\"userName\",\"amount\":3,\"_type\":{\"_id\":\"LoginCountDecisionNode\",\"name\":\"Login Count Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "300"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.461Z",
+        "time": 15,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 15
+        }
+      },
+      {
+        "_id": "5bf7a3c05d0d0c056989843ee2145a5f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 368,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "368"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 657,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_outcomes\":[{\"displayName\":\"Outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"displayName\":\"Attribute Collector\",\"nodeType\":\"AttributeCollectorNode\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PageNode/a5aecad8-854a-4ed5-b719-ff6c90e858c0"
+        },
+        "response": {
+          "bodySize": 387,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 387,
+            "text": "{\"_id\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\",\"_rev\":\"380010937\",\"nodes\":[{\"_id\":\"0a042e10-b22e-4e02-86c4-65e26e775f7a\",\"nodeType\":\"AttributeCollectorNode\",\"displayName\":\"Attribute Collector\"}],\"pageDescription\":{},\"pageHeader\":{\"en\":\"Please select your preferences\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"Outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "387"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.483Z",
+        "time": 16,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 16
+        }
+      },
+      {
+        "_id": "de387377a7d1bddbfddef87b12edd95c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 321,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "321"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 664,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_outcomes\":[{\"displayName\":\"Patched\",\"id\":\"PATCHED\"},{\"displayName\":\"Failed\",\"id\":\"FAILURE\"}],\"_type\":{\"_id\":\"PatchObjectNode\",\"collection\":true,\"name\":\"Patch Object\"},\"identityAttribute\":\"userName\",\"identityResource\":\"managed/user\",\"ignoredFields\":[],\"patchAsObject\":false}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/PatchObjectNode/423a959a-a1b9-498a-b0f7-596b6b6e775a"
+        },
+        "response": {
+          "bodySize": 341,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 341,
+            "text": "{\"_id\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\",\"_rev\":\"1653653564\",\"identityResource\":\"managed/user\",\"patchAsObject\":false,\"ignoredFields\":[],\"identityAttribute\":\"userName\",\"_type\":{\"_id\":\"PatchObjectNode\",\"name\":\"Patch Object\",\"collection\":true},\"_outcomes\":[{\"id\":\"PATCHED\",\"displayName\":\"Patched\"},{\"id\":\"FAILURE\",\"displayName\":\"Failed\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "341"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.506Z",
+        "time": 15,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 15
+        }
+      },
+      {
+        "_id": "bf8abff157b418baf082abf1eea8d367",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 357,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "357"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 672,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"}],\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"collection\":true,\"name\":\"Query Filter Decision\"},\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/nodes/QueryFilterDecisionNode/a1f45b44-5bf7-4c57-aa3f-75c619c7db8e"
+        },
+        "response": {
+          "bodySize": 378,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 378,
+            "text": "{\"_id\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\",\"_rev\":\"-1852493841\",\"identityAttribute\":\"userName\",\"queryFilter\":\"!(/preferences pr) or /preferences/marketing eq false or /preferences/updates eq false\",\"_type\":{\"_id\":\"QueryFilterDecisionNode\",\"name\":\"Query Filter Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "378"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.528Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "7cd28cef37196c568770627ac6ea91e4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1345,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1345"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"ProgressiveProfile\",\"description\":\"Prompt for missing preferences on 3rd login\",\"enabled\":true,\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}},\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"identityResource\":\"managed/user\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realms/alpha/realm-config/authentication/authenticationtrees/trees/ProgressiveProfile"
+        },
+        "response": {
+          "bodySize": 1365,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1365,
+            "text": "{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1365"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.550Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_D_m_1348920437/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_D_m_1348920437/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_n_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 562,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=2HQUl19zohmwhmxsbZGf7ATh29k.*AAJTSQACMDIAAlNLABxoRjREdjZsd0Qvd3hXN0xkK0lUQnBhOG96cjA9AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=M4380glfLmuaDJ89iMyMf8Ht6Ag5SBrUTeOrXRKMRAY&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=dYnr9op1rg_NIBBcyv1j6yoRrJo&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 671,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=dYnr9op1rg_NIBBcyv1j6yoRrJo&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.356Z",
+        "time": 18,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 18
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=dYnr9op1rg_NIBBcyv1j6yoRrJo&code_verifier=bGK5rU1dokfGAOrd34elFTLOqaowXd-QzQzsOE822DY"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 404,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:02:41.381Z",
+        "time": 41,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 41
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_d_D_m_742098390/am_1076162899/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_d_D_m_742098390/am_1076162899/recording.har
@@ -1,0 +1,3123 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_n_d_D_m/am",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ccd7a5defd0fdeaa986a2b54642d911a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 367,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/*"
+        },
+        "response": {
+          "bodySize": 585,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 585,
+            "text": "{\"_id\":\"*\",\"_rev\":\"-2120245986\",\"domains\":[],\"protectedUserAttributes\":[\"telephoneNumber\",\"mail\"],\"cookieName\":\"iPlanetDirectoryPro\",\"secureCookie\":true,\"forgotPassword\":\"true\",\"forgotUsername\":\"true\",\"kbaEnabled\":\"false\",\"selfRegistration\":\"true\",\"lang\":\"en-US\",\"successfulUserRegistrationDestination\":\"default\",\"socialImplementations\":[],\"referralsEnabled\":\"false\",\"zeroPageLogin\":{\"enabled\":false,\"refererWhitelist\":[],\"allowedWithoutReferer\":true},\"realm\":\"/\",\"xuiUserSessionValidationEnabled\":true,\"fileBasedConfiguration\":true,\"userIdAttributes\":[],\"nodeDesignerXuiEnabled\":true}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "585"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.228Z",
+        "time": 28,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 28
+        }
+      },
+      {
+        "_id": "9f5671275c36a1c0090d0df26ce0e93f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=2.0, protocol=1.0"
+            },
+            {
+              "name": "x-openam-username",
+              "value": "<username>"
+            },
+            {
+              "name": "x-openam-password",
+              "value": "<password>"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 494,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/authenticate"
+        },
+        "response": {
+          "bodySize": 167,
+          "content": {
+            "mimeType": "application/json",
+            "size": 167,
+            "text": "{\"tokenId\":\"<token id>\",\"successUrl\":\"/am/console\",\"realm\":\"/\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "iPlanetDirectoryPro",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "httpOnly": true,
+              "name": "amlbcookie",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "167"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "iPlanetDirectoryPro=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "amlbcookie=<cookie>; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=2.1"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 692,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.263Z",
+        "time": 20,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 20
+        }
+      },
+      {
+        "_id": "6a3744385d3fd7416ea7089e610fa7e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 128,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-length",
+              "value": "128"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"tokenId\":\"<token id>\"}"
+          },
+          "queryString": [
+            {
+              "name": "_action",
+              "value": "getSessionInfo"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/sessions/?_action=getSessionInfo"
+        },
+        "response": {
+          "bodySize": 291,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 291,
+            "text": "{\"username\":\"amadmin\",\"universalId\":\"id=amadmin,ou=user,ou=am-config\",\"realm\":\"/\",\"latestAccessTime\":\"2026-07-24T16:03:29Z\",\"maxIdleExpirationTime\":\"2026-07-24T16:33:29Z\",\"maxSessionExpirationTime\":\"2026-07-24T18:03:28Z\",\"properties\":{\"AMCtxId\":\"ac50ecb2-03a1-4d64-b223-6b1ec81a8354-22287\"}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "291"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=4.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 607,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.290Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "6125d0328ad0dcaee55f73fd8b22ca14",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 517,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/serverinfo/version"
+        },
+        "response": {
+          "bodySize": 257,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 257,
+            "text": "{\"_id\":\"version\",\"_rev\":\"-466575464\",\"version\":\"8.0.1\",\"fullVersion\":\"ForgeRock Access Management 8.0.1 Build b59bc0908346197b0c33afcb9e733d0400feeea1 (2025-April-15 11:37)\",\"revision\":\"b59bc0908346197b0c33afcb9e733d0400feeea1\",\"date\":\"2025-April-15 11:37\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "257"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.304Z",
+        "time": 5,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5
+        }
+      },
+      {
+        "_id": "aed97a9b5b18b5ca1d2a1f407b85f7b1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 595,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "_queryFilter",
+              "value": "true"
+            }
+          ],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees?_queryFilter=true"
+        },
+        "response": {
+          "bodySize": 15873,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 15873,
+            "text": "{\"result\":[{\"_id\":\"ResetPassword\",\"_rev\":\"-1854762395\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\",\"innerTreeOnly\":false,\"description\":\"Reset Password Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"06c97be5-7fdd-4739-aea1-ecc7fe082865\":{\"connections\":{\"outcome\":\"e4c752f9-c625-48c9-9644-a58802fa9e9c\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":453,\"y\":66},\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\":{\"connections\":{\"false\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\",\"true\":\"06c97be5-7fdd-4739-aea1-ecc7fe082865\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":271,\"y\":21},\"989f0bf8-a328-4217-b82b-5275d79ca8bd\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":819,\"y\":61},\"cc3e1ed2-25f1-47bf-83c6-17084f8b2b2b\":{\"connections\":{\"outcome\":\"21b8ddf3-0203-4ae1-ab05-51cf3a3a707a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":103,\"y\":50},\"e4c752f9-c625-48c9-9644-a58802fa9e9c\":{\"connections\":{\"outcome\":\"989f0bf8-a328-4217-b82b-5275d79ca8bd\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":643,\"y\":50}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":79},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":981,\"y\":147},\"startNode\":{\"x\":25,\"y\":25}}},{\"_id\":\"Agent\",\"_rev\":\"1590168042\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Agent\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"35cb0861-c160-47ff-808c-3429ba18772c\":{\"connections\":{\"outcome\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":350,\"y\":200},\"6c24a892-4bae-48ad-8d9c-8061257c9ed7\":{\"connections\":{\"false\":\"35cb0861-c160-47ff-808c-3429ba18772c\",\"true\":\"7a910023-cad2-4f49-9ce0-1a0c711613d3\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25},\"7a910023-cad2-4f49-9ce0-1a0c711613d3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Agent Data Store Decision\",\"nodeType\":\"AgentDataStoreDecisionNode\",\"x\":700,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"InnerTest\",\"_rev\":\"-1762283053\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"innerTreeOnly\":true,\"description\":\"Inner Test Journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"},\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}}},{\"_id\":\"amsterService\",\"_rev\":\"-1457460165\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\",\"innerTreeOnly\":false,\"description\":\"Authentication Tree for Amster utility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"cfcd2084-95d5-35ef-a6e7-d7f9f98764db\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Amster Jwt Decision Node\",\"nodeType\":\"AmsterJwtDecisionNode\",\"x\":200,\"y\":30}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":500,\"y\":30},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":500,\"y\":130},\"startNode\":{\"x\":50,\"y\":30}}},{\"_id\":\"Test\",\"_rev\":\"2131508795\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}},{\"_id\":\"Registration\",\"_rev\":\"-285075550\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\",\"innerTreeOnly\":false,\"description\":\"Platform Registration Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Registration\\\"]\"},\"nodes\":{\"0c091c49-f3af-48fb-ac6f-07fba0499dd6\":{\"connections\":{\"outcome\":\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":261,\"y\":168},\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\":{\"connections\":{\"outcome\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":681,\"y\":144},\"ad5dcbb3-7335-49b7-b3e7-7d850bb88237\":{\"connections\":{\"CREATED\":\"97a15eb2-a015-4b6d-81a0-be78c3aa1a3b\",\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Create Object\",\"nodeType\":\"CreateObjectNode\",\"x\":537,\"y\":206}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":905,\"y\":171},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":741,\"y\":293},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ProgressiveProfile\",\"_rev\":\"-840266108\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"8afdaec3-275e-4301-bb53-34f03e6a4b29\",\"innerTreeOnly\":false,\"description\":\"Prompt for missing preferences on 3rd login\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Progressive Profile\\\"]\"},\"nodes\":{\"423a959a-a1b9-498a-b0f7-596b6b6e775a\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":766,\"y\":36},\"8afdaec3-275e-4301-bb53-34f03e6a4b29\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\"},\"displayName\":\"Login Count Decision\",\"nodeType\":\"LoginCountDecisionNode\",\"x\":152,\"y\":36},\"a1f45b44-5bf7-4c57-aa3f-75c619c7db8e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\"},\"displayName\":\"Query Filter Decision\",\"nodeType\":\"QueryFilterDecisionNode\",\"x\":357,\"y\":36},\"a5aecad8-854a-4ed5-b719-ff6c90e858c0\":{\"connections\":{\"outcome\":\"423a959a-a1b9-498a-b0f7-596b6b6e775a\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":555,\"y\":20}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":802,\"y\":312},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":919,\"y\":171},\"startNode\":{\"x\":50,\"y\":58.5}}},{\"_id\":\"ldapService\",\"_rev\":\"-1619916438\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\",\"innerTreeOnly\":false,\"description\":\"Authentication tree replacing old default chain for backward compatibility\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"6c8349cc-7260-3e62-a3b1-396831a8398a\":{\"connections\":{\"outcome\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":500,\"y\":25},\"c81e728d-9d4c-3f63-af06-7f89cc14862d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":800,\"y\":25},\"eccbc87e-4b5c-32fe-a830-8fd9f2a7baf5\":{\"connections\":{\"false\":\"6c8349cc-7260-3e62-a3b1-396831a8398a\",\"true\":\"c81e728d-9d4c-3f63-af06-7f89cc14862d\"},\"displayName\":\"Zero Page Login Collector\",\"nodeType\":\"ZeroPageLoginNode\",\"x\":150,\"y\":25}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1000,\"y\":25},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1000,\"y\":200},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"ForgottenUsername\",\"_rev\":\"350164141\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5e2a7c95-94af-4b23-8724-deb13853726a\",\"innerTreeOnly\":false,\"description\":\"Forgotten Username Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Username Reset\\\"]\"},\"nodes\":{\"5e2a7c95-94af-4b23-8724-deb13853726a\":{\"connections\":{\"outcome\":\"bf9ea8d5-9802-4f26-9664-a21840faac23\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":139,\"y\":146},\"b93ce36e-1976-4610-b24f-8d6760b5463b\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":767,\"y\":188},\"bf9ea8d5-9802-4f26-9664-a21840faac23\":{\"connections\":{\"false\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\",\"true\":\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\"},\"displayName\":\"Identify Existing User\",\"nodeType\":\"IdentifyExistingUserNode\",\"x\":324,\"y\":152},\"d9a79f01-2ce3-4be2-a28a-975f35c3c8ca\":{\"connections\":{\"outcome\":\"b93ce36e-1976-4610-b24f-8d6760b5463b\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":563,\"y\":193}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":970,\"y\":149},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":982,\"y\":252},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"TestJourney\",\"_rev\":\"-1352788891\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\",\"innerTreeOnly\":false,\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[]\"},\"nodes\":{\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\":{\"connections\":{\"false\":\"804d3377-fbfe-4b05-902a-1ffcfdadb49e\",\"true\":\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":973,\"y\":224.015625},\"1b879025-76c8-4660-8b33-7c0c1f284482\":{\"connections\":{\"outcome\":\"abbaa271-85e9-4ad4-a0f5-d01dda4c35ef\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":442.34375,\"y\":235.015625},\"7d97831d-feb8-42d4-b665-f3bd596555ce\":{\"connections\":{\"outcome\":\"1b879025-76c8-4660-8b33-7c0c1f284482\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":199.34375,\"y\":149.015625},\"804d3377-fbfe-4b05-902a-1ffcfdadb49e\":{\"connections\":{\"false\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\",\"true\":\"7d97831d-feb8-42d4-b665-f3bd596555ce\"},\"displayName\":\"UserDoesNotExist\",\"nodeType\":\"MessageNode\",\"x\":1261,\"y\":359.015625},\"a7785e65-295b-4fc3-908b-3077a5f9fcfe\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Message Node\",\"nodeType\":\"MessageNode\",\"x\":1322,\"y\":163.015625},\"abbaa271-85e9-4ad4-a0f5-d01dda4c35ef\":{\"connections\":{\"true\":\"1a62e972-325a-4955-8c5f-b3fdd2e5176d\"},\"displayName\":\"DoesUserExist\",\"nodeType\":\"designer-user\",\"x\":711.765625,\"y\":252.015625}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1946,\"y\":145},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1818,\"y\":322},\"startNode\":{\"x\":50,\"y\":250}}},{\"_id\":\"UpdatePassword\",\"_rev\":\"1874809216\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"d1b79744-493a-44fe-bc26-7d324a8caa4e\",\"innerTreeOnly\":false,\"description\":\"Update password using active session\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Password Reset\\\"]\"},\"nodes\":{\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\":{\"connections\":{\"false\":\"a3d97b53-e38a-4b24-aed0-a021050eb744\",\"true\":\"20237b34-26cb-4a0b-958f-abb422290d42\"},\"displayName\":\"Attribute Present Decision\",\"nodeType\":\"AttributePresentDecisionNode\",\"x\":288,\"y\":133},\"20237b34-26cb-4a0b-958f-abb422290d42\":{\"connections\":{\"outcome\":\"7d1deabe-cd98-49c8-943f-ca12305775f3\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":526,\"y\":46},\"3990ce1f-cce6-435b-ae1c-f138e89411c1\":{\"connections\":{\"FAILURE\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"PATCHED\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Patch Object\",\"nodeType\":\"PatchObjectNode\",\"x\":1062,\"y\":189},\"7d1deabe-cd98-49c8-943f-ca12305775f3\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":722,\"y\":45},\"a3d97b53-e38a-4b24-aed0-a021050eb744\":{\"connections\":{\"outcome\":\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\"},\"displayName\":\"Email Suspend Node\",\"nodeType\":\"EmailSuspendNode\",\"x\":659,\"y\":223},\"d018fcd1-4e22-4160-8c41-63bee51c9cb3\":{\"connections\":{\"outcome\":\"3990ce1f-cce6-435b-ae1c-f138e89411c1\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":943,\"y\":30},\"d1b79744-493a-44fe-bc26-7d324a8caa4e\":{\"connections\":{\"outcome\":\"0f0904e6-1da3-4cdb-9abf-0d2545016fab\"},\"displayName\":\"Get Session Data\",\"nodeType\":\"SessionDataNode\",\"x\":122,\"y\":129}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1212,\"y\":128},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":939,\"y\":290},\"startNode\":{\"x\":50,\"y\":25}}},{\"_id\":\"Login\",\"_rev\":\"-2008678727\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\",\"innerTreeOnly\":false,\"description\":\"Platform Login Tree\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Authentication\\\"]\"},\"nodes\":{\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"bba3e0d8-8525-4e82-bf48-ac17f7988917\"},\"displayName\":\"Data Store Decision\",\"nodeType\":\"DataStoreDecisionNode\",\"x\":315,\"y\":140},\"33b24514-3e50-4180-8f08-ab6f4e51b07e\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Inner Tree Evaluator\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":815,\"y\":180},\"a12bc72f-ad97-4f1e-a789-a1fa3dd566c8\":{\"connections\":{\"outcome\":\"2998c1c9-f4c8-4a00-b2c6-3426783ee49d\"},\"displayName\":\"Page Node\",\"nodeType\":\"PageNode\",\"x\":136,\"y\":59},\"bba3e0d8-8525-4e82-bf48-ac17f7988917\":{\"connections\":{\"outcome\":\"33b24514-3e50-4180-8f08-ab6f4e51b07e\"},\"displayName\":\"Increment Login Count\",\"nodeType\":\"IncrementLoginCountNode\",\"x\":564,\"y\":132}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":1008,\"y\":186},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":624,\"y\":267},\"startNode\":{\"x\":50,\"y\":25}}}],\"resultCount\":12,\"pagedResultsCookie\":null,\"totalPagedResultsPolicy\":\"NONE\",\"totalPagedResults\":-1,\"remainingPagedResults\":-1}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "protocol=2.1,resource=1.0, resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.379Z",
+        "time": 7,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7
+        }
+      },
+      {
+        "_id": "d5b2c0840d57b2b0eb02b12160a60382",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 226,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "226"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"collection\":true,\"name\":\"Display State\"},\"displayFormat\":\"TABLE\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-8ab9f1aad4b4460a9c45d15fb148e221/df153624-6d66-4e82-9b62-8cee4d62ab8f"
+        },
+        "response": {
+          "bodySize": 246,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 246,
+            "text": "{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"_rev\":\"1300434121\",\"displayFormat\":\"TABLE\",\"_type\":{\"_id\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"name\":\"Display State\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "246"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.396Z",
+        "time": 23,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 23
+        }
+      },
+      {
+        "_id": "84b90775da82fcb50bfa0db951972301",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 294,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "294"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"collection\":true,\"name\":\"Display Callback\"},\"callback\":\"TEXT_OUTPUT_CALLBACK\",\"options\":{\"message\":\"Hello World!\",\"messageType\":\"0\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-ef81b1a52c914710b3388caebfe7233a/cccb0cb9-a134-4f52-a499-55d4f095ac81"
+        },
+        "response": {
+          "bodySize": 314,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 314,
+            "text": "{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"_rev\":\"-248191681\",\"callback\":\"TEXT_OUTPUT_CALLBACK\",\"options\":{\"message\":\"Hello World!\",\"messageType\":\"0\"},\"_type\":{\"_id\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"name\":\"Display Callback\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "314"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.424Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "7b455d0b474bd76766ff8820b93c3145",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 260,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "260"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"1bfea910-5d16-4439-b0db-70c3245644e1\",\"_outcomes\":[{\"displayName\":\"Success\",\"id\":\"Success\"},{\"displayName\":\"Script Error\",\"id\":\"Script Error\"}],\"_type\":{\"_id\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"collection\":true,\"name\":\"ALU\"},\"operator\":\"ADD\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c6063fb2f5dc42dd9772bedc93898bd8/1bfea910-5d16-4439-b0db-70c3245644e1"
+        },
+        "response": {
+          "bodySize": 278,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 278,
+            "text": "{\"_id\":\"1bfea910-5d16-4439-b0db-70c3245644e1\",\"_rev\":\"71843373\",\"operator\":\"ADD\",\"_type\":{\"_id\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"name\":\"ALU\",\"collection\":true},\"_outcomes\":[{\"id\":\"Success\",\"displayName\":\"Success\"},{\"id\":\"Script Error\",\"displayName\":\"Script Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "278"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.443Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "0cb5165a45eb34813b96bb9128c27698",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 231,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "231"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"True\"},{\"displayName\":\"False\",\"id\":\"False\"}],\"_type\":{\"_id\":\"designer-c605506774a848f7877b4d17a453bd39\",\"collection\":true,\"name\":\"Has Session\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c605506774a848f7877b4d17a453bd39/02e10086-108c-441c-b14b-cc2054ef7483"
+        },
+        "response": {
+          "bodySize": 251,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 251,
+            "text": "{\"_id\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"_rev\":\"1815890486\",\"_type\":{\"_id\":\"designer-c605506774a848f7877b4d17a453bd39\",\"name\":\"Has Session\",\"collection\":true},\"_outcomes\":[{\"id\":\"True\",\"displayName\":\"True\"},{\"id\":\"False\",\"displayName\":\"False\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "251"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.461Z",
+        "time": 8,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 8
+        }
+      },
+      {
+        "_id": "dc375c86ec31d265bf7ca0cad2a56772",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 304,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "304"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 658,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\",\"_outcomes\":[{\"displayName\":\"True\",\"id\":\"true\"},{\"displayName\":\"False\",\"id\":\"false\"},{\"displayName\":\"Error\",\"id\":\"error\"}],\"_type\":{\"_id\":\"InnerTreeEvaluatorNode\",\"collection\":true,\"name\":\"Inner Tree Evaluator\"},\"displayErrorOutcome\":true,\"tree\":\"InnerTest\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/InnerTreeEvaluatorNode/a77ddb64-45af-4f7b-a734-8a8294f53294"
+        },
+        "response": {
+          "bodySize": 324,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 324,
+            "text": "{\"_id\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\",\"_rev\":\"-998861558\",\"displayErrorOutcome\":true,\"tree\":\"InnerTest\",\"_type\":{\"_id\":\"InnerTreeEvaluatorNode\",\"name\":\"Inner Tree Evaluator\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"True\"},{\"id\":\"false\",\"displayName\":\"False\"},{\"id\":\"error\",\"displayName\":\"Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "324"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.474Z",
+        "time": 23,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 23
+        }
+      },
+      {
+        "_id": "f267f8e3d4d260de5b341a6f37972491",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 654,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "654"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 644,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"PageNode\",\"collection\":true,\"name\":\"Page Node\"},\"nodes\":[{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"displayName\":\"Display State\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\"},{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"displayName\":\"Hello World!\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\"}],\"pageDescription\":{\"en\":\"Description\"},\"pageHeader\":{\"en\":\"Header\"},\"stage\":\"{\\\"submitButtonText\\\":{\\\"en\\\":\\\"Submit Button\\\"},\\\"pageFooter\\\":{\\\"en\\\":\\\"Footer\\\"},\\\"themeId\\\":\\\"a9bc15cf-8d9c-4bfb-8979-67a5f5823227\\\"}\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/PageNode/e78ff99e-59f8-4302-93b7-1770f18b4ae7"
+        },
+        "response": {
+          "bodySize": 673,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 673,
+            "text": "{\"_id\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\",\"_rev\":\"942720118\",\"nodes\":[{\"_id\":\"df153624-6d66-4e82-9b62-8cee4d62ab8f\",\"nodeType\":\"designer-8ab9f1aad4b4460a9c45d15fb148e221\",\"displayName\":\"Display State\"},{\"_id\":\"cccb0cb9-a134-4f52-a499-55d4f095ac81\",\"nodeType\":\"designer-ef81b1a52c914710b3388caebfe7233a\",\"displayName\":\"Hello World!\"}],\"pageDescription\":{\"en\":\"Description\"},\"stage\":\"{\\\"submitButtonText\\\":{\\\"en\\\":\\\"Submit Button\\\"},\\\"pageFooter\\\":{\\\"en\\\":\\\"Footer\\\"},\\\"themeId\\\":\\\"a9bc15cf-8d9c-4bfb-8979-67a5f5823227\\\"}\",\"pageHeader\":{\"en\":\"Header\"},\"_type\":{\"_id\":\"PageNode\",\"name\":\"Page Node\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "673"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 629,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.503Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "41b7d3c748449dfd1fb5b60fa8bfca37",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 293,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "293"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 677,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"_outcomes\":[{\"displayName\":\"Success\",\"id\":\"Success\"},{\"displayName\":\"Script Error\",\"id\":\"Script Error\"}],\"_type\":{\"_id\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"collection\":true,\"name\":\"Vector ALU\"},\"a\":[1,2,3],\"b\":[4,5,6],\"operator\":\"CROSS\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/designer-c15e2efb3deb4d4ea338c74a6440b69f/0dd3743e-2aaf-4a4a-9e83-a64490303a10"
+        },
+        "response": {
+          "bodySize": 313,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 313,
+            "text": "{\"_id\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"_rev\":\"1826892730\",\"a\":[1,2,3],\"operator\":\"CROSS\",\"b\":[4,5,6],\"_type\":{\"_id\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"name\":\"Vector ALU\",\"collection\":true},\"_outcomes\":[{\"id\":\"Success\",\"displayName\":\"Success\"},{\"id\":\"Script Error\",\"displayName\":\"Script Error\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "313"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.522Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "a8e6d62af4ac47c99d148821710c85d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1616,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1616"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 604,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"Test\",\"description\":\"Test journey\",\"enabled\":true,\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":false,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}},\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees/Test"
+        },
+        "response": {
+          "bodySize": 1636,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1636,
+            "text": "{\"_id\":\"Test\",\"_rev\":\"2131508795\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"02e10086-108c-441c-b14b-cc2054ef7483\",\"innerTreeOnly\":false,\"description\":\"Test journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\"]\"},\"nodes\":{\"02e10086-108c-441c-b14b-cc2054ef7483\":{\"connections\":{\"False\":\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\",\"True\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Has Session\",\"nodeType\":\"designer-c605506774a848f7877b4d17a453bd39\",\"x\":210,\"y\":155},\"0dd3743e-2aaf-4a4a-9e83-a64490303a10\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"1bfea910-5d16-4439-b0db-70c3245644e1\"},\"displayName\":\"Vector ALU\",\"nodeType\":\"designer-c15e2efb3deb4d4ea338c74a6440b69f\",\"x\":440,\"y\":80},\"1bfea910-5d16-4439-b0db-70c3245644e1\":{\"connections\":{\"Script Error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"Success\":\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\"},\"displayName\":\"ALU\",\"nodeType\":\"designer-c6063fb2f5dc42dd9772bedc93898bd8\",\"x\":670,\"y\":155},\"a77ddb64-45af-4f7b-a734-8a8294f53294\":{\"connections\":{\"error\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"e301438c-0bd0-429c-ab0c-66126501069a\"},\"displayName\":\"Inner Test\",\"nodeType\":\"InnerTreeEvaluatorNode\",\"x\":1172,\"y\":141.5},\"e78ff99e-59f8-4302-93b7-1770f18b4ae7\":{\"connections\":{\"outcome\":\"a77ddb64-45af-4f7b-a734-8a8294f53294\"},\"displayName\":\"My Page\",\"nodeType\":\"PageNode\",\"x\":900,\"y\":107.5}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":440,\"y\":284},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":1454,\"y\":182},\"startNode\":{\"x\":70,\"y\":182}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1636"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 631,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.539Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "3170c9714f4c5f92d6fa82fd4dede3bf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1157,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1157"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 590,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"9b75654f-2553-4627-9938-b14a5f62ce81\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906960447,\"default\":false,\"description\":\"Debug script that prints the shared state\",\"evaluatorVersion\":\"1.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784906960447,\"name\":\"Debug\",\"script\":\"dmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKKTsKCnZhciBzY3JpcHRPdXRjb21lcyA9IHsKICAgIE9VVENPTUU6ICdvdXRjb21lJywKfTsKCmZ1bmN0aW9uIG1haW4oKSB7CiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkgewogICAgICAgIHZhciBkZWJ1Z1N0YXRlID0gewogICAgICAgICAgICBzaGFyZWRTdGF0ZTogc2hhcmVkU3RhdGUsCiAgICAgICAgICAgIHRyYW5zaWVudFN0YXRlOiB0cmFuc2llbnRTdGF0ZQogICAgICAgIH07CiAgICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQobmV3IGZyLlRleHRPdXRwdXRDYWxsYmFjaygwLCBgPHByZSBzdHlsZT0idGV4dC1hbGlnbjogbGVmdDsiPiR7SlNPTi5zdHJpbmdpZnkoZGVidWdTdGF0ZSwgbnVsbCwgMil9PC9wcmU+YCkpLmJ1aWxkKCk7CiAgICAgICAgcmV0dXJuOwogICAgfQogICAgb3V0Y29tZSA9IHNjcmlwdE91dGNvbWVzLk9VVENPTUU7Cn0KCm1haW4oKTsK\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/scripts/9b75654f-2553-4627-9938-b14a5f62ce81"
+        },
+        "response": {
+          "bodySize": 1157,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1157,
+            "text": "{\"_id\":\"9b75654f-2553-4627-9938-b14a5f62ce81\",\"name\":\"Debug\",\"description\":\"Debug script that prints the shared state\",\"script\":\"dmFyIGZyID0gSmF2YUltcG9ydGVyKAogICAgb3JnLmZvcmdlcm9jay5vcGVuYW0uYXV0aC5ub2RlLmFwaS5BY3Rpb24sCiAgICBqYXZheC5zZWN1cml0eS5hdXRoLmNhbGxiYWNrLlRleHRPdXRwdXRDYWxsYmFjaywKKTsKCnZhciBzY3JpcHRPdXRjb21lcyA9IHsKICAgIE9VVENPTUU6ICdvdXRjb21lJywKfTsKCmZ1bmN0aW9uIG1haW4oKSB7CiAgICBpZiAoY2FsbGJhY2tzLmlzRW1wdHkoKSkgewogICAgICAgIHZhciBkZWJ1Z1N0YXRlID0gewogICAgICAgICAgICBzaGFyZWRTdGF0ZTogc2hhcmVkU3RhdGUsCiAgICAgICAgICAgIHRyYW5zaWVudFN0YXRlOiB0cmFuc2llbnRTdGF0ZQogICAgICAgIH07CiAgICAgICAgYWN0aW9uID0gZnIuQWN0aW9uLnNlbmQobmV3IGZyLlRleHRPdXRwdXRDYWxsYmFjaygwLCBgPHByZSBzdHlsZT0idGV4dC1hbGlnbjogbGVmdDsiPiR7SlNPTi5zdHJpbmdpZnkoZGVidWdTdGF0ZSwgbnVsbCwgMil9PC9wcmU+YCkpLmJ1aWxkKCk7CiAgICAgICAgcmV0dXJuOwogICAgfQogICAgb3V0Y29tZSA9IHNjcmlwdE91dGNvbWVzLk9VVENPTUU7Cn0KCm1haW4oKTsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906960447,\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784909009467,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1157"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 611,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.554Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      },
+      {
+        "_id": "436cf155a105359b03d5e6e0479de38b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 629,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "629"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961100,\"default\":false,\"description\":\"Test\",\"evaluatorVersion\":\"1.0\",\"language\":\"GROOVY\",\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784906961100,\"name\":\"Test Groovy Script\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/scripts/bd027bdf-002d-42e2-a549-d5fdb0d6605a"
+        },
+        "response": {
+          "bodySize": 629,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 629,
+            "text": "{\"_id\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\",\"name\":\"Test Groovy Script\",\"description\":\"Test\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\",\"default\":false,\"language\":\"GROOVY\",\"context\":\"AUTHENTICATION_TREE_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961100,\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784909009481,\"evaluatorVersion\":\"1.0\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "629"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.567Z",
+        "time": 9,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 9
+        }
+      },
+      {
+        "_id": "491201c0171b4ed0c996e2f7090d8135",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 617,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.0,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "617"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 589,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\",\"context\":\"SCRIPTED_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961115,\"default\":false,\"description\":\"null\",\"evaluatorVersion\":\"2.0\",\"language\":\"JAVASCRIPT\",\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784906961115,\"name\":\"Test Next Gen\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/scripts/3d27b6d3-0f41-410a-9975-2e9df43d885e"
+        },
+        "response": {
+          "bodySize": 617,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 617,
+            "text": "{\"_id\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\",\"name\":\"Test Next Gen\",\"description\":\"null\",\"script\":\"LyoKICAtIERhdGEgbWFkZSBhdmFpbGFibGUgYnkgbm9kZXMgdGhhdCBoYXZlIGFscmVhZHkgZXhlY3V0ZWQgYXJlIGF2YWlsYWJsZSBpbiB0aGUgc2hhcmVkU3RhdGUgdmFyaWFibGUuCiAgLSBUaGUgc2NyaXB0IHNob3VsZCBzZXQgb3V0Y29tZSB0byBlaXRoZXIgInRydWUiIG9yICJmYWxzZSIuCiAqLwoKb3V0Y29tZSA9ICJ0cnVlIjsK\",\"default\":false,\"language\":\"JAVASCRIPT\",\"context\":\"SCRIPTED_DECISION_NODE\",\"createdBy\":\"id=amadmin,ou=user,ou=am-config\",\"creationDate\":1784906961115,\"lastModifiedBy\":\"id=amadmin,ou=user,ou=am-config\",\"lastModifiedDate\":1784909009498,\"evaluatorVersion\":\"2.0\"}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "617"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.1"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 610,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.584Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "fb1b184542b1448c03c21dd9e044a557",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 287,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "287"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"_outcomes\":[{\"displayName\":\"outcome\",\"id\":\"outcome\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"outcome\"],\"outputs\":[\"*\"],\"script\":\"9b75654f-2553-4627-9938-b14a5f62ce81\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/5d969de4-98c8-44ab-9df1-4de9170205eb"
+        },
+        "response": {
+          "bodySize": 308,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 308,
+            "text": "{\"_id\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"_rev\":\"-1660489373\",\"script\":\"9b75654f-2553-4627-9938-b14a5f62ce81\",\"outcomes\":[\"outcome\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"outcome\",\"displayName\":\"outcome\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "308"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.600Z",
+        "time": 14,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 14
+        }
+      },
+      {
+        "_id": "cd186bee6882923ebc1de3568ad76ebc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 323,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "323"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\",\"_outcomes\":[{\"displayName\":\"true\",\"id\":\"true\"},{\"displayName\":\"false\",\"id\":\"false\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"script\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/fd51424b-2a28-41a9-bc3e-44c2adc61a62"
+        },
+        "response": {
+          "bodySize": 343,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 343,
+            "text": "{\"_id\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\",\"_rev\":\"-890383722\",\"script\":\"bd027bdf-002d-42e2-a549-d5fdb0d6605a\",\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"true\"},{\"id\":\"false\",\"displayName\":\"false\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "343"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 630,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.623Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      },
+      {
+        "_id": "634f4bc4772ea6429f15af12cb41e7a0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 323,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "323"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\",\"_outcomes\":[{\"displayName\":\"true\",\"id\":\"true\"},{\"displayName\":\"false\",\"id\":\"false\"}],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"collection\":true,\"name\":\"Scripted Decision\"},\"inputs\":[\"*\"],\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"script\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\"}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/nodes/ScriptedDecisionNode/af596d89-e0ae-41c9-b1f5-e7318f517e2d"
+        },
+        "response": {
+          "bodySize": 342,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 342,
+            "text": "{\"_id\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\",\"_rev\":\"919944373\",\"script\":\"3d27b6d3-0f41-410a-9975-2e9df43d885e\",\"outcomes\":[\"true\",\"false\"],\"outputs\":[\"*\"],\"inputs\":[\"*\"],\"_type\":{\"_id\":\"ScriptedDecisionNode\",\"name\":\"Scripted Decision\",\"collection\":true},\"_outcomes\":[{\"id\":\"true\",\"displayName\":\"true\"},{\"id\":\"false\",\"displayName\":\"false\"}]}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "342"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 628,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.639Z",
+        "time": 10,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 10
+        }
+      },
+      {
+        "_id": "53eeaecac33e81ef38d7c8b0de06907d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1066,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "1066"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 609,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"_id\":\"InnerTest\",\"description\":\"Inner Test Journey\",\"enabled\":true,\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"identityResource\":\"managed/user\",\"innerTreeOnly\":true,\"mustRun\":false,\"noSession\":false,\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}},\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"}}"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/json/realms/root/realm-config/authentication/authenticationtrees/trees/InnerTest"
+        },
+        "response": {
+          "bodySize": 1087,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1087,
+            "text": "{\"_id\":\"InnerTest\",\"_rev\":\"-1762283053\",\"identityResource\":\"managed/user\",\"entryNodeId\":\"5d969de4-98c8-44ab-9df1-4de9170205eb\",\"innerTreeOnly\":true,\"description\":\"Inner Test Journey\",\"noSession\":false,\"mustRun\":false,\"enabled\":true,\"uiConfig\":{\"categories\":\"[\\\"Test\\\",\\\"Inner\\\"]\"},\"nodes\":{\"5d969de4-98c8-44ab-9df1-4de9170205eb\":{\"connections\":{\"outcome\":\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\"},\"displayName\":\"Debug\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":210,\"y\":154.5},\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\"},\"displayName\":\"Test Next Gen\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":726,\"y\":128},\"fd51424b-2a28-41a9-bc3e-44c2adc61a62\":{\"connections\":{\"false\":\"e301438c-0bd0-429c-ab0c-66126501069a\",\"true\":\"af596d89-e0ae-41c9-b1f5-e7318f517e2d\"},\"displayName\":\"Test Groovy\",\"nodeType\":\"ScriptedDecisionNode\",\"x\":468,\"y\":128}},\"staticNodes\":{\"70e691a5-1e33-4ac3-a356-e7b6d60d92e0\":{\"x\":984,\"y\":80},\"e301438c-0bd0-429c-ab0c-66126501069a\":{\"x\":984,\"y\":230},\"startNode\":{\"x\":70,\"y\":155}}}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1087"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "content-api-version",
+              "value": "resource=1.0"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none';frame-ancestors 'none';sandbox"
+            },
+            {
+              "name": "cross-origin-opener-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "cross-origin-resource-policy",
+              "value": "same-origin"
+            },
+            {
+              "name": "etag",
+              "value": "<etag>"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 632,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.655Z",
+        "time": 12,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 12
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_d_D_m_742098390/oauth2_393036114/recording.har
+++ b/test/e2e/mocks/config-manager_4167095917/push_2272264157/journeys_4003426976/0_n_d_D_m_742098390/oauth2_393036114/recording.har
@@ -1,0 +1,289 @@
+{
+  "log": {
+    "_recordingName": "config-manager/push/journeys/0_n_d_D_m/oauth2",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a684e2f67fd67a4263878c3124af167a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 365,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "cookie",
+              "value": "iPlanetDirectoryPro=<cookie>"
+            },
+            {
+              "name": "content-length",
+              "value": "365"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 562,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&scope=fr:idm:* openid&response_type=code&client_id=idm-admin-ui&csrf=H6mdN1Qy4KQJ2Sl5S_WRSaldWyU.*AAJTSQACMDIAAlNLABxiVWxpS2laUlUwbjI2VnpRYVBPM1Z0bXhqZTA9AAR0eXBlAANDVFMAAlMxAAIwMQ..*&decision=allow&code_challenge=jSwr-ydFFA7T22QAIcE3aVlkRvCigUcfmLyS2ekuW3c&code_challenge_method=S256"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/authorize"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            },
+            {
+              "expires": "1970-01-01T00:00:00.000Z",
+              "httpOnly": true,
+              "name": "OAUTH_REQUEST_ATTRIBUTES",
+              "path": "/",
+              "sameSite": "none",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "OAUTH_REQUEST_ATTRIBUTES=<cookie>; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; HttpOnly; SameSite=none"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "location",
+              "value": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=e-7OMs_1HN9TJfwOLdqHbU5esQQ&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 673,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html?code=e-7OMs_1HN9TJfwOLdqHbU5esQQ&iss=https%3A%2F%2Fplatform.dev.trivir.com%2Fam%2Foauth2&client_id=idm-admin-ui",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.315Z",
+        "time": 13,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 13
+        }
+      },
+      {
+        "_id": "ff75519a93ccab829f8ee8cf5e92b49f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 224,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "user-agent",
+              "value": "<user agent>"
+            },
+            {
+              "name": "x-forgerock-transactionid",
+              "value": "<transaction id>"
+            },
+            {
+              "name": "accept-api-version",
+              "value": "protocol=2.1,resource=1.0"
+            },
+            {
+              "name": "content-length",
+              "value": "224"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, compress, deflate, br"
+            },
+            {
+              "name": "host",
+              "value": "openam-frodo-dev.forgeblocks.com"
+            }
+          ],
+          "headersSize": 421,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [],
+            "text": "client_id=idm-admin-ui&redirect_uri=https://platform.dev.trivir.com/platform/appAuthHelperRedirect.html&grant_type=authorization_code&code=e-7OMs_1HN9TJfwOLdqHbU5esQQ&code_verifier=3ACV_Js1P4lN4la-JanrYyVrxb1YRxBrmwmlk0U4XjY"
+          },
+          "queryString": [],
+          "url": "https://platform.dev.trivir.com/am/oauth2/access_token"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 1249,
+            "text": "{\"access_token\":\"<access token>\",\"scope\":\"openid fr:idm:*\",\"id_token\":\"<id token>\",\"token_type\":\"Bearer\",\"expires_in\":239}"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "route",
+              "path": "/am",
+              "secure": true,
+              "value": "<cookie>"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "<date>"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "route=<cookie>; Path=/am; Secure; HttpOnly"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains"
+            }
+          ],
+          "headersSize": 405,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2026-07-24T16:03:29.335Z",
+        "time": 36,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 36
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
I added a function to import journeys configurations for the frodo config-manager push journeys command.

I modified the config-manager pull journeys command to extract the journeys to the root realm directory instead of journey directory. 

I updated the config-manager-pull-authentication tests to handle the root realm behavior.

I added the command implementation file to enable the config manager push journeys command.