### PR TITLE
test: re-record CLI-output snapshots for --username help text and resolved-identity Modifier row

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/node": "^2.0.0",
         "@modelcontextprotocol/server": "^2.0.0",
-        "@rockcarver/frodo-lib": "4.3.2",
+        "@rockcarver/frodo-lib": "4.3.3",
         "@types/colors": "^1.2.1",
         "@types/fs-extra": "^11.0.1",
         "@types/jest": "^29.2.3",
@@ -1908,9 +1908,9 @@
       }
     },
     "node_modules/@rockcarver/frodo-lib": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@rockcarver/frodo-lib/-/frodo-lib-4.3.2.tgz",
-      "integrity": "sha512-lcmmakt7rQnr823fwj27STQPsOy2o/AR9BGiWm/nP7hyUKSpkjtyigV7ECZeJuRwgcpxsko1Gvs6mYKkp+y4zA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@rockcarver/frodo-lib/-/frodo-lib-4.3.3.tgz",
+      "integrity": "sha512-we+K7ONOTXdIaHSDAhOWp9yPLctUcLqQ23M/nVuHK7GHqBxdNHrBWQlYmiidbP+0t9/EcO/2Ey9tup4ItkDrCg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
-    "@rockcarver/frodo-lib": "4.3.2",
+    "@rockcarver/frodo-lib": "4.3.3",
     "@types/colors": "^1.2.1",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.2.3",

--- a/test/client_cli/en/__snapshots__/admin-add-autoid-static-user-mapping.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-add-autoid-static-user-mapping.test.js.snap
@@ -12,6 +12,10 @@ Arguments:
                     alias.
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/admin-create-oauth2-client-with-admin-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-create-oauth2-client-with-admin-privileges.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                             "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                  Username to login with. Must be an admin user with
                             appropriate rights to manage authentication
-                            journeys/trees.
+                            journeys/trees. If given without a password, and it
+                            matches the username already stored in the
+                            connection profile for the target host, frodo uses
+                            that profile's stored password instead of requiring
+                            it on the command line.
   password                  Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-get-access-token.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-get-access-token.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                 "/" otherwise.)
   username                      Username to login with. Must be an admin user
                                 with appropriate rights to manage authentication
-                                journeys/trees.
+                                journeys/trees. If given without a password, and
+                                it matches the username already stored in the
+                                connection profile for the target host, frodo
+                                uses that profile's stored password instead of
+                                requiring it on the command line.
   password                      Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-grant-oauth2-client-admin-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-grant-oauth2-client-admin-privileges.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                         for Identity Cloud tenants, "/" otherwise.)
   username              Username to login with. Must be an admin user with
                         appropriate rights to manage authentication
-                        journeys/trees.
+                        journeys/trees. If given without a password, and it
+                        matches the username already stored in the connection
+                        profile for the target host, frodo uses that profile's
+                        stored password instead of requiring it on the command
+                        line.
   password              Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-hide-generic-extension-attributes.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-hide-generic-extension-attributes.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                         for Identity Cloud tenants, "/" otherwise.)
   username              Username to login with. Must be an admin user with
                         appropriate rights to manage authentication
-                        journeys/trees.
+                        journeys/trees. If given without a password, and it
+                        matches the username already stored in the connection
+                        profile for the target host, frodo uses that profile's
+                        stored password instead of requiring it on the command
+                        line.
   password              Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/admin-list-oauth2-clients-with-admin-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-list-oauth2-clients-with-admin-privileges.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-list-oauth2-clients-with-custom-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-list-oauth2-clients-with-custom-privileges.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-list-static-user-mappings.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-list-static-user-mappings.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-remove-static-user-mapping.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-remove-static-user-mapping.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-repair-org-model.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-repair-org-model.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                         for Identity Cloud tenants, "/" otherwise.)
   username              Username to login with. Must be an admin user with
                         appropriate rights to manage authentication
-                        journeys/trees.
+                        journeys/trees. If given without a password, and it
+                        matches the username already stored in the connection
+                        profile for the target host, frodo uses that profile's
+                        stored password instead of requiring it on the command
+                        line.
   password              Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-revoke-oauth2-client-admin-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-revoke-oauth2-client-admin-privileges.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                         for Identity Cloud tenants, "/" otherwise.)
   username              Username to login with. Must be an admin user with
                         appropriate rights to manage authentication
