### PR TITLE
ci: gate all release jobs on workflow_dispatch

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -221,7 +221,7 @@ jobs:
           frodo info "$FIDC_TENANT_URL"
 
   release:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     needs:
       [
         build,
@@ -320,7 +320,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   npm-release:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     # npm-release only needs the build job but since it is inconvenient to unpublish an npm we want this job to run last
     needs:
       [
@@ -403,7 +403,7 @@ jobs:
           fi
 
   homebrew-formula-update:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     name: Bump Homebrew formula
     needs: [release, build, npm-release]
     runs-on: ubuntu-latest
@@ -433,7 +433,7 @@ jobs:
 
   macos-intel-binary-release:
     # don't run on PRs, since secrets are not available
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     needs: [build, test]
     runs-on: macos-15-intel
     timeout-minutes: 15
@@ -511,7 +511,7 @@ jobs:
 
   macos-arm64-binary-release:
     # don't run on PRs, since secrets are not available
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     needs: [build, test]
     runs-on: macos-15
     timeout-minutes: 15
@@ -626,7 +626,7 @@ jobs:
 
   linux-arm64-binary-release:
     # don't run on PRs to speed up the checks
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     needs: [build, test]
     runs-on: ubuntu-24.04-arm
     steps:
@@ -664,7 +664,7 @@ jobs:
 
   windows-x64-binary-release:
     # don't run on PRs to speed up the checks
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     needs: [build, test]
     runs-on: windows-2022
     steps:

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -11,15 +11,16 @@ The Frodo CLI project uses an automated release pipeline defined in [../.github/
 The workflow runs on:
 
 - Pull requests to `main` (build/test/packaging validation)
-- Pushes to `main` (automated prerelease flow)
-- Manual `workflow_dispatch` (explicit release type selection)
+- Pushes to `main` (build/test validation only — no release)
+- Manual `workflow_dispatch` (release — explicit release type selection)
 
 ### Release Type Selection
 
-Release type resolution is:
+All releases are manual. Release type is selected via `workflow_dispatch` input:
 
-- `workflow_dispatch` on `main`: use selected input (`prerelease`, `patch`, `minor`, `major`)
-- all other runs: `prerelease`
+- `prerelease`, `patch`, `minor`, `major`
+
+Pushes to `main` run build and test validation but do not publish or create a release.
 
 There is no PR-label-based release-type logic.
 


### PR DESCRIPTION
## Summary

- All release jobs (`npm-release`, `release`, `homebrew-formula-update`, and all binary release jobs) are now gated on `github.event_name == 'workflow_dispatch'` instead of `!= 'pull_request'`
- Merges to `main` no longer trigger an automatic prerelease publish — all releases are fully manual
- `build` and `test` jobs continue to run on push to `main` for CI validation
- Updated `docs/PIPELINE.md` to document the corrected release model

## Test plan

- [ ] Merge a test PR to `main` and verify that only `build` and `test` jobs run (no release/npm/binary jobs)
- [ ] Trigger a `workflow_dispatch` and verify the full release pipeline runs as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)