### PR TITLE
feat(mcp): MCP server visibility improvements for Claude CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/node": "^2.0.0",
         "@modelcontextprotocol/server": "^2.0.0",
-        "@rockcarver/frodo-lib": "4.2.1",
+        "@rockcarver/frodo-lib": "4.3.1",
         "@types/colors": "^1.2.1",
         "@types/fs-extra": "^11.0.1",
         "@types/jest": "^29.2.3",
@@ -1908,9 +1908,9 @@
       }
     },
     "node_modules/@rockcarver/frodo-lib": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rockcarver/frodo-lib/-/frodo-lib-4.2.1.tgz",
-      "integrity": "sha512-F7ADrVtrh8z/7T8GQPBbGu8G16wbgIGKdoVlJ4Dejvx3yatOLU60Ipep6n/Xtp0fWHyb+YfLgOdmZQhlJBQ6uw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@rockcarver/frodo-lib/-/frodo-lib-4.3.1.tgz",
+      "integrity": "sha512-CRPaQgJExqHJ8cBgfj3BbGoggPgq0uQwUmITnHingMlu7PqGnYf3qrFaHRlRoulXwOxpgIPGIKzr9dH7pC7hqg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
-    "@rockcarver/frodo-lib": "4.2.1",
+    "@rockcarver/frodo-lib": "4.3.1",
     "@types/colors": "^1.2.1",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.2.3",

--- a/src/cli/mcp/server/server-start.ts
+++ b/src/cli/mcp/server/server-start.ts
@@ -1,4 +1,10 @@
-import { createMcpService, frodo, state } from '@rockcarver/frodo-lib';
+import {
+  createMcpService,
+  frodo,
+  hydrateMcpDiscoveryContext,
+  type McpDiscoveryHydrationEvent,
+  state,
+} from '@rockcarver/frodo-lib';
 import { Option } from 'commander';
 import c from 'tinyrainbow';
 
@@ -168,8 +174,15 @@ export default function setup() {
       if (state.getHost()) {
         await frodo.login.getTokens();
       }
-      const managedObjectHydration = await hydrateManagedObjectTypes(logger);
       const activeHost = sanitizeHost(state.getHost());
+      const discoveryContext = await hydrateMcpDiscoveryContext({
+        frodoInstance: frodo,
+        activeTarget: {
+          host: activeHost,
+          profile: opts.profile,
+        },
+        onEvent: (event) => logDiscoveryHydrationEvent(logger, event),
+      });
       const policySelection = resolvePolicySelection(opts.policy);
       const service = createMcpService({
         profileName: opts.profile,
@@ -180,18 +193,12 @@ export default function setup() {
           excludeTopLevelDomains: opts.excludeDomains,
           includeUtils: !!opts.includeUtils,
         },
-        discoveryContext: {
-          managedObjectTypes: managedObjectHydration.types,
-          managedObjectHydrationStatus: managedObjectHydration.status,
-          activeTarget: {
-            host: activeHost,
-            profile: opts.profile,
-          },
-        },
+        discoveryContext,
         // Reuse the preconfigured frodo singleton; the CLI has already
         // applied connection credentials via handleDefaultArgsAndOpts.
         runtimeOptions: {
           resolveFrodoForRequest: async () => frodo,
+          executeRecommendedByDefault: true,
         },
       });
 
@@ -314,44 +321,26 @@ function sanitizeHost(host?: string): string | undefined {
   }
 }
 