-                        journeys/trees.
+                        journeys/trees. If given without a password, and it
+                        matches the username already stored in the connection
+                        profile for the target host, frodo uses that profile's
+                        stored password instead of requiring it on the command
+                        line.
   password              Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/admin-show-generic-extension-attributes.test.js.snap
+++ b/test/client_cli/en/__snapshots__/admin-show-generic-extension-attributes.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                         for Identity Cloud tenants, "/" otherwise.)
   username              Username to login with. Must be an admin user with
                         appropriate rights to manage authentication
-                        journeys/trees.
+                        journeys/trees. If given without a password, and it
+                        matches the username already stored in the connection
+                        profile for the target host, frodo uses that profile's
+                        stored password instead of requiring it on the command
+                        line.
   password              Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/agent-ai-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-ai-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-ai-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-ai-describe.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:
@@ -41,7 +45,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-ai-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-ai-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-ai-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-ai-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-ai-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-ai-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-describe.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:
@@ -42,7 +46,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-gateway-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-gateway-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-gateway-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-gateway-describe.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:
@@ -41,7 +45,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-gateway-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-gateway-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-gateway-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-gateway-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-gateway-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-gateway-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-java-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-java-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-java-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-java-describe.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:
@@ -41,7 +45,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-java-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-java-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-java-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-java-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-java-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-java-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-web-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-web-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-web-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-web-describe.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:
@@ -41,7 +45,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-web-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-web-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-web-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-web-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/agent-web-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/agent-web-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/app-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/app-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/app-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/app-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/app-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/app-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/app-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/app-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authn-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authn-describe.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authn-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authn-export.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authn-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authn-import.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-policy-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-policy-delete.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-policy-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-policy-describe.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-policy-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-policy-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-policy-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-policy-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-policy-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-policy-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-set-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-set-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-set-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-set-describe.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-set-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-set-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-set-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-set-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-type-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-type-delete.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-type-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-type-describe.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-type-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-type-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-type-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-type-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/authz-type-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/authz-type-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-export.test.js.snap
@@ -22,7 +22,11 @@ Arguments:
                              "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                   Username to login with. Must be an admin user with
                              appropriate rights to manage authentication
-                             journeys/trees.
+                             journeys/trees. If given without a password, and it
+                             matches the username already stored in the
+                             connection profile for the target host, frodo uses
+                             that profile's stored password instead of requiring
+                             it on the command line.
   password                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                            "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                 Username to login with. Must be an admin user with
                            appropriate rights to manage authentication
-                           journeys/trees.
+                           journeys/trees. If given without a password, and it
+                           matches the username already stored in the connection
+                           profile for the target host, frodo uses that
+                           profile's stored password instead of requiring it on
+                           the command line.
   password                 Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-access-config.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-access-config.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-all-static.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-all-static.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-all.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-all.test.js.snap
@@ -8,7 +8,7 @@ exports[`CLI help interface for 'config export' should be expected english 1`] =
 Arguments:
   host                                      AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                     Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                  Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                  Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                  Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-audit.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-audit.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-authentication.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-authentication.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-authz-policies.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-authz-policies.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                        Cloud tenants, "/" otherwise.)
   username                             Username to login with. Must be an admin
                                        user with appropriate rights to manage
-                                       authentication journeys/trees.
+                                       authentication journeys/trees. If given
+                                       without a password, and it matches the
+                                       username already stored in the connection
+                                       profile for the target host, frodo uses
+                                       that profile's stored password instead of
+                                       requiring it on the command line.
   password                             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-connector-definitions.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-connector-definitions.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-connector-mappings.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-connector-mappings.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-cookie-domains.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-cookie-domains.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-cors.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-cors.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-csp.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-csp.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-email-provider.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-email-provider.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-email-templates.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-email-templates.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-endpoints.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-endpoints.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-iga-workflows.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-iga-workflows.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                             "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                  Username to login with. Must be an admin user with
                             appropriate rights to manage authentication
-                            journeys/trees.
+                            journeys/trees. If given without a password, and it
+                            matches the username already stored in the
+                            connection profile for the target host, frodo uses
+                            that profile's stored password instead of requiring
+                            it on the command line.
   password                  Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/config-manager-export-internal-roles.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-internal-roles.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-journeys.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-journeys.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                            "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                 Username to login with. Must be an admin user with
                            appropriate rights to manage authentication
