### PR TITLE
fix: skip null/malformed entries in managed/sync JSON export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+- `writeSyncJsonToDirectory` (used by `frodo idm export` and `frodo config export`) no longer throws `Cannot read properties of null (reading 'name')` when a tenant's legacy `sync.json` `mappings` array contains a null/malformed entry; such entries are now skipped instead of aborting the config entity save.
+- `writeManagedJsonToDirectory` (used by `frodo idm export` and `frodo config export`) no longer throws `Cannot read properties of null (reading 'name')` when a tenant's `managed.json` `objects` array contains a null/malformed entry; such entries are now skipped instead of aborting the config entity save.
+
 ## [v4.7.1] - 2026-08-19
 
 ### Changed

--- a/src/ops/IdmOps.ts
+++ b/src/ops/IdmOps.ts
@@ -719,6 +719,10 @@ export function writeManagedJsonToDirectory(
 ) {
   const objectPaths = [];
   for (const object of managed.objects) {
+    if (!object) {
+      // Skip null/malformed entries in the tenant's managed.json objects array.
+      continue;
+    }
     const fileName = getTypedFilename(object.name, 'managed');
     if (
       extract &&

--- a/src/ops/MappingOps.ts
+++ b/src/ops/MappingOps.ts
@@ -541,6 +541,10 @@ export function writeSyncJsonToDirectory(
 ) {
   const mappingPaths = [];
   for (const mapping of sync.mappings) {
+    if (!mapping) {
+      // Skip null/malformed entries in the tenant's sync.json mappings array.
+      continue;
+    }
     const fileName = getTypedFilename(mapping.name, 'sync');
     if (
       extract &&


### PR DESCRIPTION
## Summary
- `writeManagedJsonToDirectory` (used by `frodo idm export` and `frodo config export`) now skips null/malformed entries in a tenant's `managed.json` `objects` array instead of throwing `Cannot read properties of null (reading 'name')`.
- `writeSyncJsonToDirectory` (used by the same commands) now skips null/malformed entries in a tenant's `sync.json` `mappings` array for the same reason.

## Test plan
- [ ] Verify `frodo idm export`/`frodo config export` no longer throw against a tenant with a malformed `managed.json` objects entry
- [ ] Verify same commands no longer throw against a tenant with a malformed `sync.json` mappings entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vpf4gkcgWJzRJ98n3DK7GE