-const MANAGED_OBJECT_HYDRATION_TIMEOUT_MS = 3000;
-
-async function hydrateManagedObjectTypes(logger: McpLogger): Promise<{
-  types: string[];
-  status: 'available' | 'not-applicable' | 'failed' | 'timed-out';
-}> {
-  const deploymentType = state.getDeploymentType();
-  if (deploymentType !== 'cloud' && deploymentType !== 'forgeops') {
-    return { types: [], status: 'not-applicable' };
-  }
-
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const types = await Promise.race([
-      frodo.idm.config.readManagedObjectTypes(),
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(
-          () => reject(new Error('Managed-object hydration timed out.')),
-          MANAGED_OBJECT_HYDRATION_TIMEOUT_MS
-        );
-      }),
-    ]);
+function logDiscoveryHydrationEvent(
+  logger: McpLogger,
+  event: McpDiscoveryHydrationEvent
+): void {
+  const catalogLabel =
+    event.catalog === 'managed-object-types'
+      ? 'managed-object types'
+      : 'config entity IDs';
+  if (event.status === 'available') {
     logger.info(
       'startup.discovery',
-      `Hydrated ${types.length} managed-object types for discovery.`
+      `Hydrated ${event.count} ${catalogLabel} for discovery.`
     );
-    return { types, status: 'available' };
-  } catch (error) {
-    const timedOut =
-      error instanceof Error &&
-      error.message === 'Managed-object hydration timed out.';
+    return;
+  }
+  if (event.status === 'failed' || event.status === 'timed-out') {
     logger.warn(
       'startup.discovery',
-      'Managed-object discovery hydration failed; continuing with static skill metadata.'
+      `${catalogLabel} discovery hydration ${event.status}; continuing with static skill metadata.`
     );
-    return { types: [], status: timedOut ? 'timed-out' : 'failed' };
-  } finally {
-    if (timeout) clearTimeout(timeout);
   }
 }
 