-                           journeys/trees.
+                           journeys/trees. If given without a password, and it
+                           matches the username already stored in the connection
+                           profile for the target host, frodo uses that
+                           profile's stored password instead of requiring it on
+                           the command line.
   password                 Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-kba.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-kba.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-locales.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-locales.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-managed-objects.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-managed-objects.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-oauth2-agents.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-oauth2-agents.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-org-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-org-privileges.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-password-policy.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-password-policy.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-raw.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-raw.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                             "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                  Username to login with. Must be an admin user with
                             appropriate rights to manage authentication
-                            journeys/trees.
+                            journeys/trees. If given without a password, and it
+                            matches the username already stored in the
+                            connection profile for the target host, frodo uses
+                            that profile's stored password instead of requiring
+                            it on the command line.
   password                  Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-remote-servers.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-remote-servers.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-saml.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-saml.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-schedules.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-schedules.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-scripts.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-scripts.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                      Cloud tenants, "/" otherwise.)
   username                           Username to login with. Must be an admin
                                      user with appropriate rights to manage
-                                     authentication journeys/trees.
+                                     authentication journeys/trees. If given
+                                     without a password, and it matches the
+                                     username already stored in the connection
+                                     profile for the target host, frodo uses
+                                     that profile's stored password instead of
+                                     requiring it on the command line.
   password                           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-secret-mappings.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-secret-mappings.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-secrets.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-secrets.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-service-objects.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-service-objects.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-services.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-services.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-terms-and-conditions.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-terms-and-conditions.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-test.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-test.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-themes.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-themes.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-ui-config.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-ui-config.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-export-variables.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-export-variables.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-pull-custom-nodes.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-pull-custom-nodes.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-pull-org-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-pull-org-privileges.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-access-config.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-access-config.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-audit.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-audit.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-authentication.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-authentication.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-connector-definitions.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-connector-definitions.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-connector-mappings.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-connector-mappings.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-cookie-domains.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-cookie-domains.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-cors.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-cors.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-csp.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-csp.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/config-manager-push-custom-nodes.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-custom-nodes.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-email-provider.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-email-provider.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-email-templates.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-email-templates.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-endpoints.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-endpoints.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-internal-roles.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-internal-roles.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-journeys.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-journeys.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                            "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                 Username to login with. Must be an admin user with
                            appropriate rights to manage authentication
-                           journeys/trees.
+                           journeys/trees. If given without a password, and it
+                           matches the username already stored in the connection
+                           profile for the target host, frodo uses that
+                           profile's stored password instead of requiring it on
+                           the command line.
   password                 Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-kba.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-kba.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-locales.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-locales.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-managed-objects.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-managed-objects.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-org-privileges.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-org-privileges.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-password-policy.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-password-policy.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-remote-servers.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-remote-servers.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-restart.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-restart.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/config-manager-push-schedules.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-schedules.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-secret-mappings.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-secret-mappings.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/config-manager-push-service-objects.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-service-objects.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-terms-and-conditions.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-terms-and-conditions.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-themes.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-themes.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/config-manager-push-ui-config.test.js.snap
+++ b/test/client_cli/en/__snapshots__/config-manager-push-ui-config.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/conn-save.test.js.snap
+++ b/test/client_cli/en/__snapshots__/conn-save.test.js.snap
@@ -7,7 +7,7 @@ Save connection profiles.
 
 Arguments:
   host                                         AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
-  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                     Password.
 
 Options:
@@ -33,7 +33,7 @@ Save connection profiles.
 
 Arguments:
   host                                         AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
-  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                     Password.
 
 Options:
@@ -59,7 +59,7 @@ Save connection profiles.
 
 Arguments:
   host                                         AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
-  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                     Password.
 
 Options:
@@ -85,7 +85,7 @@ Save connection profiles.
 
 Arguments:
   host                                         AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
