### PR TITLE
edit conn delete message to show tenant URL

### DIFF
--- a/src/cli/conn/conn-delete.ts
+++ b/src/cli/conn/conn-delete.ts
@@ -18,8 +18,9 @@ export default function setup() {
     async (host, options, command) => {
       command.handleDefaultArgsAndOpts(host, options, command);
       try {
+        const profile = await frodo.conn.getConnectionProfileByHost(host);
         frodo.conn.deleteConnectionProfile(host);
-        printMessage(`Deleted connection profile ${host}`);
+        printMessage(`Deleted connection profile ${profile.tenant}`);
       } catch (error) {
         printError(error);
       }


### PR DESCRIPTION
Small change to show URL of tenant deleted by conn delete to avoid ambiguous messaging when users input a substring.