--- a/src/ops/McpLogger.ts
+++ b/src/ops/McpLogger.ts
@@ -27,6 +27,7 @@ type InternalMcpLogRecord = McpLogRecord & {
 const DEFAULT_BUFFER_SIZE = 100;
 const DEFAULT_MESSAGE_LENGTH = 2048;
 const MAX_CRITERIA_LIST_VALUES = 5;
+const MCP_STDERR_PREFIX = '[frodo-mcp]';
 
 class McpProtocolTransport extends Transport {
   constructor(
@@ -109,6 +110,9 @@ export class McpLogger {
       level: record.level,
       data: record.data.slice(0, this.maxMessageLength),
     };
+    process.stderr.write(
+      `${MCP_STDERR_PREFIX} ${boundedRecord.level}: ${boundedRecord.data}\n`
+    );
     const sink = record.mcpSink ?? this.sink;
     if (sink) {
       this.emit(boundedRecord, sink);

--- a/src/ops/McpServerMetadata.ts
+++ b/src/ops/McpServerMetadata.ts
@@ -6,7 +6,7 @@ const MCP_LATEST_PROTOCOL_VERSION = '2026-07-28';
 
 export const MCP_SERVER_NAME = 'frodo-mcp';
 export const MCP_SERVER_DISCOVERY_INSTRUCTIONS =
-  'Frodo MCP server exposes a tools-first skill surface. Trust the active target in the default frodo_discover summary; request catalog detail only for diagnostics. Use frodo_find_skills with concise intent, operationTypes, objectFamily when applicable, and limit 5. On Cloud and ForgeOps, object families are resolved dynamically against live managed-object types; semantic count dispatch aggregates matching realm-qualified types and returns a per-type breakdown. Ambiguous concepts return candidates and must not be guessed. Describe the chosen skill before invoking mutating tools.';
+  'Frodo MCP server exposes a tools-first skill surface. Call frodo_discover at most once per task and trust its active target; catalog detail is only for diagnostics. Call frodo_find_skills once with concise intent, operationTypes, objectFamily when applicable, and limit 5. Unique deterministic read-only recommendations execute automatically; when execution is returned, answer from execution.data and make no further discovery calls. On Cloud and ForgeOps, semantic count execution aggregates matching realm-qualified types and returns a per-type breakdown. Ambiguous concepts return candidates and must not be guessed. Describe the chosen skill only before mutating tools.';
 
 export const MCP_SUPPORTED_PROTOCOL_VERSIONS = [
   MCP_LATEST_PROTOCOL_VERSION,

--- a/src/ops/McpServerOps.ts
+++ b/src/ops/McpServerOps.ts
@@ -262,7 +262,7 @@ export function buildMcpServer(
   const server = new McpServer(
     { name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION },
     {
-      capabilities: { logging: {} },
+      capabilities: { logging: {}, experimental: { 'claude/channel': {} } },
       instructions: MCP_SERVER_DISCOVERY_INSTRUCTIONS,
       supportedProtocolVersions: MCP_SUPPORTED_PROTOCOL_VERSIONS,
     }

--- a/src/ops/McpServerOps.ts
+++ b/src/ops/McpServerOps.ts
@@ -269,6 +269,17 @@ export function buildMcpServer(
   );
 
   server.server.oninitialized = () => {
+    // `oninitialized` fires only when the client sends `notifications/initialized`,
+    // which is a legacy-era-only message. Modern 2026-07-28 clients use the
+    // `server/discover` handshake and never send `notifications/initialized`, so
+    // this callback never fires for them. The era check below is therefore
+    // defensive: if for any reason a modern-era client does trigger this callback,
+    // skip `attachSink` to avoid sending unsolicited `notifications/message`
+    // notifications, which are non-compliant under MCP 2026-07-28 (SEP-2577).
+    const negotiatedVersion = server.server.getNegotiatedProtocolVersion();
+    if (negotiatedVersion !== undefined && negotiatedVersion >= '2026-07-28') {
+      return;
+    }
     startupInfo?.logger.attachSink(async ({ level, data }) => {
       await server.server
         .notification({

--- a/src/ops/McpServerOps.ts
+++ b/src/ops/McpServerOps.ts
@@ -138,6 +138,12 @@ const FIND_SKILLS_SHAPE = {
     .describe(
       'Include skills incompatible with the resolved deployment. Defaults to false when deployment is known; use only for diagnostics.'
     ),
+  executeRecommended: z
+    .boolean()
+    .optional()
+    .describe(
+      'Execute a unique deterministic read-only recommendation and return its result. Defaults to true; set false only for discovery diagnostics.'
+    ),
 } as const;
 
 const DESCRIBE_SKILL_SHAPE = {

--- a/test/client_cli/en/mcp-server.test.js
+++ b/test/client_cli/en/mcp-server.test.js
@@ -221,6 +221,23 @@ test("'mcp server start' remains compatible with legacy clients", async () => {
     }
 });
 
+test("'mcp server start' advertises experimental claude/channel capability", async () => {
+    const client = await connectMcpClient({
+        supportedProtocolVersions: ['2026-07-28'],
+        versionNegotiation: { mode: { pin: '2026-07-28' } },
+    });
+
+    try {
+        const capabilities = client.getServerCapabilities();
+        expect(capabilities).toBeDefined();
+        expect(capabilities?.experimental).toBeDefined();
+        expect(capabilities?.experimental?.['claude/channel']).toBeDefined();
+        expect(typeof capabilities?.experimental?.['claude/channel']).toBe('object');
+    } finally {
+        await client.close();
+    }
+});
+
 test("'mcp server start' emits info logs without routine stderr", async () => {
     const logs = [];
     const stderr = [];

--- a/test/client_cli/en/mcp-server.test.js
+++ b/test/client_cli/en/mcp-server.test.js
@@ -238,6 +238,41 @@ test("'mcp server start' advertises experimental claude/channel capability", asy
     }
 });
 
+test("'mcp server start' does not emit unsolicited notifications/message for 2026-07-28 clients", async () => {
+    const logs = [];
+    const stderr = [];
+    const client = await connectMcpClient(
+        {
+            supportedProtocolVersions: ['2026-07-28'],
+            versionNegotiation: { mode: { pin: '2026-07-28' } },
+        },
+        { logs, stderr }
+    );
+
+    try {
+        await client.callTool({
+            name: 'frodo_find_skills',
+            arguments: { query: 'journey' },
+        });
+
+        // Modern 2026-07-28 clients never send notifications/initialized, so
+        // oninitialized never fires and attachSink is never called. Startup
+        // (unsolicited) logs must not appear in notifications/message.
+        // Per-request trace notifications (solicited, from the tool call above)
+        // may still be present — those are out of scope for this assertion (AD-5).
+        const startupLogs = logs.filter((entry) =>
+            String(entry.data).startsWith('startup:')
+        );
+        expect(startupLogs).toEqual([]);
+        // Startup log visibility is preserved via process.stderr (Task 2).
+        expect(stderr.join('')).toContain(
+            '[frodo-mcp] info: startup: Experimental feature in use'
+        );
+    } finally {
+        await client.close();
+    }
+});
+
 test("'mcp server start' emits info logs without routine stderr", async () => {
     const logs = [];
     const stderr = [];

--- a/test/client_cli/en/mcp-server.test.js
+++ b/test/client_cli/en/mcp-server.test.js
@@ -275,7 +275,12 @@ test("'mcp server start' emits info logs without routine stderr", async () => {
                 }),
             ])
         );
-        expect(stderr.join('')).not.toContain('Experimental feature in use');
+        expect(stderr.join('')).toContain(
+            '[frodo-mcp] info: startup: Experimental feature in use'
+        );
+        expect(stderr.join('')).toContain(
+            '[frodo-mcp] info: discovery: tool=frodo_find_skills'
+        );
         expect(stderr.join('')).not.toContain('MCP server startup summary');
     } finally {
         await client.close();

--- a/test/unit/mcp-logger.test.js
+++ b/test/unit/mcp-logger.test.js
@@ -1,6 +1,18 @@
+import { jest } from '@jest/globals';
+
 import { McpLogger } from '../../src/ops/McpLogger.ts';
 
 describe('McpLogger', () => {
+  // Suppress stderr output from dispatch() during tests that don't explicitly
+  // test stderr behaviour; restored after each test via jest.restoreAllMocks().
+  beforeEach(() => {
+    jest.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('applies the default info threshold', () => {
     const records = [];
     const logger = new McpLogger();
@@ -98,6 +110,20 @@ describe('McpLogger', () => {
     logger.attachSink(() => Promise.reject(new Error('async failure')));
     logger.info('async', 'message');
     await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  test('writes [frodo-mcp] <level>: <data> line to process.stderr for every dispatched record', () => {
+    const captured = [];
+    // Replace the suppressing spy set up by beforeEach with a capturing one.
+    jest.spyOn(process.stderr, 'write').mockImplementation((s) => {
+      captured.push(String(s));
+      return true;
+    });
+
+    const logger = new McpLogger('info');
+    logger.info('startup', 'hello world');
+
+    expect(captured).toContain('[frodo-mcp] info: startup: hello world\n');
   });
 
   test('formats discovery summaries and ranked candidate details', () => {


### PR DESCRIPTION
## Summary

- Replaces inline `hydrateManagedObjectTypes` call with the unified `hydrateMcpDiscoveryContext()` from frodo-lib, and enables `executeRecommendedByDefault` for the MCP server startup path
- Declares `experimental: { 'claude/channel': {} }` in `buildMcpServer` capabilities — suppresses Claude Code's "Channel notifications skipped: server did not declare claude/channel capability" warning on every session start
- Writes every MCP log record to `process.stderr` inside `McpLogger.dispatch()` — format: `[frodo-mcp] <level>: <data>` — enabling real-time server visibility via `tail -f ~/.claude/debug/latest` when Claude CLI runs with `--debug`
- Adds an explicit protocol-era gate inside `oninitialized` that skips `attachSink` for 2026-07-28+ clients, preventing unsolicited `notifications/message` startup notifications that violate MCP 2026-07-28 (SEP-2577); legacy 2025-11-25 clients are unaffected

## Background

When using Frodo MCP with Copilot Chat in VS Code, the Output tab shows full server activity in real time. No equivalent existed for Claude CLI — `notifications/message` is silently consumed internally and never displayed to the terminal user. The MCP 2026-07-28 spec deprecates `notifications/message` for stdio servers and recommends `process.stderr` instead; Claude CLI captures MCP server stderr and routes it to `~/.claude/debug/latest`.

## How to verify

Start Claude CLI with `--debug` and run any Frodo tool, then in a second terminal:

```bash
tail -f ~/.claude/debug/latest | grep '\[frodo-mcp\]'
```

Expected output:
```
[DEBUG] MCP server "mcp-volker-dev": Server stderr: [frodo-mcp] info: startup: Experimental feature in use
[DEBUG] MCP server "mcp-volker-dev": Server stderr: [frodo-mcp] info: discovery: tool=frodo_find_skills ...
```

The "Channel notifications skipped" warning will no longer appear in the debug log.

## Test plan

- [ ] `npm run build:only` compiles cleanly
- [ ] `npm test` — all integration + unit tests pass
- [ ] New integration test: advertises `experimental['claude/channel']` capability
- [ ] New integration test: 2026-07-28 client receives no unsolicited startup `notifications/message`; startup visible on stderr
- [ ] Updated integration test: `[frodo-mcp] info: startup:` and `[frodo-mcp] info: discovery:` present on stderr for legacy client
- [ ] New unit test: `process.stderr.write` spy verifies `[frodo-mcp] info: startup: hello world\n` format

## Dependencies

Requires [rockcarver/frodo-lib#626](https://github.com/rockcarver/frodo-lib/pull/626) to be merged first — this PR uses `hydrateMcpDiscoveryContext` and `executeRecommendedByDefault` from that library change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)