-  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                     Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/dcc-session-abort.test.js.snap
+++ b/test/client_cli/en/__snapshots__/dcc-session-abort.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only
@@ -41,6 +45,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/dcc-session-apply.test.js.snap
+++ b/test/client_cli/en/__snapshots__/dcc-session-apply.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only
@@ -41,6 +45,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/dcc-session-init.test.js.snap
+++ b/test/client_cli/en/__snapshots__/dcc-session-init.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only
@@ -41,6 +45,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/dcc-session-state.test.js.snap
+++ b/test/client_cli/en/__snapshots__/dcc-session-state.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only
@@ -41,6 +45,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/email-template-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/email-template-delete.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/email-template-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/email-template-export.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/email-template-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/email-template-import.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/email-template-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/email-template-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/esv-apply.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-apply.test.js.snap
@@ -13,7 +13,11 @@ Arguments:
                        alias.
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-create.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-create.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-delete.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-describe.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-export.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-import.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-list.test.js.snap
@@ -11,6 +11,10 @@ Arguments:
                      alias.
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-set.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-set.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-version-activate.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-version-activate.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-version-create.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-version-create.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-version-deactivate.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-version-deactivate.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-version-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-version-delete.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-secret-version-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-secret-version-list.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-variable-create.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-create.test.js.snap
@@ -12,7 +12,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-variable-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-delete.test.js.snap
@@ -12,7 +12,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-variable-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-describe.test.js.snap
@@ -12,7 +12,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-variable-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-export.test.js.snap
@@ -12,7 +12,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-variable-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-import.test.js.snap
@@ -12,7 +12,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-variable-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-list.test.js.snap
@@ -11,6 +11,10 @@ Arguments:
                      alias.
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/esv-variable-set.test.js.snap
+++ b/test/client_cli/en/__snapshots__/esv-variable-set.test.js.snap
@@ -12,7 +12,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/idm-count.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm-count.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idm-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm-delete.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idm-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm-export.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                        Cloud tenants, "/" otherwise.)
   username                             Username to login with. Must be an admin
                                        user with appropriate rights to manage
-                                       authentication journeys/trees.
+                                       authentication journeys/trees. If given
+                                       without a password, and it matches the
+                                       username already stored in the connection
+                                       profile for the target host, frodo uses
+                                       that profile's stored password instead of
+                                       requiring it on the command line.
   password                             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idm-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm-import.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                        Cloud tenants, "/" otherwise.)
   username                             Username to login with. Must be an admin
                                        user with appropriate rights to manage
-                                       authentication journeys/trees.
+                                       authentication journeys/trees. If given
+                                       without a password, and it matches the
+                                       username already stored in the connection
+                                       profile for the target host, frodo uses
+                                       that profile's stored password instead of
+                                       requiring it on the command line.
   password                             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idm-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idm-schema-object-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm-schema-object-export.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                   "/" otherwise.)
   username                        Username to login with. Must be an admin user
                                   with appropriate rights to manage
-                                  authentication journeys/trees.
+                                  authentication journeys/trees. If given
+                                  without a password, and it matches the
+                                  username already stored in the connection
+                                  profile for the target host, frodo uses that
+                                  profile's stored password instead of requiring
+                                  it on the command line.
   password                        Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idm-schema-object-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idm-schema-object-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                             "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                  Username to login with. Must be an admin user with
                             appropriate rights to manage authentication
-                            journeys/trees.
+                            journeys/trees. If given without a password, and it
+                            matches the username already stored in the
+                            connection profile for the target host, frodo uses
+                            that profile's stored password instead of requiring
+                            it on the command line.
   password                  Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idp-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idp-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idp-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idp-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idp-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idp-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                       Identity Cloud tenants, "/" otherwise.)
   username            Username to login with. Must be an admin user with
                       appropriate rights to manage authentication
-                      journeys/trees.
+                      journeys/trees. If given without a password, and it
+                      matches the username already stored in the connection
+                      profile for the target host, frodo uses that profile's
+                      stored password instead of requiring it on the command
+                      line.
   password            Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/idp-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/idp-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/iga-workflow-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/iga-workflow-delete.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/iga-workflow-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/iga-workflow-describe.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/iga-workflow-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/iga-workflow-export.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/iga-workflow-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/iga-workflow-import.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/iga-workflow-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/iga-workflow-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/iga-workflow-publish.test.js.snap
+++ b/test/client_cli/en/__snapshots__/iga-workflow-publish.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                    Cloud tenants, "/" otherwise.)
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/info.test.js.snap
+++ b/test/client_cli/en/__snapshots__/info.test.js.snap
@@ -11,6 +11,10 @@ Arguments:
                     alias.
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-delete.test.js.snap
@@ -15,7 +15,11 @@ Arguments:
                               otherwise.)
   username                    Username to login with. Must be an admin user with
                               appropriate rights to manage authentication
-                              journeys/trees.
+                              journeys/trees. If given without a password, and
+                              it matches the username already stored in the
+                              connection profile for the target host, frodo uses
+                              that profile's stored password instead of
+                              requiring it on the command line.
   password                    Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-describe.test.js.snap
@@ -18,7 +18,12 @@ Arguments:
                                     Cloud tenants, "/" otherwise.)
   username                          Username to login with. Must be an admin
                                     user with appropriate rights to manage
-                                    authentication journeys/trees.
+                                    authentication journeys/trees. If given
+                                    without a password, and it matches the
+                                    username already stored in the connection
+                                    profile for the target host, frodo uses that
+                                    profile's stored password instead of
+                                    requiring it on the command line.
   password                          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-disable.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-disable.test.js.snap
@@ -15,7 +15,11 @@ Arguments:
                               otherwise.)
   username                    Username to login with. Must be an admin user with
                               appropriate rights to manage authentication
-                              journeys/trees.
+                              journeys/trees. If given without a password, and
+                              it matches the username already stored in the
+                              connection profile for the target host, frodo uses
+                              that profile's stored password instead of
+                              requiring it on the command line.
   password                    Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-enable.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-enable.test.js.snap
@@ -15,7 +15,11 @@ Arguments:
                               otherwise.)
   username                    Username to login with. Must be an admin user with
                               appropriate rights to manage authentication
-                              journeys/trees.
+                              journeys/trees. If given without a password, and
+                              it matches the username already stored in the
+                              connection profile for the target host, frodo uses
+                              that profile's stored password instead of
+                              requiring it on the command line.
   password                    Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-export.test.js.snap
@@ -15,7 +15,11 @@ Arguments:
                               otherwise.)
   username                    Username to login with. Must be an admin user with
                               appropriate rights to manage authentication
-                              journeys/trees.
+                              journeys/trees. If given without a password, and
+                              it matches the username already stored in the
+                              connection profile for the target host, frodo uses
+                              that profile's stored password instead of
+                              requiring it on the command line.
   password                    Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-import.test.js.snap
@@ -15,7 +15,11 @@ Arguments:
                               otherwise.)
   username                    Username to login with. Must be an admin user with
                               appropriate rights to manage authentication
-                              journeys/trees.
+                              journeys/trees. If given without a password, and
+                              it matches the username already stored in the
+                              connection profile for the target host, frodo uses
+                              that profile's stored password instead of
+                              requiring it on the command line.
   password                    Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/journey-prune.test.js.snap
+++ b/test/client_cli/en/__snapshots__/journey-prune.test.js.snap
@@ -15,6 +15,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/log-fetch.test.js.snap
+++ b/test/client_cli/en/__snapshots__/log-fetch.test.js.snap
@@ -14,7 +14,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only
@@ -65,7 +70,12 @@ Arguments:
                                    substring or alias.
   username                         Username to login with. Must be an admin user
                                    with appropriate rights to manage
-                                   authentication journeys/trees.
+                                   authentication journeys/trees. If given
+                                   without a password, and it matches the
+                                   username already stored in the connection
+                                   profile for the target host, frodo uses that
+                                   profile's stored password instead of
+                                   requiring it on the command line.
   password                         Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/log-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/log-list.test.js.snap
@@ -11,6 +11,10 @@ Arguments:
                     alias.
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only
@@ -34,6 +38,10 @@ Arguments:
                     alias.
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/log-tail.test.js.snap
+++ b/test/client_cli/en/__snapshots__/log-tail.test.js.snap
@@ -12,7 +12,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only
@@ -52,7 +56,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/client_cli/en/__snapshots__/mapping-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/mapping-delete.test.js.snap
@@ -8,7 +8,7 @@ Delete IDM mappings.
 Arguments:
   host                                             AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                            Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                         Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                         Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                         Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/mapping-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/mapping-export.test.js.snap
@@ -8,7 +8,7 @@ Export IDM mappings.
 Arguments:
   host                                             AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                            Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                         Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                         Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                         Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/mapping-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/mapping-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/mapping-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/mapping-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/mapping-rename.test.js.snap
+++ b/test/client_cli/en/__snapshots__/mapping-rename.test.js.snap
@@ -18,7 +18,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/node-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/node-delete.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/node-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/node-describe.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/node-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/node-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/node-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/node-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/node-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/node-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/oauth-client-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client-delete.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                      Identity Cloud tenants, "/" otherwise.)
   username           Username to login with. Must be an admin user with
                      appropriate rights to manage authentication journeys/trees.
+                     If given without a password, and it matches the username
+                     already stored in the connection profile for the target
+                     host, frodo uses that profile's stored password instead of
+                     requiring it on the command line.
   password           Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/oauth-client-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/oauth-client-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                       Identity Cloud tenants, "/" otherwise.)
   username            Username to login with. Must be an admin user with
                       appropriate rights to manage authentication
-                      journeys/trees.
+                      journeys/trees. If given without a password, and it
+                      matches the username already stored in the connection
+                      profile for the target host, frodo uses that profile's
+                      stored password instead of requiring it on the command
+                      line.
   password            Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/oauth-client-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/oauth-client-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/promote.test.js.snap
+++ b/test/client_cli/en/__snapshots__/promote.test.js.snap
@@ -16,7 +16,12 @@ Arguments:
                                       Cloud tenants, "/" otherwise.)
   username                            Username to login with. Must be an admin
                                       user with appropriate rights to manage
-                                      authentication journeys/trees.
+                                      authentication journeys/trees. If given
+                                      without a password, and it matches the
+                                      username already stored in the connection
+                                      profile for the target host, frodo uses
+                                      that profile's stored password instead of
+                                      requiring it on the command line.
   password                            Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/realm-add-custom-domain.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm-add-custom-domain.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/realm-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm-describe.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/realm-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/realm-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/realm-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/realm-remove-custom-domain.test.js.snap
+++ b/test/client_cli/en/__snapshots__/realm-remove-custom-domain.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                        Identity Cloud tenants, "/" otherwise.)
   username             Username to login with. Must be an admin user with
                        appropriate rights to manage authentication
-                       journeys/trees.
+                       journeys/trees. If given without a password, and it
+                       matches the username already stored in the connection
+                       profile for the target host, frodo uses that profile's
+                       stored password instead of requiring it on the command
+                       line.
   password             Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/role-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/role-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/role-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/role-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/role-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/role-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-cot-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-cot-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-cot-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-cot-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-cot-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-cot-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-delete.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-describe.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/saml-metadata-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/saml-metadata-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                otherwise.)
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/script-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-delete.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/script-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-describe.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                             "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                  Username to login with. Must be an admin user with
                             appropriate rights to manage authentication
-                            journeys/trees.
+                            journeys/trees. If given without a password, and it
+                            matches the username already stored in the
+                            connection profile for the target host, frodo uses
+                            that profile's stored password instead of requiring
+                            it on the command line.
   password                  Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/script-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/script-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                             "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                  Username to login with. Must be an admin user with
                             appropriate rights to manage authentication
-                            journeys/trees.
+                            journeys/trees. If given without a password, and it
+                            matches the username already stored in the
+                            connection profile for the target host, frodo uses
+                            that profile's stored password instead of requiring
+                            it on the command line.
   password                  Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/script-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/script-list.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-delete.test.js.snap
@@ -8,7 +8,7 @@ Delete secret stores.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-describe.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-describe.test.js.snap
@@ -8,7 +8,7 @@ Describe secret stores.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-export.test.js.snap
@@ -8,7 +8,7 @@ Export secret stores.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-import.test.js.snap
@@ -8,7 +8,7 @@ Import secret stores.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-mapping-alias-activate.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-mapping-alias-activate.test.js.snap
@@ -8,7 +8,7 @@ Activate secret store mapping alias.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-mapping-alias-create.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-mapping-alias-create.test.js.snap
@@ -8,7 +8,7 @@ Create secret store mapping alias.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-mapping-alias-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-mapping-alias-delete.test.js.snap
@@ -8,7 +8,7 @@ Delete secret store mapping aliases.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-mapping-alias-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-mapping-alias-list.test.js.snap
@@ -8,7 +8,7 @@ List secret store mapping aliases.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-mapping-create.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-mapping-create.test.js.snap
@@ -8,7 +8,7 @@ Create secret store mappings.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-mapping-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-mapping-delete.test.js.snap
@@ -8,7 +8,7 @@ Delete secret store mappings.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/secretstore-mapping-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/secretstore-mapping-list.test.js.snap
@@ -8,7 +8,7 @@ List secret store mappings.
 Arguments:
   host                                       AM base URL, e.g.: https://cdk.iam.example.com/am. To use a connection profile, just specify a unique substring or alias.
   realm                                      Realm. Specify realm as '/' for the root realm or 'realm' or '/parent/child' otherwise. (default: "alpha" for Identity Cloud tenants, "/" otherwise.)
-  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees.
+  username                                   Username to login with. Must be an admin user with appropriate rights to manage authentication journeys/trees. If given without a password, and it matches the username already stored in the connection profile for the target host, frodo uses that profile's stored password instead of requiring it on the command line.
   password                                   Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/server-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/server-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/server-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/server-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/server-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/server-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/service-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/service-delete.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/service-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/service-export.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/service-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/service-import.test.js.snap
@@ -16,7 +16,11 @@ Arguments:
                                  "/" otherwise.)
   username                       Username to login with. Must be an admin user
                                  with appropriate rights to manage
-                                 authentication journeys/trees.
+                                 authentication journeys/trees. If given without
+                                 a password, and it matches the username already
+                                 stored in the connection profile for the target
+                                 host, frodo uses that profile's stored password
+                                 instead of requiring it on the command line.
   password                       Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/service-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/service-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/shell.test.js.snap
+++ b/test/client_cli/en/__snapshots__/shell.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/theme-delete.test.js.snap
+++ b/test/client_cli/en/__snapshots__/theme-delete.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                            "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                 Username to login with. Must be an admin user with
                            appropriate rights to manage authentication
-                           journeys/trees.
+                           journeys/trees. If given without a password, and it
+                           matches the username already stored in the connection
+                           profile for the target host, frodo uses that
+                           profile's stored password instead of requiring it on
+                           the command line.
   password                 Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/theme-export.test.js.snap
+++ b/test/client_cli/en/__snapshots__/theme-export.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                            "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                 Username to login with. Must be an admin user with
                            appropriate rights to manage authentication
-                           journeys/trees.
+                           journeys/trees. If given without a password, and it
+                           matches the username already stored in the connection
+                           profile for the target host, frodo uses that
+                           profile's stored password instead of requiring it on
+                           the command line.
   password                 Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/theme-import.test.js.snap
+++ b/test/client_cli/en/__snapshots__/theme-import.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                            "alpha" for Identity Cloud tenants, "/" otherwise.)
   username                 Username to login with. Must be an admin user with
                            appropriate rights to manage authentication
-                           journeys/trees.
+                           journeys/trees. If given without a password, and it
+                           matches the username already stored in the connection
+                           profile for the target host, frodo uses that
+                           profile's stored password instead of requiring it on
+                           the command line.
   password                 Password.
 
 Options:

--- a/test/client_cli/en/__snapshots__/theme-list.test.js.snap
+++ b/test/client_cli/en/__snapshots__/theme-list.test.js.snap
@@ -14,6 +14,10 @@ Arguments:
                     Cloud tenants, "/" otherwise.)
   username          Username to login with. Must be an admin user with
                     appropriate rights to manage authentication journeys/trees.
+                    If given without a password, and it matches the username
+                    already stored in the connection profile for the target
+                    host, frodo uses that profile's stored password instead of
+                    requiring it on the command line.
   password          Password.
 
 Options:

--- a/test/e2e/__snapshots__/esv-secret-create.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/esv-secret-create.e2e.test.js.snap
@@ -26,7 +26,11 @@ Arguments:
                                substring or alias.
   username                     Username to login with. Must be an admin user
                                with appropriate rights to manage authentication
-                               journeys/trees.
+                               journeys/trees. If given without a password, and
+                               it matches the username already stored in the
+                               connection profile for the target host, frodo
+                               uses that profile's stored password instead of
+                               requiring it on the command line.
   password                     Password.
 
 Deployment: Cloud-only

--- a/test/e2e/__snapshots__/esv-variable-describe.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/esv-variable-describe.e2e.test.js.snap
@@ -34,13 +34,14 @@ exports[`frodo esv variable describe "frodo esv variable describe --json --usage
 `;
 
 exports[`frodo esv variable describe "frodo esv variable describe -i esv-neo-age": should describe the esv variable "esv-neo-age" 1`] = `
-"Name         │esv-neo-age             
-Value        │28                      
-Type         │int                     
-Status       │loaded                  
-Description  │Neo's age in the matrix.
-Modified     │7/7/2026, 1:42:42 PM    
-Modifier UUID│Frodo-SA-1782747461119  
+"Name         │esv-neo-age                                       
+Value        │28                                                
+Type         │int                                               
+Status       │loaded                                            
+Description  │Neo's age in the matrix.                          
+Modified     │7/7/2026, 1:42:42 PM                              
+Modifier     │Tenant admin (unconfirmed): Frodo-SA-1782747461119
+Modifier UUID│Frodo-SA-1782747461119                            
 "
 `;
 
@@ -51,6 +52,7 @@ Type                     │number
 Status                   │loaded                                                                                                               
 Description              │This is another test variable.                                                                                       
 Modified                 │7/7/2026, 1:42:44 PM                                                                                                 
+Modifier                 │Tenant admin (unconfirmed): Frodo-SA-1782747461119                                                                   
 Modifier UUID            │Frodo-SA-1782747461119                                                                                               
 Usage Locations (2 total)│realm.root-alpha.script.da7a96a8-7969-4dab-9c6e-a812938cc76d(name: 'test-script-with-secrets-and-variables').script.0
                          │realm.root-alpha.script.da7a96a8-7969-4dab-9c6e-a812938cc76d(name: 'test-script-with-secrets-and-variables').script.4
@@ -64,19 +66,21 @@ Type                     │number
 Status                   │loaded                                                                                                             
 Description              │This is another test variable.                                                                                     
 Modified                 │7/7/2026, 1:42:44 PM                                                                                               
+Modifier                 │Tenant admin (unconfirmed): Frodo-SA-1782747461119                                                                 
 Modifier UUID            │Frodo-SA-1782747461119                                                                                             
 Usage Locations (1 total)│realm.root-alpha.script.da7a96a8-7969-4dab-9c6e-a812938cc76d(name: 'test-script-with-secrets-and-variables').script
 "
 `;
 
 exports[`frodo esv variable describe "frodo esv variable describe -ui esv-test-var-pi": should describe the esv variable "esv-test-var-pi" with usage 1`] = `
-"Name                     │esv-test-var-pi               
-Value                    │3.1415926                     
-Type                     │number                        
-Status                   │loaded                        
-Description              │This is another test variable.
-Modified                 │7/7/2026, 1:42:44 PM          
-Modifier UUID            │Frodo-SA-1782747461119        
-Usage Locations (0 total)│                              
+"Name                     │esv-test-var-pi                                   
+Value                    │3.1415926                                         
+Type                     │number                                            
+Status                   │loaded                                            
+Description              │This is another test variable.                    
+Modified                 │7/7/2026, 1:42:44 PM                              
+Modifier                 │Tenant admin (unconfirmed): Frodo-SA-1782747461119
+Modifier UUID            │Frodo-SA-1782747461119                            
+Usage Locations (0 total)│                                                  
 "
 `;

--- a/test/e2e/__snapshots__/idp-delete.e2e.test.js.snap
+++ b/test/e2e/__snapshots__/idp-delete.e2e.test.js.snap
@@ -14,7 +14,11 @@ Arguments:
                          for Identity Cloud tenants, "/" otherwise.)
   username               Username to login with. Must be an admin user with
                          appropriate rights to manage authentication
-                         journeys/trees.
+                         journeys/trees. If given without a password, and it
+                         matches the username already stored in the connection
+                         profile for the target host, frodo uses that profile's
+                         stored password instead of requiring it on the command
+                         line.
   password               Password.
 
 Options:


### PR DESCRIPTION
## Summary

While investigating the e2e suite failing wholesale (377 of 538 suites), root-caused to [rockcarver/frodo-lib#629](https://github.com/rockcarver/frodo-lib/pull/629) (an eager, unnecessary IDM-version probe added on every login that broke nearly every Polly-replayed e2e fixture), two genuine and already-published output changes were hiding underneath that noise and needed their frozen snapshots refreshed:

- The global `--username` option's `--help` text now documents password auto-resolution from a stored connection profile (frodo-lib#628 / frodo-cli#665), which touches nearly every command's help output.
- `esv variable describe` now prints a resolved-identity `Modifier` row alongside the existing `Modifier UUID` (same identity-resolution work).

Both changes were already in the published `@rockcarver/frodo-lib@4.3.2` this repo depended on when this PR was opened — the snapshots simply hadn't caught up.

Now also bumps `@rockcarver/frodo-lib` to `4.3.3`, which includes #629's fix.

## Depends on

Resolved: [rockcarver/frodo-lib#629](https://github.com/rockcarver/frodo-lib/pull/629) merged and published as `4.3.3`.

## Test plan

- [x] Locally: rebuilt against a patched frodo-lib with #629's fix and confirmed the full e2e suite is green except 4 pre-existing, unrelated `conn-describe.e2e.test.js` failures (local connection-profile decryption issue, present before any of this work)
- [x] rockcarver/frodo-lib#629 merged and published
- [x] `@rockcarver/frodo-lib` bumped in package.json (4.3.3)
- [x] Re-verified full e2e suite against the real published `@rockcarver/frodo-lib@4.3.3` (not a local link): green except the same 4 pre-existing `conn-describe.e2e.test.js` failures
- [ ] CI green on this PR